### PR TITLE
DSNPI-673/ Remove the Personal data text around comments

### DIFF
--- a/src/components/comment_check_answer/index.tsx
+++ b/src/components/comment_check_answer/index.tsx
@@ -381,8 +381,7 @@ const CommentCheckAnswer = ({
                 </p>
                 <p className="govuk-body">
                   Your comments will be made available online for the public to
-                  see. We will not include your name, address, telephone number
-                  or email address.
+                  see.
                 </p>
                 <p className="govuk-body">
                   We&apos;ll make sure any other personal or sensitive

--- a/src/components/comment_personal_details/index.tsx
+++ b/src/components/comment_personal_details/index.tsx
@@ -288,8 +288,7 @@ const CommentPersonalDetails = ({
               </p>
               <p className="govuk-body">
                 Your comments will be made available online for the public to
-                see. We will not include your name, address, telephone number or
-                email address.
+                see.
               </p>
               <p className="govuk-body">
                 We&apos;ll make sure any other personal or sensitive information

--- a/src/components/comment_pre_submission/index.tsx
+++ b/src/components/comment_pre_submission/index.tsx
@@ -114,8 +114,7 @@ const PreSubmission = ({
         )}{" "}
         into account when deciding whether or not to approve the application. As
         part of this process, your comments will be posted online for the public
-        to see. We will not include your name, address, telephone number or
-        email address. The case officer will summarise their findings in the
+        to see. The case officer will summarise their findings in the
         officer&apos;s report and decision notice.
       </p>
       <form onSubmit={handleSubmit}>


### PR DESCRIPTION
Removing all instances of the sentence - "We will not include your name, address, telephone number or email address"  as some LPAs do show people’s names.