### PR TITLE
DSNPI-449 "extra attributes from the server: hidden" error fix

### DIFF
--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -61,6 +61,7 @@ const Header = ({ currentPath }: { currentPath: string }) => {
           aria-controls="navigation"
           aria-expanded={isExtended}
           onClick={() => setIsExtended(!isExtended)}
+          hidden={true}
         >
           Menu
         </button>


### PR DESCRIPTION
This isn't strictly related to this DSNPI-449 it was just getting in my way as I was looking at the code. I'm not sure if its been looked at before yet either?

The error is caused by govuk code making changes to the dom and next likes to know everything so the fix seems to be just to let next know its going to happen. I set it to true since the site is mobile first. 

![Screenshot 2024-07-05 at 1 05 07 PM](https://github.com/tpximpact/council-public-index/assets/649148/173d1096-8e62-40fa-8a0a-e4dec0bb9293)
