### PR TITLE
DSNPI-653 Fix for description component continue logic causing search…

### DIFF
--- a/src/components/description_card/index.tsx
+++ b/src/components/description_card/index.tsx
@@ -1,6 +1,13 @@
 "use client";
-import { useRef, useEffect, useState } from "react";
+import React, { useRef, useEffect, useState } from "react";
 
+/**
+ * This component displays the description passed to it
+ * Max description length is 640 characters
+ * if theres a map then the max is 350 characters
+ * @param descrption
+ * @returns
+ */
 const DescriptionCard = ({ description }: any) => {
   const commentContainerRef = useRef<HTMLDivElement>(null);
   const [newDescription, setNewDescription] = useState(description);
@@ -10,13 +17,17 @@ const DescriptionCard = ({ description }: any) => {
     const checkOverflow = () => {
       const current = commentContainerRef.current;
       if (current) {
-        const getMap =
-          document.querySelectorAll('[role="region"]')[0].clientHeight;
-        const isOverflow = current.scrollHeight > getMap;
-        if (isOverflow) {
+        const getMap = current
+          ?.closest(".govuk-grid-row")
+          ?.querySelector(".landing-map");
+        const getMapHeight = getMap?.clientHeight ?? 0;
+        const isOverflow = current.scrollHeight > getMapHeight;
+        const currDescription =
+          current.querySelector("span")?.textContent ?? "";
+        if (isOverflow && currDescription?.length > 350) {
           setNewDescription(
-            current?.textContent
-              ?.slice(0, getMap > 250 ? 640 : 350)
+            currDescription
+              ?.slice(0, getMapHeight > 250 ? 640 : 350)
               .trim()
               .concat(`...`),
           );
@@ -30,9 +41,10 @@ const DescriptionCard = ({ description }: any) => {
     window.addEventListener("resize", checkOverflow);
     return () => window.removeEventListener("resize", checkOverflow);
   }, [description]);
+
   return (
     <p className="govuk-body" ref={commentContainerRef}>
-      {newDescription} {continuedText}
+      <span>{newDescription}</span> {continuedText}
     </p>
   );
 };


### PR DESCRIPTION
When searching for applications with no map the page displayed an error.

Issue was due to the `[role="region"]` not existing if no maps present. 

I have updated this to be more specific to the component, previously the component checked to see if any maps existed at all, `document.querySelectorAll('[role="region"]')[0].clientHeight` the component now checks within its row, though its not ideal its a realistic assumption that this component will be used as part of a `govuk-grid-row` in this project. 

This means that the description length is now set based on it's information and not if any maps exist.

I've also updated the logic so that if a map is present the max lenth will be 350 chars but if there isn't one its 640. I added in a new guard against concatenating if the content was < 350 to begin with

I've also added in spans around the description as `useEffect` is called multiple times by react (on purpose!) so this meant continue was added twice in some cases - so I have wrapped the descroption in a span so ensure content isn't duplicated. 