### PR TITLE
remove p and add div

### DIFF
--- a/src/app/[council]/[reference]/application-form/page.tsx
+++ b/src/app/[council]/[reference]/application-form/page.tsx
@@ -71,13 +71,13 @@ export default async function ApplicationFormPage({
 
         <div className="govuk-grid-column-one-half">
           <h2 className="govuk-heading-m">Submitted</h2>
-          <p>
+          <div>
             {submittedAt ? (
               formatDprDateTime(submittedAt)
             ) : (
               <p className="govuk-body">Date not available</p>
             )}
-          </p>
+          </div>
         </div>
       </div>
       {applicationSubmissionData ? (


### PR DESCRIPTION
when there's no data in application form we are having a hydration error, caused by p inside another p, I just changed the first p to a div
**It can be tested with application 23-00112-PA1A**