### PR TITLE
DSNPI-945 / add decision notice to documents list

### DIFF
--- a/src/handlers/bops/types/schemas.d.ts
+++ b/src/handlers/bops/types/schemas.d.ts
@@ -60,7 +60,7 @@ export interface BopsV2PublicPlanningApplicationDocuments {
   metadata: BopsDocumentsMetadata;
   application: BopsApplicationOverview;
   files: BopsFile[];
-  decisionNotice: {
+  decisionNotice?: {
     name: string;
     url: string;
   };

--- a/src/handlers/bops/v2/documents.ts
+++ b/src/handlers/bops/v2/documents.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { applicationFormObject } from "@/lib/planningApplication";
-import DecisionNoticeObject from "@/components/DecisionNotice";
+import decisionNoticeObject from "@/lib/planningApplication/decisionNotice";
 import { ApiResponse, DprDocumentsApiResponse } from "@/types";
 import { BopsV2PublicPlanningApplicationDocuments } from "@/handlers/bops/types";
 import {
@@ -35,17 +35,20 @@ export async function documents(
   // add fake application form document
   const applicationFormDocument = applicationFormObject(council, reference);
 
-  // add fake decision notice document and only show if decision has been made and url is present
-  const decision = request?.data?.application?.decision;
-  const decisionNotice = request?.data?.decisionNotice;
-  const decisionNoticeUrl = decisionNotice?.url;
-  const decisionNoticeDocument = DecisionNoticeObject(decisionNoticeUrl);
+  const { decision } = request?.data?.application || {};
+  const decisionNoticeUrl = request?.data?.decisionNotice?.url;
+
+  // Create the decision notice document if applicable
+  const decisionNoticeDocument =
+    decision && decisionNoticeUrl
+      ? decisionNoticeObject(decisionNoticeUrl)
+      : null;
 
   const convertedData = {
     pagination: convertBopsDocumentPagination(metadata),
     files: [
       applicationFormDocument,
-      ...(decision && decisionNoticeUrl ? [decisionNoticeDocument] : []),
+      ...(decisionNoticeDocument ? [decisionNoticeDocument] : []),
       ...files.map(convertDocumentBopsFile),
     ],
   };

--- a/src/lib/planningApplication/decisionNotice.tsx
+++ b/src/lib/planningApplication/decisionNotice.tsx
@@ -5,7 +5,7 @@ import { DprDocument } from "@/types";
  * @param url
  * @returns
  */
-export const DecisionNoticeObject = (url: string): DprDocument => {
+export const decisionNoticeObject = (url: string): DprDocument => {
   return {
     url: url,
     title: "Decision notice",
@@ -15,4 +15,4 @@ export const DecisionNoticeObject = (url: string): DprDocument => {
   };
 };
 
-export default DecisionNoticeObject;
+export default decisionNoticeObject;


### PR DESCRIPTION
[Ticket 945](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-945)

This PR includes the decision notice as a PDF in the documents, adding it in at the top of the documents list, like the submission is done at the moment.
The document is only shown if a decision has been made and if a URL to the decision notice is present.

![image](https://github.com/user-attachments/assets/81cebdd4-2149-4ab9-8134-10c1f8a8f71d)
