### PR TITLE
Remove annotations so PRs are readable!

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Coverage Report
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:
+          annotations: none
           output: comment, report-markdown
 
   e2e-pa11y:


### PR DESCRIPTION
Its been driving me mad for a while but these annotations make it so hard to read the PR's! I'd like to switch us to codecov at some point anyway

![image](https://github.com/user-attachments/assets/a63eeb5e-c443-43ab-95df-ad36adde7aaa)
