### PR TITLE
BUG? update getApplicationIdFromPrivateEndpoint flag

### DIFF
--- a/src/components/comment_check_answer/index.tsx
+++ b/src/components/comment_check_answer/index.tsx
@@ -169,7 +169,7 @@ const CommentCheckAnswer = ({
           sendGTMEvent({
             event: "error_submission",
           });
-          throw new Error("Submission failed");
+          throw new Error(`Submission failed ${response.status.detail}`);
         }
       }
     } catch (error) {

--- a/src/handlers/bops/converters/planningApplication.ts
+++ b/src/handlers/bops/converters/planningApplication.ts
@@ -79,7 +79,6 @@ export const convertBopsApplicationToDpr = (
     decision: application.decision ?? null,
 
     // missing fields from public endpoint
-    id: privateApplication?.id ?? 0,
     documents: privateApplication?.documents
       ? [
           applicationFormDocument,

--- a/src/handlers/bops/v2/show.ts
+++ b/src/handlers/bops/v2/show.ts
@@ -24,10 +24,7 @@ export async function show(
 
   // only get missing data if the feature is enabled
   let missingData;
-  if (
-    appConfig.features.getApplicationIdFromPrivateEndpoint ||
-    appConfig.features.getApplicantDetailsFromPrivateEndpoint
-  ) {
+  if (appConfig.features.getApplicantDetailsFromPrivateEndpoint) {
     const privateApplication = await handleBopsGetRequest<
       ApiResponse<BopsV2PlanningApplicationDetail | null>
     >(council, `planning_applications/${reference}`);


### PR DESCRIPTION
Noticed that `getApplicationIdFromPrivateEndpoint` flag is not controlling the fetching of the applicationId in the postComment method. 

- Added error message into the Error that is thrown which will tell us which piece of data is missing in the logs
- Updated postComment method to return an error if it is missing council, reference or applicationId fields
- Wrapped postComment applicationId fetching in `getApplicationIdFromPrivateEndpoint` flag
- removed `id` from planning application converter as we're not using that field anymore