### PR TITLE
GovUk Summary Card and Summary List components

### DIFF
--- a/__tests__/components/govuk/SummaryCard.test.tsx
+++ b/__tests__/components/govuk/SummaryCard.test.tsx
@@ -1,0 +1,84 @@
+import { SummaryCard, SummaryCardProps } from "@/components/govuk/SummaryCard";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+const defaultProps: SummaryCardProps = {
+  title: { text: "Card Title" },
+  children: null,
+};
+
+describe("SummaryCard", () => {
+  it("renders the title", () => {
+    render(<SummaryCard {...defaultProps} />);
+    const titleElement = screen.getByRole("heading", { level: 2 });
+    expect(titleElement).toBeInTheDocument();
+    expect(titleElement).toHaveTextContent("Card Title");
+  });
+
+  it("renders the title with defined heading", () => {
+    const newProps: SummaryCardProps = {
+      ...defaultProps,
+      title: {
+        ...defaultProps.title,
+        headingLevel: "3",
+      },
+    };
+    render(<SummaryCard {...newProps} />);
+    const titleElement = screen.getByRole("heading", { level: 3 });
+    expect(titleElement).toBeInTheDocument();
+    expect(titleElement).toHaveTextContent("Card Title");
+  });
+  it("renders a single action", () => {
+    const actions = {
+      items: [
+        {
+          href: "#",
+          text: "Action 1",
+          visuallyHiddenText: "Action 1 hidden text",
+        },
+      ],
+    };
+    render(
+      <SummaryCard title={defaultProps.title} actions={actions}>
+        {null}
+      </SummaryCard>,
+    );
+    const actionLink = screen.getByText("Action 1");
+    expect(actionLink).toBeInTheDocument();
+    expect(actionLink).toHaveAttribute("href", "#");
+  });
+  it("renders multiple actions", () => {
+    const actions = {
+      items: [
+        {
+          href: "#",
+          text: "Action 1",
+          visuallyHiddenText: "Action 1 hidden text",
+        },
+        {
+          href: "#",
+          text: "Action 2",
+          visuallyHiddenText: "Action 2 hidden text",
+        },
+      ],
+    };
+    render(
+      <SummaryCard title={defaultProps.title} actions={actions}>
+        {null}
+      </SummaryCard>,
+    );
+    const actionLinks = screen.getAllByRole("link");
+    expect(actionLinks).toHaveLength(2);
+    expect(actionLinks[0]).toHaveTextContent("Action 1");
+    expect(actionLinks[1]).toHaveTextContent("Action 2");
+  });
+  it("renders children", () => {
+    render(
+      <SummaryCard title={defaultProps.title} actions={defaultProps.actions}>
+        <div>Child Content</div>
+      </SummaryCard>,
+    );
+    const childContent = screen.getByText("Child Content");
+    expect(childContent).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/govuk/SummaryList.test.tsx
+++ b/__tests__/components/govuk/SummaryList.test.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  SummaryList,
+  SummaryListProps,
+} from "@/components/govuk/SummaryList/SummaryList";
+
+describe("SummaryList Component", () => {
+  const defaultProps: SummaryListProps = {
+    rows: [
+      {
+        key: { text: "Key 1" },
+        value: { text: "Value 1" },
+        actions: {
+          items: [
+            {
+              href: "#",
+              text: "Action 1",
+              visuallyHiddenText: "Action 1 hidden text",
+            },
+          ],
+        },
+      },
+      {
+        key: { text: "Key 2" },
+        value: { text: "Value 2" },
+      },
+    ],
+    cardTitle: { text: "Card Title" },
+  };
+
+  it("renders without crashing", () => {
+    render(<SummaryList {...defaultProps} />);
+    expect(screen.getByText("Key 1")).toBeInTheDocument();
+    expect(screen.getByText("Value 1")).toBeInTheDocument();
+    expect(screen.getByText("Action 1")).toBeInTheDocument();
+    expect(screen.getByText("Key 2")).toBeInTheDocument();
+    expect(screen.getByText("Value 2")).toBeInTheDocument();
+  });
+
+  it("renders actions correctly", () => {
+    render(<SummaryList {...defaultProps} />);
+    const actionLink = screen.getByText("Action 1");
+    expect(actionLink).toBeInTheDocument();
+    expect(actionLink).toHaveAttribute("href", "#");
+    const hiddenText = screen.getByText("Action 1 hidden text Card Title");
+    expect(hiddenText).toBeInTheDocument();
+  });
+
+  it("renders without actions", () => {
+    const propsWithoutActions: SummaryListProps = {
+      rows: [
+        {
+          key: { text: "Key 1" },
+          value: { text: "Value 1" },
+        },
+      ],
+    };
+    render(<SummaryList {...propsWithoutActions} />);
+    expect(screen.getByText("Key 1")).toBeInTheDocument();
+    expect(screen.getByText("Value 1")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("renders multiple actions correctly", () => {
+    const propsWithMultipleActions: SummaryListProps = {
+      rows: [
+        {
+          key: { text: "Key 1" },
+          value: { text: "Value 1" },
+          actions: {
+            items: [
+              {
+                href: "#",
+                text: "Action 1",
+                visuallyHiddenText: "Action 1 hidden text",
+              },
+              {
+                href: "#",
+                text: "Action 2",
+                visuallyHiddenText: "Action 2 hidden text",
+              },
+            ],
+          },
+        },
+      ],
+    };
+    render(<SummaryList {...propsWithMultipleActions} />);
+    expect(screen.getByText("Action 1")).toBeInTheDocument();
+    expect(screen.getByText("Action 2")).toBeInTheDocument();
+  });
+
+  it("applies no-border class when noBorder is true", () => {
+    const propsWithNoBorder: SummaryListProps = {
+      ...defaultProps,
+      noBorder: true,
+    };
+    const { container } = render(<SummaryList {...propsWithNoBorder} />);
+    // dl doesn't have a role attribute
+    const summaryList = container.firstChild;
+    expect(summaryList).toHaveClass("govuk-summary-list--no-border");
+  });
+
+  it("renders JSX elements in key and value", () => {
+    const propsWithJSX: SummaryListProps = {
+      rows: [
+        {
+          key: { text: <strong>Key 1</strong> },
+          value: { text: <em>Value 1</em> },
+        },
+      ],
+    };
+    render(<SummaryList {...propsWithJSX} />);
+    expect(screen.getByText("Key 1")).toBeInTheDocument();
+    expect(screen.getByText("Value 1")).toBeInTheDocument();
+  });
+
+  it("renders correctly with empty rows", () => {
+    const propsWithEmptyRows: SummaryListProps = {
+      rows: [],
+    };
+    render(<SummaryList {...propsWithEmptyRows} />);
+    expect(screen.queryByText("Key 1")).not.toBeInTheDocument();
+    expect(screen.queryByText("Value 1")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/application_form/row.tsx
+++ b/src/components/application_form/row.tsx
@@ -10,6 +10,7 @@ export const Row = ({
     return null;
   }
 
+  // @todo apply <SummaryList /> <SummaryCard /> components here
   return (
     <dl className="govuk-summary-list__row">
       <dt className="govuk-summary-list__key">{description}</dt>

--- a/src/components/comment_check_answer/index.tsx
+++ b/src/components/comment_check_answer/index.tsx
@@ -180,6 +180,7 @@ const CommentCheckAnswer = ({
     }
   };
 
+  // @todo apply <SummaryList /> <SummaryCard /> components here
   return (
     <>
       <div className="govuk-grid-row">

--- a/src/components/govuk/SummaryCard/SummaryCard.scss
+++ b/src/components/govuk/SummaryCard/SummaryCard.scss
@@ -1,0 +1,2 @@
+@import "node_modules/govuk-frontend/dist/govuk/base";
+@import "node_modules/govuk-frontend/dist/govuk/components/summary-list/index";

--- a/src/components/govuk/SummaryCard/SummaryCard.stories.tsx
+++ b/src/components/govuk/SummaryCard/SummaryCard.stories.tsx
@@ -1,0 +1,143 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SummaryCard } from "./SummaryCard";
+import { SummaryList } from "../SummaryList";
+
+const meta = {
+  title: "GOV UK Components/SummaryCard",
+  component: SummaryCard,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  parameters: {
+    // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
+    layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+  args: {
+    title: {
+      text: "Lead tenant",
+    },
+    children: (
+      <SummaryList
+        rows={[
+          {
+            key: {
+              text: "Age",
+            },
+            value: {
+              text: "38",
+            },
+            actions: {
+              items: [
+                {
+                  href: "#",
+                  text: "Change",
+                  visuallyHiddenText: "age",
+                },
+              ],
+            },
+          },
+          {
+            key: {
+              text: "Nationality",
+            },
+            value: {
+              text: "UK national resident in UK",
+            },
+            actions: {
+              items: [
+                {
+                  href: "#",
+                  text: "Change",
+                  visuallyHiddenText: "nationality",
+                },
+              ],
+            },
+          },
+          {
+            key: {
+              text: "Working situation",
+            },
+            value: {
+              text: "Part time - less than 30 hours a week",
+            },
+            actions: {
+              items: [
+                {
+                  href: "#",
+                  text: "Change",
+                  visuallyHiddenText: "working situation",
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    ),
+  },
+} satisfies Meta<typeof SummaryCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithActions: Story = {
+  args: {
+    title: {
+      text: "University of Gloucestershire",
+    },
+    actions: {
+      items: [
+        {
+          href: "#",
+          text: "Delete choice",
+          visuallyHiddenText: "of University of Gloucestershire",
+        },
+        {
+          href: "#",
+          text: "Withdraw",
+          visuallyHiddenText: "from University of Gloucestershire",
+        },
+      ],
+    },
+    children: (
+      <SummaryList
+        cardTitle={{
+          text: "University of Gloucestershire",
+        }}
+        rows={[
+          {
+            key: {
+              text: "Course",
+            },
+            value: {
+              text: (
+                <>
+                  English (3DMD)
+                  <br />
+                  PGCE with QTS full time
+                </>
+              ),
+            },
+          },
+          {
+            key: {
+              text: "Location",
+            },
+            value: {
+              text: (
+                <>
+                  School name
+                  <br />
+                  Road, City, SW1 1AA
+                </>
+              ),
+            },
+          },
+        ]}
+      />
+    ),
+  },
+};

--- a/src/components/govuk/SummaryCard/SummaryCard.tsx
+++ b/src/components/govuk/SummaryCard/SummaryCard.tsx
@@ -1,0 +1,47 @@
+import { ActionLink, SummaryListProps } from "../SummaryList";
+import "./SummaryCard.scss";
+
+export interface SummaryCardProps {
+  title: NonNullable<SummaryListProps["cardTitle"]>;
+  actions?: SummaryListProps["rows"][number]["actions"];
+  children: React.ReactNode;
+}
+
+export const SummaryCard = ({ title, actions, children }: SummaryCardProps) => {
+  const headingLevel = title.headingLevel ?? "2";
+  const HeadingTag = `h${headingLevel}` as keyof JSX.IntrinsicElements;
+  return (
+    <>
+      <div className="govuk-summary-card">
+        <div className="govuk-summary-card__title-wrapper">
+          {title && (
+            <HeadingTag className="govuk-summary-card__title">
+              {title.text}
+            </HeadingTag>
+          )}
+          {actions && (
+            <>
+              {actions.items.length === 1 ? (
+                <div className="govuk-summary-card__actions">
+                  <ActionLink action={actions.items[0]} cardTitle={title} />
+                </div>
+              ) : (
+                <ul className="govuk-summary-card__actions">
+                  {actions.items.map((action, index) => (
+                    <li
+                      key={`items-${index}`}
+                      className="govuk-summary-card__action"
+                    >
+                      <ActionLink action={action} cardTitle={title} />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
+          )}
+        </div>
+        <div className="govuk-summary-card__content">{children}</div>
+      </div>
+    </>
+  );
+};

--- a/src/components/govuk/SummaryCard/index.ts
+++ b/src/components/govuk/SummaryCard/index.ts
@@ -1,0 +1,1 @@
+export * from "./SummaryCard";

--- a/src/components/govuk/SummaryList/SummaryList.scss
+++ b/src/components/govuk/SummaryList/SummaryList.scss
@@ -1,0 +1,2 @@
+@import "node_modules/govuk-frontend/dist/govuk/base";
+@import "node_modules/govuk-frontend/dist/govuk/components/summary-list/index";

--- a/src/components/govuk/SummaryList/SummaryList.stories.tsx
+++ b/src/components/govuk/SummaryList/SummaryList.stories.tsx
@@ -1,0 +1,196 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SummaryList } from "./SummaryList";
+
+const meta = {
+  title: "GOV UK Components/SummaryList",
+  component: SummaryList,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  parameters: {
+    // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
+    layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+  args: {
+    rows: [
+      {
+        key: {
+          text: "Name",
+        },
+        value: {
+          text: "Sarah Philips",
+        },
+        // actions: {
+        //   items: [
+        //     {
+        //       href: "#",
+        //       text: "Change",
+        //       visuallyHiddenText: "name",
+        //     },
+        //   ],
+        // },
+      },
+      {
+        key: {
+          text: "Date of birth",
+        },
+        value: {
+          text: "5 January 1978",
+        },
+        actions: {
+          items: [
+            {
+              href: "#",
+              text: "Change",
+              visuallyHiddenText: "date of birth",
+            },
+          ],
+        },
+      },
+      {
+        key: {
+          text: "Address",
+        },
+        value: {
+          text: (
+            <>
+              72 Guild Street
+              <br />
+              London
+              <br />
+              SE23 6FH
+            </>
+          ),
+        },
+        actions: {
+          items: [
+            {
+              href: "#",
+              text: "Change",
+              visuallyHiddenText: "address",
+            },
+          ],
+        },
+      },
+      {
+        key: {
+          text: "Contact details",
+        },
+        value: {
+          text: (
+            <>
+              <p className="govuk-body">07700 900457</p>
+              <p className="govuk-body">sarah.phillips@example.com</p>
+            </>
+          ),
+        },
+        actions: {
+          items: [
+            {
+              href: "#",
+              text: "Add",
+              visuallyHiddenText: "contact details",
+            },
+            {
+              href: "#",
+              text: "Change",
+              visuallyHiddenText: "contact details",
+            },
+          ],
+        },
+      },
+      {
+        key: {
+          text: "Contact information",
+        },
+        value: {
+          text: (
+            <>
+              <a href="#" className="govuk-link">
+                Enter contact information
+              </a>
+            </>
+          ),
+        },
+      },
+      {
+        key: {
+          text: "Contact details",
+        },
+        value: {
+          text: (
+            <>
+              <a href="#" className="govuk-link">
+                Enter contact details
+              </a>
+            </>
+          ),
+        },
+      },
+    ],
+  },
+} satisfies Meta<typeof SummaryList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const WithoutBorders: Story = {
+  args: {
+    noBorder: true,
+  },
+};
+
+export const Simple: Story = {
+  args: {
+    rows: [
+      {
+        key: {
+          text: "Name",
+        },
+        value: {
+          text: "Sarah Philips",
+        },
+      },
+      {
+        key: {
+          text: "Date of birth",
+        },
+        value: {
+          text: "5 January 1978",
+        },
+      },
+      {
+        key: {
+          text: "Address",
+        },
+        value: {
+          text: (
+            <>
+              72 Guild Street
+              <br />
+              London
+              <br />
+              SE23 6FH
+            </>
+          ),
+        },
+      },
+      {
+        key: {
+          text: "Contact details",
+        },
+        value: {
+          text: (
+            <>
+              <p className="govuk-body">07700 900457</p>
+              <p className="govuk-body">sarah.phillips@example.com</p>
+            </>
+          ),
+        },
+      },
+    ],
+  },
+};

--- a/src/components/govuk/SummaryList/SummaryList.tsx
+++ b/src/components/govuk/SummaryList/SummaryList.tsx
@@ -1,0 +1,97 @@
+import Link from "next/link";
+import "./SummaryList.scss";
+
+export interface SummaryListProps {
+  rows: {
+    key: {
+      text: JSX.Element | string;
+    };
+    value: {
+      text: JSX.Element | string;
+    };
+    actions?: {
+      items: {
+        href: string;
+        text: string;
+        visuallyHiddenText: string;
+      }[];
+    };
+  }[];
+  cardTitle?: {
+    text: string;
+    headingLevel?: string;
+  };
+  noBorder?: boolean;
+}
+
+export const ActionLink = ({
+  action,
+  cardTitle,
+}: {
+  action: NonNullable<
+    SummaryListProps["rows"][number]["actions"]
+  >["items"][number];
+  cardTitle: SummaryListProps["cardTitle"];
+}) => {
+  return (
+    <Link className="govuk-link" href={action.href}>
+      {action.text}
+      {(action.visuallyHiddenText || cardTitle) && (
+        <span className="govuk-visually-hidden">
+          {action.visuallyHiddenText && <>{action.visuallyHiddenText}</>}{" "}
+          {cardTitle && <>{cardTitle.text}</>}
+        </span>
+      )}
+    </Link>
+  );
+};
+
+export const SummaryList = ({
+  rows,
+  cardTitle,
+  noBorder,
+}: SummaryListProps) => {
+  if (!rows) {
+    return null;
+  }
+  return (
+    <>
+      <dl
+        className={`govuk-summary-list ${noBorder ? "govuk-summary-list--no-border" : ""}`}
+      >
+        {rows.map((row, index) => (
+          <div
+            key={index}
+            className={`govuk-summary-list__row ${row.actions ? "govuk-summary-list__row--no-actions" : ""}`}
+          >
+            <dt className="govuk-summary-list__key">{row.key.text}</dt>
+            <dd className="govuk-summary-list__value">{row.value.text}</dd>
+            {row.actions && (
+              <dd className="govuk-summary-list__actions">
+                {row.actions.items.length === 1 ? (
+                  <>
+                    <ActionLink
+                      action={row.actions.items[0]}
+                      cardTitle={cardTitle}
+                    />
+                  </>
+                ) : (
+                  <ul className="govuk-summary-list__actions-list">
+                    {row.actions.items.map((action, index) => (
+                      <li
+                        key={`items-${index}`}
+                        className="govuk-summary-list__actions-list-item"
+                      >
+                        <ActionLink action={action} cardTitle={cardTitle} />
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </dd>
+            )}
+          </div>
+        ))}
+      </dl>
+    </>
+  );
+};

--- a/src/components/govuk/SummaryList/index.ts
+++ b/src/components/govuk/SummaryList/index.ts
@@ -1,0 +1,1 @@
+export * from "./SummaryList";


### PR DESCRIPTION
When I was looking into the applicationSubmission types and before I realised it may end up being a lot of work I realised that we're using the govuk Summary List component in two places but we don't actually have a component for it

This PR adds in this missing component

- gov uk summary list component
- gov uk summary card component (though we're not using it right now I can see it maybe being used in the future)


We still need to add them to the applicationSubmission page as part of a future piece of work. Theres also a use for them on the comment workflow as well.



![image](https://github.com/user-attachments/assets/08afa16e-736c-4e2a-a999-3f0d0a699d2f)
![image](https://github.com/user-attachments/assets/9814cac5-1b81-40cf-855f-780917bfedab)
