### PR TITLE
Bugfix - stop long file names breaking the layout for documents

### DIFF
--- a/src/components/document_card/index.tsx
+++ b/src/components/document_card/index.tsx
@@ -22,7 +22,7 @@ export const DocumentCard = ({ document }: DocumentCardProps) => {
         />
       </div>
       <div className="govuk-grid-column-two-thirds">
-        <p className="govuk-body">
+        <p className="govuk-body document-title-link">
           <a
             href={document?.url}
             className="govuk-link govuk-link--no-visited-state"

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -8,5 +8,6 @@ $govuk-font-family: Arial, Helvetica, sans-serif;
 @import "./cookie-policy.scss";
 @import "./components/button";
 @import "./digital-site-notice.scss";
+@import "./documents.scss";
 
 $govuk-assets-path: "public/assets/";

--- a/src/styles/documents.scss
+++ b/src/styles/documents.scss
@@ -1,0 +1,3 @@
+.document-title-link {
+  word-wrap: break-word;
+}


### PR DESCRIPTION
Add word wrap style to stop the file names breaking the layout

![image](https://github.com/user-attachments/assets/f23400c3-1471-4d5b-86e9-80041db0cd6c)
