### PR TITLE
ubuntu-latest is now 24.04 not 22.04 need to install heroku

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -14,6 +14,9 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: "Install Heroku CLI"
+        run: curl https://cli-assets.heroku.com/install.sh | sh
+
       - name: Deploy to Heroku
         uses: akhileshns/heroku-deploy@v3.13.15
         with:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -14,6 +14,9 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: "Install Heroku CLI"
+        run: curl https://cli-assets.heroku.com/install.sh | sh
+
       - name: Deploy to Heroku
         uses: akhileshns/heroku-deploy@v3.13.15
         with:


### PR DESCRIPTION


ubuntu-latest is now mapped ubuntu-24.04 was ubuntu-22.04 previously - and it doesn't include heroku-cli by default now

Details here: https://github.com/AkhileshNS/heroku-deploy/issues/184#issuecomment-2417061522