### PR TITLE
SPIKE: Hide application form if no submission

### DIFF
--- a/src/components/DocumentCard/DocumentCard.stories.ts
+++ b/src/components/DocumentCard/DocumentCard.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { DocumentCard } from "./DocumentCard";
 import { generateDocument } from "@mocks/dprApplicationFactory";
-import { ApplicationFormObject } from "../application_form";
+import { applicationFormObject } from "@/lib/documents";
 
 const meta = {
   title: "DPR Components/DocumentCard",
@@ -23,6 +23,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 export const ApplicationFormDocument: Story = {
   args: {
-    document: ApplicationFormObject("public-council-1", "12345"),
+    document: applicationFormObject("public-council-1", "12345"),
   },
 };

--- a/src/components/application_form/index.tsx
+++ b/src/components/application_form/index.tsx
@@ -1,8 +1,4 @@
-import {
-  DprApplicationSubmissionSubtopic,
-  DprApplicationSubmissionSubtopicValue,
-  DprDocument,
-} from "@/types";
+import { DprApplicationSubmissionSubtopic } from "@/types";
 import { Section } from "./section";
 import "./ApplicationForm.scss";
 
@@ -23,28 +19,6 @@ const ApplicationForm = ({ submissionData }: ApplicationFormProps) => {
       </div>
     </div>
   );
-};
-
-/**
- * This generates a fake document - currently using the BopsNonStandardDocument type
- * @todo this will soon not be compatible with the new document type
- * Its added per page as opposed to at a higher level since we fetch the data at each load anyway,
- * it might be worth looking into if this affects caching for data fetching at some point though
- * @param council
- * @param reference
- * @returns
- */
-export const ApplicationFormObject = (
-  council: string,
-  reference: string,
-): DprDocument => {
-  return {
-    url: `/${council}/${reference}/application-form`,
-    title: "Application form",
-    metadata: {
-      contentType: "text/html",
-    },
-  };
 };
 
 export default ApplicationForm;

--- a/src/handlers/bops/converters/planningApplication.ts
+++ b/src/handlers/bops/converters/planningApplication.ts
@@ -6,7 +6,6 @@ import {
 } from "../types";
 import { sortComments } from "@/lib/comments";
 import { convertCommentBops } from "./comments";
-import { ApplicationFormObject } from "@/components/application_form";
 import { convertDocumentBopsNonStandard } from "./documents";
 import { getCommentsAllowed } from "@/lib/planningApplication";
 
@@ -46,11 +45,6 @@ export const convertBopsApplicationToDpr = (
       ? sortComments(publishedComments?.map(convertCommentBops))
       : null;
 
-  const reference = application.reference;
-
-  // add fake application form document
-  const applicationFormDocument = ApplicationFormObject(council, reference);
-
   return {
     reference: application.reference,
     type: {
@@ -72,10 +66,7 @@ export const convertBopsApplicationToDpr = (
     // missing fields from public endpoint
     id: privateApplication?.id ?? 0,
     documents: privateApplication?.documents
-      ? [
-          applicationFormDocument,
-          ...privateApplication.documents.map(convertDocumentBopsNonStandard),
-        ]
+      ? privateApplication.documents.map(convertDocumentBopsNonStandard)
       : null,
   };
 };

--- a/src/handlers/bops/v2/documents.ts
+++ b/src/handlers/bops/v2/documents.ts
@@ -1,6 +1,4 @@
 "use server";
-
-import { ApplicationFormObject } from "@/components/application_form";
 import { ApiResponse, DprDocumentsApiResponse } from "@/types";
 import { BopsV2PublicPlanningApplicationDocuments } from "@/handlers/bops/types";
 import {
@@ -28,15 +26,11 @@ export async function documents(
       results: 0,
       totalResults: 0,
     },
-    ...restData
   } = request.data || {};
-
-  // add fake application form document
-  const applicationFormDocument = ApplicationFormObject(council, reference);
 
   const convertedData = {
     pagination: convertBopsDocumentPagination(metadata),
-    files: [applicationFormDocument, ...files.map(convertDocumentBopsFile)],
+    files: files.map(convertDocumentBopsFile),
   };
 
   return { ...request, data: convertedData };

--- a/src/handlers/local/v1/documents.ts
+++ b/src/handlers/local/v1/documents.ts
@@ -21,16 +21,10 @@ const responseQuery = (
   const appConfig = getAppConfig();
   const resultsPerPage = appConfig.defaults.resultsPerPage;
 
-  const documents = [
-    {
-      url: `/${council}/${reference}/application-form`,
-      title: "Application form",
-      metadata: {
-        contentType: "text/html",
-      },
-    },
-    ...generateNResults<DprDocument>(resultsPerPage, generateDocument),
-  ];
+  const documents = generateNResults<DprDocument>(
+    resultsPerPage,
+    generateDocument,
+  );
 
   // if we've done a search just rename the first result to match the query
   if (searchParams?.query) {

--- a/src/lib/documents.ts
+++ b/src/lib/documents.ts
@@ -16,3 +16,25 @@ export const buildDocumentData = (
   };
   return documentData;
 };
+
+/**
+ * This generates a fake document - currently using the BopsNonStandardDocument type
+ * @todo this will soon not be compatible with the new document type
+ * Its added per page as opposed to at a higher level since we fetch the data at each load anyway,
+ * it might be worth looking into if this affects caching for data fetching at some point though
+ * @param council
+ * @param reference
+ * @returns
+ */
+export const applicationFormObject = (
+  council: string,
+  reference: string,
+): DprDocument => {
+  return {
+    url: `/${council}/${reference}/application-form`,
+    title: "Application form",
+    metadata: {
+      contentType: "text/html",
+    },
+  };
+};


### PR DESCRIPTION
if theres no submission don't show the fake document on the details and documents pages

This PR does the above however

- now that there is less of a no-js response we can wrap our components in data fetchers (to keep them away from data fetching) and make use of `<Suspense /`>
- would it be a sensible request to add public submission data to the show endpoint?