### PR TITLE
DSNPI-872/ listing page intro

### DIFF
--- a/src/components/PageSearch/PageSearch.scss
+++ b/src/components/PageSearch/PageSearch.scss
@@ -1,0 +1,3 @@
+.intro-text {
+  margin-bottom: 3em;
+}

--- a/src/components/PageSearch/PageSearch.stories.tsx
+++ b/src/components/PageSearch/PageSearch.stories.tsx
@@ -7,6 +7,8 @@ import {
 } from "@mocks/dprApplicationFactory";
 import { createAppConfig } from "@mocks/appConfigFactory";
 
+const defaultAppConfig = createAppConfig("public-council-1");
+
 const meta = {
   title: "Council pages/Search",
   component: PageSearch,
@@ -30,7 +32,7 @@ const meta = {
     },
   },
   args: {
-    appConfig: createAppConfig("public-council-1"),
+    appConfig: defaultAppConfig,
     applications: generateNResults(10, generateDprApplication),
     pagination: generatePagination(),
   },
@@ -40,6 +42,22 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+export const DefaultWithEmailAlerts: Story = {
+  args: {
+    appConfig: {
+      ...defaultAppConfig,
+      council: defaultAppConfig.council && {
+        ...defaultAppConfig.council,
+        pageContent: {
+          ...defaultAppConfig.council.pageContent,
+          email_alerts: {
+            sign_up_for_alerts_link: "email alerts link",
+          },
+        },
+      },
+    },
+  },
+};
 export const SearchResults: Story = {
   args: {
     searchParams: {

--- a/src/components/PageSearch/PageSearch.tsx
+++ b/src/components/PageSearch/PageSearch.tsx
@@ -1,10 +1,11 @@
 import { DprPagination, DprPlanningApplication, SearchParams } from "@/types";
-import { BackLink } from "../button";
+import { BackLink, ButtonEmailSignUp } from "../button";
 import { FormSearch } from "../FormSearch";
 import { ContentNoResult } from "../ContentNoResult";
 import { AppConfig } from "@/config/types";
 import { ApplicationCard } from "../ApplicationCard";
 import { Pagination } from "@/components/Pagination";
+import "./PageSearch.scss";
 
 export interface PageSearchProps {
   appConfig: AppConfig;
@@ -24,7 +25,8 @@ export const PageSearch = ({
   }
   const page = searchParams?.page ? searchParams.page : 1;
 
-  const title = searchParams?.query
+  const hasSearchQuery = searchParams?.query ? true : false;
+  const title = hasSearchQuery
     ? "Search results"
     : "Recently published applications";
 
@@ -32,13 +34,45 @@ export const PageSearch = ({
     <>
       {!applications && <BackLink />}
       <div className="govuk-main-wrapper">
+        {!hasSearchQuery && (
+          <div className="govuk-grid-row intro-text">
+            <div className="govuk-grid-column-two-thirds">
+              <h1 className="govuk-heading-xl">
+                Welcome to the Digital Planning Register
+              </h1>
+              <p className="govuk-body">
+                You can find planning applications submitted through the Open
+                Digital Planning system for your local council planning
+                authority.
+              </p>
+              <p className="govuk-body">
+                Not all planning applications will be available through this
+                register. You may need to check individual council&apos;s
+                websites to see what records are kept here.
+              </p>
+            </div>
+            {appConfig.council?.pageContent?.email_alerts
+              ?.sign_up_for_alerts_link && (
+              <div className="govuk-grid-column-one-third">
+                <div className="email-signup-button-container">
+                  <ButtonEmailSignUp
+                    href={
+                      appConfig.council?.pageContent?.email_alerts
+                        ?.sign_up_for_alerts_link
+                    }
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        )}
         <FormSearch
           action={`/${appConfig.council.slug}`}
           searchParams={searchParams}
         />
         {applications && applications?.length > 0 ? (
           <>
-            <h2 className="govuk-heading-m">{title}</h2>
+            <h2 className="govuk-heading-l">{title}</h2>
             {applications.map((application) => (
               <ApplicationCard
                 key={application.application.reference}

--- a/src/components/PageSearchSiteNotices/PageSearchSiteNotices.tsx
+++ b/src/components/PageSearchSiteNotices/PageSearchSiteNotices.tsx
@@ -34,13 +34,13 @@ export const PageSearchSiteNotices = ({
         is to make it easier for you to access the information most important to
         the local community.
       </p>
-      {appConfig.council?.pageContent?.digital_site_notice
+      {appConfig.council?.pageContent?.email_alerts
         ?.sign_up_for_alerts_link && (
         <a
           className="govuk-button govuk-button--secondary"
           target="_blank"
           href={
-            appConfig.council?.pageContent?.digital_site_notice
+            appConfig.council?.pageContent?.email_alerts
               ?.sign_up_for_alerts_link
           }
         >

--- a/src/components/button/Button.scss
+++ b/src/components/button/Button.scss
@@ -88,3 +88,16 @@ $button-shadow-size: $govuk-border-width-form-element;
     }
   }
 }
+
+.email-signup-button {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+
+  &-container {
+    display: flex;
+    width: auto;
+    min-width: 200px;
+  }
+}

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -134,3 +134,27 @@ export const LinkButton = ({ href, text }: { href: string; text: string }) => {
     </Link>
   );
 };
+
+export const ButtonEmailSignUp = ({ href }: { href: string }) => (
+  <Link
+    href={href}
+    role="button"
+    className="govuk-button govuk-button--secondary blue-button email-signup-button"
+    data-module="govuk-button"
+  >
+    <svg
+      className="button-icon"
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      height="18"
+      width="18"
+      viewBox="0 0 459.334 459.334"
+    >
+      <path
+        fill="currentColor"
+        d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z"
+      ></path>
+    </svg>
+    Sign up for email alerts
+  </Link>
+);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -250,7 +250,7 @@ const councils: Council[] = [
         privacy_policy_link:
           "https://www.camden.gov.uk/data-protection-privacy-and-cookies",
       },
-      digital_site_notice: {
+      email_alerts: {
         sign_up_for_alerts_link:
           "https://accountforms.camden.gov.uk/alert-web/select.xhtml?alertType=PLANNING",
       },

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -76,7 +76,7 @@ export interface Council {
       corporate_privacy_statement_link: string;
       planning_service_privacy_statement_link: string;
     };
-    digital_site_notice?: {
+    email_alerts?: {
       sign_up_for_alerts_link: string;
     };
   };


### PR DESCRIPTION
[Ticket 872
](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-872)

Listing page intro paragraph is shown on the top of the listing page when there is no search query present. There is also a CTA email alert button that is shown if there is a link provided for the council. The config for this link was originally under `digital_site_notice` in the config, however I've changed this to be `email_alerts` because we use it in more places than just the DSN page. 
Stories have been added into storybook showing the listing page with and without the text and the alert button.
Additional small tweak to make the 'Recently published applications / Search results' title larger to match the prototype

![image](https://github.com/user-attachments/assets/5bb7265b-f9e3-46fc-a706-44b0e1cbbfcc)


