### PR TITLE
Remove optional symbol from properties

### DIFF
--- a/util/type.ts
+++ b/util/type.ts
@@ -1,14 +1,14 @@
 export type ApplicationDocument = {
-  url?: string;
-  applicant_description?: string;
-  tags?: string[];
-  created_at?: string;
-  numbers?: string;
+  url: string;
+  applicant_description: string;
+  tags: string[];
+  created_at: string;
+  numbers: string;
 };
 
 export type ApplicationComment = {
-  comment?: string;
-  received_at?: string;
+  comment: string;
+  received_at: string;
   summary_tag?: string;
 };
 


### PR DESCRIPTION
Removes the ‘?’ modifier after the property name on properties that are not optional.