### PR TITLE
DSNPI- 964 / Remove consent checkbox

### DIFF
--- a/__e2e__/add-comment.spec.ts
+++ b/__e2e__/add-comment.spec.ts
@@ -146,16 +146,10 @@ const testCommentFlow = async (page: Page) => {
   expect(page.getByText("Your name is required", { exact: true }));
   expect(page.getByText("Your address is required", { exact: true }));
   expect(page.getByText("A valid postcode is required", { exact: true }));
-  expect(page.getByText("You need to consent", { exact: true }));
 
   await page.getByLabel("Name", { exact: true }).fill("Test Name");
   await page.getByLabel("Address", { exact: true }).fill("Test Address");
   await page.getByLabel("Postcode", { exact: true }).fill("EC1N 8BA");
-  await page
-    .getByLabel(
-      "I consent to Public Council 1 Council using my data for the purposes of assessing this planning application",
-    )
-    .check();
   await page.getByRole("button", { name: "Continue" }).click();
 
   // 10. Comment flow - review

--- a/__tests__/components/comment_personal_details.test.tsx
+++ b/__tests__/components/comment_personal_details.test.tsx
@@ -36,7 +36,6 @@ describe("CommentPersonalDetails", () => {
     expect(screen.getByLabelText("Postcode")).toBeInTheDocument();
     expect(screen.getByLabelText("Email address")).toBeInTheDocument();
     expect(screen.getByLabelText("Telephone number")).toBeInTheDocument();
-    expect(screen.getByLabelText(/I consent to/)).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Continue" }),
     ).toBeInTheDocument();
@@ -51,7 +50,6 @@ describe("CommentPersonalDetails", () => {
     expect(
       screen.getByText("A valid postcode is required"),
     ).toBeInTheDocument();
-    expect(screen.getByText("You need to consent")).toBeInTheDocument();
     expect(defaultProps.navigateToPage).not.toHaveBeenCalled();
     expect(defaultProps.updateProgress).not.toHaveBeenCalled();
     expect(sendGTMEvent).toHaveBeenCalledWith({
@@ -77,7 +75,6 @@ describe("CommentPersonalDetails", () => {
     fireEvent.change(screen.getByLabelText("Telephone number"), {
       target: { value: "01234567890" },
     });
-    fireEvent.click(screen.getByLabelText(/I consent to/));
     fireEvent.click(screen.getByRole("button", { name: "Continue" }));
 
     expect(defaultProps.navigateToPage).toHaveBeenCalledWith(5);
@@ -89,7 +86,6 @@ describe("CommentPersonalDetails", () => {
       postcode: "AB12 3CD",
       emailAddress: "john@example.com",
       telephoneNumber: "01234567890",
-      consent: true,
     });
   });
 
@@ -102,7 +98,6 @@ describe("CommentPersonalDetails", () => {
         postcode: "XY98 7ZA",
         emailAddress: "jane@example.com",
         telephoneNumber: "09876543210",
-        consent: true,
       }),
     );
     render(<CommentPersonalDetails {...defaultProps} />);
@@ -116,7 +111,6 @@ describe("CommentPersonalDetails", () => {
     expect(screen.getByLabelText("Telephone number")).toHaveValue(
       "09876543210",
     );
-    expect(screen.getByLabelText(/I consent to/)).toBeChecked();
     expect(sendGTMEvent).not.toHaveBeenCalled();
   });
 });

--- a/src/components/comment_personal_details/index.tsx
+++ b/src/components/comment_personal_details/index.tsx
@@ -13,7 +13,6 @@ interface PersonalDetails {
   postcode: string;
   emailAddress: string;
   telephoneNumber: string;
-  consent: boolean;
 }
 
 interface ValidationErrors {
@@ -22,7 +21,6 @@ interface ValidationErrors {
   postcode?: string;
   emailAddress?: string;
   telephoneNumber?: string;
-  consent?: string;
 }
 
 const CommentPersonalDetails = ({
@@ -46,7 +44,6 @@ const CommentPersonalDetails = ({
     postcode: "",
     emailAddress: "",
     telephoneNumber: "",
-    consent: false,
   });
   const [validationErrors, setValidationErrors] = useState<ValidationErrors>(
     {},
@@ -59,7 +56,6 @@ const CommentPersonalDetails = ({
     postcode: useRef<HTMLDivElement>(null),
     emailAddress: useRef<HTMLDivElement>(null),
     telephoneNumber: useRef<HTMLDivElement>(null),
-    consent: useRef<HTMLDivElement>(null),
   };
 
   const contactPlanningAdviceLink =
@@ -131,7 +127,6 @@ const CommentPersonalDetails = ({
       !phoneValidation(personalDetails.telephoneNumber)
     )
       errors.telephoneNumber = "Telephone number must be valid";
-    if (!personalDetails.consent) errors.consent = "You need to consent";
 
     setValidationErrors(errors);
 
@@ -323,46 +318,6 @@ const CommentPersonalDetails = ({
                 validationErrors.telephoneNumber ? "telephone-error" : undefined
               }
             />
-          </div>
-
-          {/* Consent checkbox */}
-          <div
-            ref={fieldRefs.consent}
-            className={`govuk-form-group ${validationErrors.consent ? "govuk-form-group--error" : ""}`}
-          >
-            {validationErrors.consent && (
-              <p
-                id="consent-error"
-                className="govuk-error-message"
-                role="alert"
-              >
-                <span className="govuk-visually-hidden">Error:</span>{" "}
-                {validationErrors.consent}
-              </p>
-            )}
-            <div className="govuk-checkboxes" data-module="govuk-checkboxes">
-              <div className="govuk-checkboxes__item">
-                <input
-                  className={`govuk-checkboxes__input ${validationErrors.consent ? "govuk-input--error" : ""}`}
-                  id="consent"
-                  name="consent"
-                  type="checkbox"
-                  checked={personalDetails.consent}
-                  onChange={handleInputChange}
-                  aria-invalid={!!validationErrors.consent}
-                  aria-describedby={
-                    validationErrors.consent ? "consent-error" : undefined
-                  }
-                />
-                <label
-                  className="govuk-label govuk-checkboxes__label"
-                  htmlFor="consent"
-                >
-                  I consent to {councilConfig?.name ?? "the"} Council using my
-                  data for the purposes of assessing this planning application
-                </label>
-              </div>
-            </div>
           </div>
 
           <Details


### PR DESCRIPTION
[Ticket 964](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-964) 

This PR removes the consent checkbox from the submit a comment flow. The checkbox which reads “I consent to [council name] Council using my data for the purposes of assessing this planning application” should be removed, as it implies GDPR allowances that the submitter does not have; confuses some users; and the relevant information is provided in other places.
Tests have also been updated.