### PR TITLE
change font

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -8,13 +8,13 @@
   box-sizing: border-box;
   padding: 0;
   margin: 0;
+  font-family: var(--font-mono) !important;
 }
 
 html,
 body {
   max-width: 100vw;
   overflow-x: hidden;
-  font-family: var(--font-mono);
 }
 
 a {


### PR DESCRIPTION
[Ticket](https://tpximpact.atlassian.net/browse/DSNPI-866?atlOrigin=eyJpIjoiOGIzODFlYzY3MzEzNDQ3ZmJhZTEzMThmOWFmZmIzNjUiLCJwIjoiaiJ9)

We seem to have applied the GDS transport font, we we shouldn’t use as we’re not a [gov.uk](http://gov.uk/) domain. Please use the same font family as the prototype.