### PR TITLE
DSNPI-626 - Decision Date bug

### DIFF
--- a/__tests__/components/application_information.test.js
+++ b/__tests__/components/application_information.test.js
@@ -27,6 +27,8 @@ describe("Render ApplicationInformation", () => {
     received_date: "2024-03-18T00:00:00.000+00:00",
     result_flag: null,
     determination_date: "2024-03-19",
+    determined_at: "2024-03-19",
+    decision: null,
     status: "not_started",
     consultation: { end_date: "2024-04-08" },
     description: "Simple description",
@@ -50,6 +52,11 @@ describe("Render ApplicationInformation", () => {
     in_assessment_at: null,
   };
 
+  it("should not show determined_at date if decision is null", () => {
+    render(<ApplicationInformation {...mockData} />);
+    expect(screen.queryByText("Decision")).toBeNull();
+  });
+
   it("should render correctly with Polygon geometry", () => {
     render(<ApplicationInformation {...mockData} />);
     const mapComponent = screen.getByTestId("mockMap");
@@ -68,6 +75,8 @@ describe("Render ApplicationInformation", () => {
     received_date: "2024-03-18T00:00:00.000+00:00",
     result_flag: null,
     determination_date: "2024-03-19",
+    determined_at: "2024-03-19",
+    decision: "approved",
     status: "not_started",
     consultation: { end_date: "2024-04-08" },
     description: "Simple description",
@@ -86,6 +95,11 @@ describe("Render ApplicationInformation", () => {
       },
     },
   };
+
+  it("should show determined_at date if decision is not null", () => {
+    render(<ApplicationInformation {...mockData} />);
+    expect(screen.getByText("Decision Date")).toBeInTheDocument();
+  });
 
   it("should render correctly with MultiPolygon geometry", () => {
     const mockDataWithMultiPolygon = {

--- a/src/components/application_card/index.tsx
+++ b/src/components/application_card/index.tsx
@@ -18,6 +18,7 @@ export interface ApplicationCardProps {
   applicationReceivedDate: string;
   applicationPublishedAt: string | null | undefined;
   applicationDeterminationDate: string | null | undefined;
+  applicationDeterminedAt: string | null | undefined;
   applicationDecision: string | null | undefined;
   applicationReference: string;
 }
@@ -34,6 +35,7 @@ const ApplicationCard = ({
   applicationReceivedDate,
   applicationPublishedAt,
   applicationDeterminationDate,
+  applicationDeterminedAt,
   applicationDecision,
   applicationReference,
 }: ApplicationCardProps) => {
@@ -123,13 +125,13 @@ const ApplicationCard = ({
             )}
           </div>
           <div className="govuk-grid-column-one-third">
-            {applicationDeterminationDate && (
+            {applicationDeterminedAt && applicationDecision && (
               <>
                 <div className="govuk-heading-s">Decision Date</div>
                 <p className="govuk-body">
-                  {applicationDeterminationDate &&
+                  {applicationDeterminedAt &&
                     `${format(
-                      new Date(applicationDeterminationDate),
+                      new Date(applicationDeterminedAt),
                       "dd MMM yyyy",
                     )}`}
                 </p>
@@ -137,11 +139,11 @@ const ApplicationCard = ({
             )}
           </div>
           <div className="govuk-grid-column-one-third">
-            {applicationDeterminationDate && applicationDecision && (
+            {applicationDeterminedAt && applicationDecision && (
               <>
                 <div className="govuk-heading-s">Decision</div>
                 <p className="govuk-body">
-                  {applicationDeterminationDate &&
+                  {applicationDeterminedAt &&
                     definedDecision(applicationDecision, applicationType)}
                 </p>
               </>

--- a/src/components/application_information/index.tsx
+++ b/src/components/application_information/index.tsx
@@ -15,6 +15,7 @@ interface ApplicationInformationProps
     | "publishedAt"
     | "decision"
     | "determination_date"
+    | "determined_at"
     | "status"
     | "consultation"
     | "boundary_geojson"
@@ -59,6 +60,7 @@ const ApplicationInformation = ({
   publishedAt,
   decision,
   determination_date,
+  determined_at,
   status,
   consultation,
   boundary_geojson,
@@ -245,7 +247,7 @@ const ApplicationInformation = ({
 
           <div className="govuk-grid-row">
             <div className="govuk-grid-column-one-half">
-              {determination_date && decision && (
+              {determined_at && decision && (
                 <>
                   <div className="govuk-heading-s">
                     Decision Date{" "}
@@ -260,14 +262,14 @@ const ApplicationInformation = ({
                     </a>
                   </div>
                   <p className="govuk-body">
-                    {format(new Date(determination_date), "dd MMM yyyy")}
+                    {format(new Date(determined_at), "dd MMM yyyy")}
                   </p>
                 </>
               )}
             </div>
 
             <div className="govuk-grid-column-one-half">
-              {decision && determination_date && (
+              {decision && determined_at && (
                 <>
                   <div className="govuk-heading-s">
                     Decision{" "}

--- a/util/applicationHelpers.ts
+++ b/util/applicationHelpers.ts
@@ -61,6 +61,11 @@ export const getNonStandardApplicationDetails = (
         ?.determinedAt
     : (application as V2PlanningApplications["data"][0]).determination_date;
 
+  const applicationDeterminedAt = search
+    ? (application as V2PlanningApplicationsSearch["data"][0])?.application
+        ?.determinedAt
+    : (application as V2PlanningApplications["data"][0]).determined_at;
+
   const applicationDecision = search
     ? (application as V2PlanningApplicationsSearch["data"][0])?.application
         ?.decision
@@ -82,6 +87,7 @@ export const getNonStandardApplicationDetails = (
     applicationReceivedDate,
     applicationPublishedAt,
     applicationDeterminationDate,
+    applicationDeterminedAt,
     applicationDecision,
     applicationReference,
   };


### PR DESCRIPTION
[Ticket 626](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-626)

This PR exposes the correct API fields for decision + when the decision is made. The 'Decision Date' field we were initially using was determination_date but we are now using determined_at

We are now ensuring that decisions and their dates are only shown when they are not null, and that we do not show a date if there has not yet been a decision.