### PR TITLE
Update tests to use npm not yarn

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -21,10 +21,10 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: npm ci
 
       - name: Lint
-        run: yarn lint
+        run: npm run lint
 
       - name: Run tests
-        run: yarn test
+        run: npm run test


### PR DESCRIPTION
Tests were failing on github but not locally - and were out of sync with our local dev environments

our enviroments were removing what the linter wanted us to add

first fix is to switch from yarn to npm 🤞