### PR TITLE
DSNPI-549 / cache revalidation

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -40,6 +40,7 @@ export const getAppConfig = (council?: string): AppConfig => {
     },
     defaults: {
       resultsPerPage: 10,
+      revalidate: 60, // 1 minute, change to 3600 for 1 hour
     },
     navigation: [
       {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -18,6 +18,10 @@ export interface AppConfig {
      * Default results per page value
      */
     resultsPerPage: number;
+    /**
+     * Default revalidate value
+     */
+    revalidate: number;
   };
   /**
    * Navigation links

--- a/src/handlers/bops/requests.ts
+++ b/src/handlers/bops/requests.ts
@@ -1,3 +1,5 @@
+import { getAppConfig } from "@/config";
+
 export async function handleBopsGetRequest<T>(
   council: string,
   url: string,
@@ -23,10 +25,15 @@ export async function handleBopsGetRequest<T>(
     } as T;
   } else {
     try {
+      const config = getAppConfig(council);
+      const revalidateConfig = config.defaults.revalidate;
       const response = await fetch(`${process.env[councilApi]}${url}`, {
         method: "GET",
         headers: {
           Authorization: `Bearer ${process.env[apiKey]}`,
+        },
+        next: {
+          revalidate: revalidateConfig,
         },
       });
 


### PR DESCRIPTION
Add config to revalidate cache on GET requests, currently temporarily set to revalidate every 60 seconds but will need to be set to 3600 (1 hour).
The revalidate value is set in src/config/index.ts in the getAppConfig. We can access this in the `handleBopsGetRequest` function. 
