### PR TITLE
DSNPI - 891 / Update `postComment` Action and Handlers to Use `reference` Instead of `id` for BOPs Comments Integration

### DIFF
--- a/__mocks__/dprApplicationFactory.ts
+++ b/__mocks__/dprApplicationFactory.ts
@@ -159,7 +159,6 @@ export const generateDprApplication = ({
       publishedAt: faker.date.anytime().toISOString(),
       determinedAt: determinedAt,
       decision: decision,
-      id: Number(faker.string.numeric(4)),
       documents: [
         {
           url: "/camden/24-00135-HAPP/application-form",

--- a/__tests__/components/comment_check_answer.test.tsx
+++ b/__tests__/components/comment_check_answer.test.tsx
@@ -35,7 +35,6 @@ describe("CommentCheckAnswer", () => {
   const defaultProps = {
     councilConfig: appConfig.council,
     reference: "REF-001",
-    applicationId: 1,
     navigateToPage: jest.fn(),
     updateProgress: jest.fn(),
   };
@@ -131,7 +130,7 @@ describe("CommentCheckAnswer", () => {
       expect(ApiV1.postComment).toHaveBeenCalledWith(
         "local",
         "public-council-1",
-        1,
+        "REF-001",
         expect.any(Object),
       );
       expect(sendGTMEvent).toHaveBeenCalledWith({ event: "comment_submit" });

--- a/src/actions/api/v1/postComment.ts
+++ b/src/actions/api/v1/postComment.ts
@@ -15,18 +15,18 @@ import { apiReturnError } from "@/handlers/lib";
 export async function postComment(
   source: string,
   council: string,
-  applicationId: number,
+  reference: string,
   apiData: object,
 ): Promise<ApiResponse<BopsV1PlanningApplicationsNeighbourResponse | null>> {
-  if (!council || !applicationId || !apiData) {
+  if (!council || !reference || !apiData) {
     return apiReturnError("Council and reference are required");
   }
 
   switch (source) {
     case "bops":
-      return await BopsV2.postComment(council, applicationId, apiData);
+      return await BopsV2.postComment(council, reference, apiData);
     case "local":
-      return await LocalV1.postComment(council, applicationId, apiData);
+      return await LocalV1.postComment(council, reference, apiData);
     default:
       return apiReturnError("Invalid source");
   }

--- a/src/app/[council]/[reference]/submit-comment/page.tsx
+++ b/src/app/[council]/[reference]/submit-comment/page.tsx
@@ -341,7 +341,6 @@ const Comment = ({ params, searchParams: searchParamsFromPage }: Props) => {
           <CommentCheckAnswer
             councilConfig={appConfig?.council}
             {...commonProps}
-            applicationId={applicationData.application.id}
           />
         );
       case 6:

--- a/src/components/comment_check_answer/CommentCheckAnswer.stories.ts
+++ b/src/components/comment_check_answer/CommentCheckAnswer.stories.ts
@@ -17,7 +17,6 @@ const meta = {
   args: {
     councilConfig: councilConfig,
     reference: "12345",
-    applicationId: 1,
     navigateToPage: () => {},
     updateProgress: () => {},
   },

--- a/src/components/comment_check_answer/index.tsx
+++ b/src/components/comment_check_answer/index.tsx
@@ -56,13 +56,11 @@ const topics_selection = [
 const CommentCheckAnswer = ({
   councilConfig,
   reference,
-  applicationId,
   navigateToPage,
   updateProgress,
 }: {
   councilConfig: AppConfig["council"];
   reference: string;
-  applicationId: number;
   navigateToPage: (page: number, params?: object) => void;
   updateProgress: (completedPage: number) => void;
 }) => {
@@ -146,7 +144,7 @@ const CommentCheckAnswer = ({
         const response = await ApiV1.postComment(
           councilConfig?.dataSource ?? "none",
           councilConfig?.slug,
-          applicationId,
+          reference,
           apiData,
         );
         if (response?.status?.code === 200) {

--- a/src/handlers/bops/v2/postComment.ts
+++ b/src/handlers/bops/v2/postComment.ts
@@ -1,26 +1,42 @@
 "use server";
 
 import { ApiResponse } from "@/types";
-import { BopsV1PlanningApplicationsNeighbourResponse } from "@/handlers/bops/types";
-import { handleBopsPostRequest } from "../requests";
+import {
+  BopsV1PlanningApplicationsNeighbourResponse,
+  BopsV2PlanningApplicationDetail,
+} from "@/handlers/bops/types";
+import { handleBopsGetRequest, handleBopsPostRequest } from "../requests";
+import { apiReturnError } from "@/handlers/lib";
 
 /**
  * POST planning_applications/${id}/neighbour_responses
  * Post a comment to BOPS
- * @param id
+ * @param reference
  * @param council
  * @param apiData
  * @returns
  */
 export async function postComment(
   council: string,
-  applicationId: number,
+  reference: string,
   apiData: object,
 ): Promise<ApiResponse<BopsV1PlanningApplicationsNeighbourResponse | null>> {
+  if (!reference) {
+    return apiReturnError("Reference is required");
+  }
+  const privateApplicationData = await handleBopsGetRequest<
+    ApiResponse<BopsV2PlanningApplicationDetail | null>
+  >(council, `planning_applications/${reference}`);
+
+  const applicationId = privateApplicationData.data?.id;
+
+  if (!applicationId) {
+    return apiReturnError("ApplicationId is required");
+  }
   const url = `planning_applications/${applicationId}/neighbour_responses`;
-  const request = await handleBopsPostRequest<
+  const postRequest = await handleBopsPostRequest<
     ApiResponse<BopsV1PlanningApplicationsNeighbourResponse | null>
   >(council, url, apiData, true);
 
-  return request;
+  return postRequest;
 }

--- a/src/handlers/local/v1/search.ts
+++ b/src/handlers/local/v1/search.ts
@@ -55,7 +55,6 @@ const responseDsn: ApiResponse<DprSearchApiResponse> = {
           publishedAt: "2024-04-25T00:00:00.000+01:00",
           determinedAt: null,
           decision: null,
-          id: 0,
           documents: null,
         },
         property: {

--- a/src/types/definitions.d.ts
+++ b/src/types/definitions.d.ts
@@ -49,11 +49,6 @@ export interface DprPlanningApplication {
     validAt: string | null;
 
     /**
-     * @todo this is missing from the public BOPS response
-     */
-    id: number;
-
-    /**
      * @todo this is missing from the public BOPS response BUT we have a new public endpoint for them
      */
     documents: DprDocument[] | null;


### PR DESCRIPTION
[Ticket 891](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-891)

Updated `postComment` action and handlers to now use reference numbers instead of IDs, leveraging the existing BOPs private endpoint to fetch application IDs by reference internally while maintaining compatibility with the v1 API. Added error handling and adjusted tests.