### PR TITLE
Temporarily disable staging deployment whilst WCAG testing is in progress

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,8 +1,13 @@
 name: build and deploy staging
 
+# TEMPORARILY DISABLE AUTOMATIC DEPLOYMENT TO STAGING
+# WCAG TESTING IN PROGRESS
 on:
   push:
-    branches: ["main"]
+    # branches: ["main"]
+    branches-ignore:
+      - "*" # This ignores all branches, effectively disabling automatic deployment
+      # TODO Remove the above line and uncomment the line above it to enable automatic deployment
 
 jobs:
   build-and-deploy-staging:


### PR DESCRIPTION
WCAG testing will be happening on the staging build so we need to not auto-deploy any changes made before testing is complete.
This PR disables the workflow file trigger that deploys to staging when a PR is merged to main.

TODO: When WCAG testing is complete, re-enable.