### PR TITLE
DSNPI-329 switch to documents public index

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -2,7 +2,7 @@ import { Config, Council, SiteConfig } from "@/types";
 import config from "../../util/config.json";
 
 export const siteConfig: SiteConfig = {
-  documentsPublicEndpoint: false,
+  documentsPublicEndpoint: true,
 };
 
 /**


### PR DESCRIPTION
BOPS have confirmed they wont be adding documents to `public/planning_applications/search` so we will now switch to `public/planning_applications/${reference}/documents` 

NB file titles are now more like file names

![image](https://github.com/user-attachments/assets/8e2ef151-0f9e-4707-88cd-a6421d0744cf)
