### PR TITLE
BUG: Application Submission page shows not found when no submission 

### DIFF
--- a/src/app/[council]/[reference]/application-form/page.tsx
+++ b/src/app/[council]/[reference]/application-form/page.tsx
@@ -65,14 +65,6 @@ export default async function ApplicationFormPage({
   const submittedAt = response?.data?.submission?.metadata.submittedAt;
   const applicationSubmissionData = response?.data?.submission?.data;
 
-  if (!applicationSubmissionData) {
-    return (
-      <PageWrapper>
-        <ContentNotFound councilConfig={appConfig.council} />
-      </PageWrapper>
-    );
-  }
-
   return (
     <PageApplicationSubmission
       reference={reference}


### PR DESCRIPTION
This has been driving me nuts, the first result on staging currently has no submission data, not sure how that happens but I keep thinking my dev env is broken but its actually missing data!

We have a design for ApplicationSubmission component if theres no data so we should let the page go into the component and handle that. 

To replicate on staging go to https://dpr-staging-f3c30ff39338.herokuapp.com/camden/24-00143-HAPP and click application form it's saying Not Found!
