### PR TITLE
DSNPI - 298/ Documents View (QA)

### DIFF
--- a/src/components/document_card/index.tsx
+++ b/src/components/document_card/index.tsx
@@ -9,7 +9,7 @@ export const DocumentCard = ({
   formatTag: (tag: any) => string;
 }) => {
   return (
-    <div className="govuk-grid-column-one-third-from-desktop">
+    <div className="govuk-grid-column-one-third-from-desktop grid-row-extra-bottom-margin">
       <div className="govuk-grid-column-one-third">
         <Image
           src={file}


### PR DESCRIPTION
[Ticket 298](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-298)

Issues fixed after QA:
- vertical spacing between documents now matches the prototype.
- documents that do not have tags (which are used as display names) now display as 'Unnamed Document'.

n.b
- file format and file size are not displayed as we do not receive it from the API yet.