### PR TITLE
fix code coverage for formatDates

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -27,13 +27,17 @@ const config = {
   collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  collectCoverageFrom: ["src/**/{!(index.ts),}.ts"],
+  collectCoverageFrom: [
+    "src/**/*.{ts,tsx,js,jsx}", // Include .ts, .tsx, .js, and .jsx files
+    "!src/**/*.d.ts", // Exclude .d.ts files
+    "!src/**/index.{ts,tsx,js,jsx}", // Exclude index.ts files
+  ],
 
   // The directory where Jest should output its coverage files
   // coverageDirectory: undefined,
 
   // An array of regexp pattern strings used to skip coverage collection
-  coveragePathIgnorePatterns: ["/node_modules/"],
+  // coveragePathIgnorePatterns: ["/node_modules/"],
 
   // Indicates which provider should be used to instrument code for coverage
   coverageProvider: "v8",
@@ -42,6 +46,7 @@ const config = {
   coverageReporters: [
     // "json",
     "text",
+    "html",
     // "lcov",
     // "clover"
   ],
@@ -96,6 +101,7 @@ const config = {
   // moduleNameMapper: {},
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
+    // "^@mocks/(.*)$": "<rootDir>/__mocks__/$1",
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/src/util/formatDates.ts
+++ b/src/util/formatDates.ts
@@ -22,13 +22,11 @@ dayjs.extend(customParseFormat);
  * formatDateString("2024-07-02T11:37:35.069Z");
  */
 export const formatDprDate = (dateString: string): string => {
-  try {
-    const date = dayjs(dateString);
-    return date.format("DD MMM YYYY");
-  } catch (error) {
-    console.error("Invalid date string:", dateString);
+  const date = dayjs(dateString);
+  if (!date.isValid()) {
     return "Invalid Date";
   }
+  return date.format("DD MMM YYYY");
 };
 
 /**
@@ -43,11 +41,9 @@ export const formatDprDate = (dateString: string): string => {
  * formatIsoDateTime("2024-07-02T11:37:35.069Z");
  */
 export const formatIsoDateTime = (isoDateString: string): string => {
-  try {
-    const date = dayjs.utc(isoDateString);
-    return date.format("DD MMM YYYY hh:mm A");
-  } catch (error) {
-    console.error("Invalid date string:", isoDateString);
+  const date = dayjs.utc(isoDateString);
+  if (!date.isValid()) {
     return "Invalid Date";
   }
+  return date.format("DD MMM YYYY hh:mm A");
 };


### PR DESCRIPTION
Part 129383 of the plan to increase testing coverage

- 100% code coverage for utils
- fixed issue on formatDates file because dayjs doesn't throw errors so the catch branch was never triggered by tests
  - (I had to switch it to dayjs in the other pr because now that we want to use standard ISO date formats the companion library `date-fs-tz` wasn't playing well with webpack in nextjs)
- also updated the coverage so it includes everything under /src except type description files (`.d.ts`) and `index.ts` files - which as we move toward a `/ComponentName` structure will make sense as an index.ts file with one export is hardly worth counting

<img width="689" alt="image" src="https://github.com/user-attachments/assets/5429f553-3d83-4aaf-a193-69f9fbf1e90a">
