### PR TITLE
DSNPI-830 / alt text - QA

### DIFF
--- a/src/components/InfoIcon/InfoIcon.tsx
+++ b/src/components/InfoIcon/InfoIcon.tsx
@@ -23,7 +23,7 @@ export const InfoIcon = ({ href, title, ariaLabel }: InfoIconProps) => {
       title={title}
       aria-label={ariaLabel}
     >
-      <span aria-label={ariaLabel}>i</span>
+      <span>i</span>
     </Link>
   );
 };


### PR DESCRIPTION
[Ticket 830
](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?assignee=62a6f3cb6085950068acebf7&selectedIssue=DSNPI-830) returned after QA.

Remove redundant aria label from span because the parent Link tag already has one. Screen readers usually read the most semantically relevant tag, which in this case would be `Link`, so the aria-label on `span` doesn’t provide additional benefit and could potentially cause confusion when read by screen readers.