### PR TITLE
DSNPI-535 Accessibility - disable autocomplete on textarea

### DIFF
--- a/src/components/comment_text_entry/index.tsx
+++ b/src/components/comment_text_entry/index.tsx
@@ -170,6 +170,7 @@ const CommentTextEntry = ({
                     ? "length-error"
                     : undefined
               }
+              autoComplete="off"
             ></textarea>
           </div>
           {!hideContinue && (


### PR DESCRIPTION
Disabled autocomplete on textarea, makes sense since we dont change the name or id of the field for different topics so you wouldn't want to auticomplete the wrong thing?