### PR TITLE
DSNPI 328 / Empty(no) comment

### DIFF
--- a/src/components/application_comments/index.tsx
+++ b/src/components/application_comments/index.tsx
@@ -76,7 +76,7 @@ const ApplicationComments = ({
         </>
       ) : (
         <div className="govuk-grid-row grid-row-extra-bottom-margin">
-          <div className="govuk-grid-column-one-third-from-desktop">
+          <div className="govuk-grid-column-two-thirds">
             <p className="govuk-hint">
               <em>{noCommentsMessage}</em>
             </p>


### PR DESCRIPTION
Minor style change to avoid message wrapping and trailing a word on a new line. Changed to fit on one line.
![image](https://github.com/tpximpact/council-public-index/assets/107464669/4c70b5ac-53e1-4bb5-8628-300a9a7d82d4)
