### PR TITLE
DSNPI-626 - Decision Date bug

### DIFF
--- a/__tests__/components/application_information.test.js
+++ b/__tests__/components/application_information.test.js
@@ -55,6 +55,11 @@ describe("Render ApplicationInformation", () => {
     const mapComponent = screen.getByTestId("mockMap");
     expect(mapComponent).toBeInTheDocument();
   });
+
+  it("should not show determined_at date if decision is null", () => {
+    render(<ApplicationInformation {...mockData} />);
+    expect(screen.queryByText("Decision")).toBeNull();
+  });
 });
 
 describe("Render ApplicationInformation", () => {
@@ -68,6 +73,8 @@ describe("Render ApplicationInformation", () => {
     received_date: "2024-03-18T00:00:00.000+00:00",
     result_flag: null,
     determination_date: "2024-03-19",
+    determined_at: "2024-07-18T00:00:00.000+00:00",
+    decision: "granted",
     status: "not_started",
     consultation: { end_date: "2024-04-08" },
     description: "Simple description",
@@ -86,6 +93,11 @@ describe("Render ApplicationInformation", () => {
       },
     },
   };
+
+  it("should show determined_at date if decision is not null", () => {
+    render(<ApplicationInformation {...mockData} />);
+    expect(screen.getByText("Decision Date")).toBeInTheDocument();
+  });
 
   it("should render correctly with MultiPolygon geometry", () => {
     const mockDataWithMultiPolygon = {

--- a/src/app/[council]/page.tsx
+++ b/src/app/[council]/page.tsx
@@ -317,14 +317,16 @@ export default async function Home({
                         )}
                       </div>
                       <div className="govuk-grid-column-one-third">
-                        {(application?.determination_date ||
-                          application?.application?.determinedAt) && (
+                        {((application?.determined_at &&
+                          application?.decision) ||
+                          (application?.application?.determinedAt &&
+                            application?.application?.decision)) && (
                           <>
                             <div className="govuk-heading-s">Decision Date</div>
                             <p className="govuk-body">
-                              {(application?.determination_date &&
+                              {(application?.determined_at &&
                                 `${format(
-                                  new Date(application?.determination_date),
+                                  new Date(application?.determined_at),
                                   "dd MMM yyyy",
                                 )}`) ||
                                 (application?.application?.determinedAt &&
@@ -339,19 +341,17 @@ export default async function Home({
                         )}
                       </div>
                       <div className="govuk-grid-column-one-third">
-                        {((application?.determination_date &&
-                          application.decision) ||
-                          (application?.application?.determinedAt &&
-                            application?.application?.decision)) && (
+                        {(application.decision ||
+                          application?.application?.decision) && (
                           <>
                             <div className="govuk-heading-s">Decision</div>
                             <p className="govuk-body">
-                              {(application?.determination_date &&
+                              {(application?.decision &&
                                 definedDecision(
                                   application.decision,
                                   application.application_type as string,
                                 )) ||
-                                (application?.application?.determinedAt &&
+                                (application?.application?.decision &&
                                   definedDecision(
                                     application?.application?.decision,
                                     application.application?.type

--- a/src/components/application_information/index.tsx
+++ b/src/components/application_information/index.tsx
@@ -36,6 +36,7 @@ type InformationData = {
   consultation?: { end_date: string };
   decision: string;
   determination_date?: string;
+  determined_at?: string;
   boundary_geojson?: BoundaryGeojson;
   in_assessment_at?: string;
   council: string;
@@ -57,6 +58,7 @@ const ApplicationInformation = ({
   publishedAt,
   decision,
   determination_date,
+  determined_at,
   status,
   consultation,
   boundary_geojson,
@@ -245,7 +247,7 @@ const ApplicationInformation = ({
 
           <div className="govuk-grid-row">
             <div className="govuk-grid-column-one-half">
-              {determination_date && decision && (
+              {determined_at && decision && (
                 <>
                   <div className="govuk-heading-s">
                     Decision Date{" "}
@@ -260,14 +262,14 @@ const ApplicationInformation = ({
                     </a>
                   </div>
                   <p className="govuk-body">
-                    {format(new Date(determination_date), "dd MMM yyyy")}
+                    {format(new Date(determined_at), "dd MMM yyyy")}
                   </p>
                 </>
               )}
             </div>
 
             <div className="govuk-grid-column-one-half">
-              {decision && determination_date && (
+              {decision && (
                 <>
                   <div className="govuk-heading-s">
                     Decision{" "}

--- a/util/type.ts
+++ b/util/type.ts
@@ -23,6 +23,7 @@ export type Data = {
   consultation?: { end_date: string };
   decision: string;
   determination_date?: string;
+  determined_at?: string;
   agent_first_name?: string;
   agent_last_name?: string;
   applicant_first_name?: string;


### PR DESCRIPTION
[Ticket 626](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-626)

This PR exposes the correct API fields for decision + when the decision is made. The 'Decision Date' field we were initially using was determination_date but we are now using determined_at/determinedAt, depending on the endpoint used.

We are now ensuring that decisions and their dates are only shown when they are not null, and that we do not show a date if there has not yet been a decision.
![image](https://github.com/user-attachments/assets/c1145c36-3389-4d92-9ce0-2ba46d966f10)
