### PR TITLE
remove search error

### DIFF
--- a/__tests__/components/PageSearch.test.tsx
+++ b/__tests__/components/PageSearch.test.tsx
@@ -9,15 +9,7 @@ jest.mock("../../src/components/button", () => ({
   BackLink: () => <div data-testid="back-link">Back Link</div>,
 }));
 jest.mock("../../src/components/FormSearch", () => ({
-  FormSearch: ({ validationError }: { validationError: boolean }) => (
-    <div data-testid="form-search">
-      {validationError && (
-        <span data-testid="validation-error">
-          Error: Search query must be at least 3 characters
-        </span>
-      )}
-    </div>
-  ),
+  FormSearch: () => <div data-testid="form-search"></div>,
 }));
 
 describe("PageSearch Component", () => {
@@ -76,21 +68,10 @@ describe("PageSearch Component", () => {
       />,
     );
 
-  it("renders FormSearch component and displays a validation error if query is less than 3 characters", () => {
-    renderComponent({
-      searchParams: { query: "ab", page: 1, resultsPerPage: 2 },
-    });
-    expect(screen.getByTestId("form-search")).toBeInTheDocument();
-    expect(screen.getByTestId("validation-error")).toHaveTextContent(
-      "Error: Search query must be at least 3 characters",
-    );
-  });
-
   it("does not display validation error when query length is valid", () => {
     renderComponent({
       searchParams: { query: "valid", page: 2, resultsPerPage: 10 },
     });
     expect(screen.getByTestId("form-search")).toBeInTheDocument();
-    expect(screen.queryByTestId("validation-error")).toBeNull();
   });
 });

--- a/src/components/FormSearch/FormSearch.tsx
+++ b/src/components/FormSearch/FormSearch.tsx
@@ -5,13 +5,13 @@ import { Button } from "../button";
 export interface FormSearchProps {
   action: string;
   searchParams?: SearchParams;
-  validationError?: boolean;
+  // validationError?: boolean;
 }
 
 export const FormSearch = ({
   action,
   searchParams,
-  validationError,
+  // validationError,
 }: FormSearchProps) => {
   return (
     <form action={action} method="get" className="govuk-grid-row">
@@ -30,16 +30,6 @@ export const FormSearch = ({
             defaultValue={searchParams?.query || ""}
             autoComplete="on"
           />
-          {validationError && (
-            <p
-              id="search-error"
-              className="govuk-error-message"
-              data-testid="validation-error"
-            >
-              <span className="govuk-visually-hidden">Error:</span> Enter at
-              least 3 characters to search
-            </p>
-          )}
         </div>
       </div>
       <div className="govuk-grid-column-one-quarter search-bar-buttons">

--- a/src/components/PageSearch/PageSearch.tsx
+++ b/src/components/PageSearch/PageSearch.tsx
@@ -23,8 +23,7 @@ export const PageSearch = ({
     return null;
   }
   const page = searchParams?.page ? searchParams.page : 1;
-  const validationError =
-    searchParams?.query && searchParams?.query.length < 3 ? true : false;
+
   return (
     <>
       {!applications && <BackLink />}
@@ -32,7 +31,6 @@ export const PageSearch = ({
         <FormSearch
           action={`/${appConfig.council.slug}`}
           searchParams={searchParams}
-          validationError={validationError}
         />
         {applications && applications?.length > 0 ? (
           <>


### PR DESCRIPTION
Ticket: https://tpximpact.atlassian.net/browse/DSNPI-861?atlOrigin=eyJpIjoiNWY3M2Y2ZGMzOGY2NGM4MWEwMGVkMDA4YTNjMjg0YjEiLCJwIjoiaiJ9

We had agreed with Bops to search at least 3 character, after the address search release we can search from 1 character, since it's Bops limitation we've decide to remove the error message