### PR TITLE
Remove env vars to be passed to heroku

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -25,27 +25,3 @@ jobs:
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
           usedocker: true
           stack: "container"
-        env:
-          # BARNET
-          HD_BARNET_BOPS_API_KEY: ${{ secrets.BARNET_BOPS_API_KEY }}
-          HD_BARNET_BOPS_API_URL: ${{ secrets.BARNET_BOPS_API_URL }}
-          HD_BARNET_BOPS_API_URL_V1: ${{ secrets.BARNET_BOPS_API_URL_V1 }}
-          # BUCKINGHAMSHIRE
-          # HD_BUCKINGHAMSHIRE_BOPS_API_KEY: ${{ secrets.BUCKINGHAMSHIRE_BOPS_API_KEY }}
-          # HD_BUCKINGHAMSHIRE_BOPS_API_URL: ${{ secrets.BUCKINGHAMSHIRE_BOPS_API_URL }}
-          # CAMDEN
-          HD_CAMDEN_BOPS_API_KEY: ${{ secrets.CAMDEN_BOPS_API_KEY }}
-          HD_CAMDEN_BOPS_API_URL: ${{ secrets.CAMDEN_BOPS_API_URL }}
-          HD_CAMDEN_BOPS_API_URL_V1: ${{ secrets.CAMDEN_BOPS_API_URL_V1 }}
-          # GATESHEAD
-          # HD_GATESHEAD_BOPS_API_KEY: ${{ secrets.GATESHEAD_BOPS_API_KEY }}
-          # HD_GATESHEAD_BOPS_API_URL: ${{ secrets.GATESHEAD_BOPS_API_URL }}
-          # LAMBETH
-          # HD_LAMBETH_BOPS_API_KEY: ${{ secrets.LAMBETH_BOPS_API_KEY }}
-          # HD_LAMBETH_BOPS_API_URL: ${{ secrets.LAMBETH_BOPS_API_URL }}
-          # SOUTHWARK
-          # HD_SOUTHWARK_BOPS_API_KEY: ${{ secrets.SOUTHWARK_BOPS_API_KEY }}
-          # HD_SOUTHWARK_BOPS_API_URL: ${{ secrets.SOUTHWARK_BOPS_API_URL }}
-          # ANALYTICS
-          # HD_GA: ${{secrets.GA}}
-          # HD_GTM: ${{secrets.GTM}}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -25,31 +25,3 @@ jobs:
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
           usedocker: true
           stack: "container"
-        env:
-          # BARNET
-          HD_BARNET_BOPS_API_KEY: ${{ secrets.BARNET_BOPS_API_KEY }}
-          HD_BARNET_BOPS_API_URL: ${{ secrets.BARNET_BOPS_API_URL }}
-          HD_BARNET_BOPS_API_URL_V1: ${{ secrets.BARNET_BOPS_API_URL_V1 }}
-          # BUCKINGHAMSHIRE
-          HD_BUCKINGHAMSHIRE_BOPS_API_KEY: ${{ secrets.BUCKINGHAMSHIRE_BOPS_API_KEY }}
-          HD_BUCKINGHAMSHIRE_BOPS_API_URL: ${{ secrets.BUCKINGHAMSHIRE_BOPS_API_URL }}
-          HD_BUCKINGHAMSHIRE_BOPS_API_URL_V1: ${{ secrets.BUCKINGHAMSHIRE_BOPS_API_URL_V1 }}
-          # CAMDEN
-          HD_CAMDEN_BOPS_API_KEY: ${{ secrets.CAMDEN_BOPS_API_KEY }}
-          HD_CAMDEN_BOPS_API_URL: ${{ secrets.CAMDEN_BOPS_API_URL }}
-          HD_CAMDEN_BOPS_API_URL_V1: ${{ secrets.CAMDEN_BOPS_API_URL_V1 }}
-          # GATESHEAD
-          HD_GATESHEAD_BOPS_API_KEY: ${{ secrets.GATESHEAD_BOPS_API_KEY }}
-          HD_GATESHEAD_BOPS_API_URL: ${{ secrets.GATESHEAD_BOPS_API_URL }}
-          HD_GATESHEAD_BOPS_API_URL_V1: ${{ secrets.GATESHEAD_BOPS_API_URL_V1 }}
-          # LAMBETH
-          HD_LAMBETH_BOPS_API_KEY: ${{ secrets.LAMBETH_BOPS_API_KEY }}
-          HD_LAMBETH_BOPS_API_URL: ${{ secrets.LAMBETH_BOPS_API_URL }}
-          HD_LAMBETH_BOPS_API_URL_V1: ${{ secrets.LAMBETH_BOPS_API_URL_V1 }}
-          # SOUTHWARK
-          HD_SOUTHWARK_BOPS_API_KEY: ${{ secrets.SOUTHWARK_BOPS_API_KEY }}
-          HD_SOUTHWARK_BOPS_API_URL: ${{ secrets.SOUTHWARK_BOPS_API_URL }}
-          HD_SOUTHWARK_BOPS_API_URL_V1: ${{ secrets.SOUTHWARK_BOPS_API_URL_V1 }}
-          # ANALYTICS
-          HD_GA: ${{secrets.GA}}
-          HD_GTM: ${{secrets.GTM}}


### PR DESCRIPTION
Cuts out a step in the process!

1password > github env secrets > heroku

Now

1password > heroku


