### PR TITLE
DSNPI-894 - Remove `documentsPublicEndpoint` feature flag

### DIFF
--- a/__mocks__/appConfigFactory.ts
+++ b/__mocks__/appConfigFactory.ts
@@ -71,7 +71,6 @@ export const createAppConfig = (council?: string): AppConfig => {
     council: council ? getCouncil(council) : undefined,
     councils: councilConfigs,
     features: {
-      documentsPublicEndpoint: true,
       getApplicantDetailsFromPrivateEndpoint: true,
       getApplicationIdFromPrivateEndpoint: true,
     },

--- a/src/app/[council]/[reference]/documents/page.tsx
+++ b/src/app/[council]/[reference]/documents/page.tsx
@@ -74,9 +74,7 @@ export default async function PlanningApplicationDetailsDocuments({
   }
 
   const application = applicationResponse?.data;
-  const documents = appConfig.features.documentsPublicEndpoint
-    ? documentResponse?.data?.files
-    : application?.application.documents;
+  const documents = application?.application.documents;
 
   if (!documents || !application) {
     return (

--- a/src/app/[council]/[reference]/page.tsx
+++ b/src/app/[council]/[reference]/page.tsx
@@ -66,9 +66,7 @@ const PlanningApplicationDetails = async ({
     );
   }
   const application = applicationResponse.data;
-  const documents = appConfig.features.documentsPublicEndpoint
-    ? (documentResponse?.data?.files ?? null)
-    : (application?.application.documents ?? null);
+  const documents = application?.application.documents ?? null;
 
   return (
     <PageShow

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -36,7 +36,6 @@ export const getAppConfig = (council?: string): AppConfig => {
     council: council ? getCouncil(council) : undefined,
     councils: councilConfigs,
     features: {
-      documentsPublicEndpoint: true,
       getApplicantDetailsFromPrivateEndpoint: true,
       getApplicationIdFromPrivateEndpoint: true,
     },

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,11 +1,6 @@
 export interface AppConfig {
   features: {
     /**
-     * Set this to true to use the public /documents endpoint
-     */
-    documentsPublicEndpoint: boolean;
-
-    /**
      * Set this to true to fetch applicant information from the BOPs private endpoint for applicants
      */
     getApplicantDetailsFromPrivateEndpoint: boolean;


### PR DESCRIPTION
[Ticket 894
](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-894)
The documentsPublicEndpoint was initially introduced during the transition to public endpoints for documents as a fallback mechanism. It is no longer required and has been removed to streamline the code.