### PR TITLE
DSNPI-1006 DPR - Remove getApplicantDetailsFromPrivateEndpoint flag

### DIFF
--- a/__mocks__/appConfigFactory.ts
+++ b/__mocks__/appConfigFactory.ts
@@ -71,7 +71,6 @@ export const createAppConfig = (council?: string): AppConfig => {
     council: council ? getCouncil(council) : undefined,
     councils: councilConfigs,
     features: {
-      getApplicantDetailsFromPrivateEndpoint: true,
       getApplicationIdFromPrivateEndpoint: true,
     },
     defaults: {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -36,7 +36,6 @@ export const getAppConfig = (council?: string): AppConfig => {
     council: council ? getCouncil(council) : undefined,
     councils: councilConfigs,
     features: {
-      getApplicantDetailsFromPrivateEndpoint: true,
       getApplicationIdFromPrivateEndpoint: true,
       osMapProxyUrl: process.env.OS_MAP_PROXY_URL ?? undefined,
     },

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,10 +1,5 @@
 export interface AppConfig {
-  features: {
-    /**
-     * Set this to true to fetch applicant information from the BOPs private endpoint for applicants
-     */
-    getApplicantDetailsFromPrivateEndpoint: boolean;
-
+  features?: {
     /**
      * Set this to true to fetch id from the BOPs private endpoint for submitting comments
      */

--- a/src/handlers/bops/converters/planningApplication.ts
+++ b/src/handlers/bops/converters/planningApplication.ts
@@ -10,28 +10,20 @@ import { getCommentsAllowed } from "@/lib/planningApplication";
 import { convertDateNoTimeToDprDate, convertDateTimeToUtc } from "@/util";
 
 export const convertBopsToDpr = (
-  council: string,
   application: BopsPlanningApplication,
-  privateApplication?: BopsV2PlanningApplicationDetail | null,
 ): DprPlanningApplication => {
   return {
     applicationType: application.application.type.value,
-    application: convertBopsApplicationToDpr(
-      council,
-      application.application,
-      privateApplication,
-    ),
+    application: convertBopsApplicationToDpr(application.application),
     property: createProperty(application),
     proposal: createProposal(application),
-    applicant: createApplicant(application, privateApplication),
+    applicant: createApplicant(application),
     officer: createOfficer(application),
   };
 };
 
 export const convertBopsApplicationToDpr = (
-  council: string,
   application: BopsApplicationOverview,
-  privateApplication?: BopsV2PlanningApplicationDetail | null,
 ): DprPlanningApplication["applicant"] => {
   const { consulteeComments = [], publishedComments = [] } =
     application.consultation || {};
@@ -102,42 +94,9 @@ export const createProposal = (
 
 export const createApplicant = (
   application: BopsPlanningApplication,
-  privateApplication?: BopsV2PlanningApplicationDetail | null,
 ): DprPlanningApplication["applicant"] => {
   if (application?.applicant) {
-    // remove when bops sends back applicant info in the show endpoint
-    if (privateApplication) {
-      const applicant = {
-        name: {
-          first:
-            application.applicant?.name?.first ||
-            privateApplication?.applicant_first_name ||
-            undefined,
-          last:
-            application.applicant?.name?.last ||
-            privateApplication?.applicant_last_name ||
-            undefined,
-        },
-        agent: {
-          name: {
-            first:
-              application.applicant?.agent?.name?.first ||
-              privateApplication?.agent_first_name ||
-              undefined,
-            last:
-              application.applicant?.agent?.name?.last ||
-              privateApplication?.agent_last_name ||
-              undefined,
-          },
-        },
-      };
-      return {
-        ...application.applicant,
-        ...applicant,
-      };
-    } else {
-      return application.applicant;
-    }
+    return application.applicant;
   } else {
     return null;
   }

--- a/src/handlers/bops/v2/applicationSubmission.ts
+++ b/src/handlers/bops/v2/applicationSubmission.ts
@@ -24,10 +24,7 @@ export async function applicationSubmission(
   >(council, url);
 
   if (request.data?.application) {
-    const application = convertBopsApplicationToDpr(
-      council,
-      request.data?.application,
-    );
+    const application = convertBopsApplicationToDpr(request.data?.application);
     const submission = request.data?.submission
       ? convertApplicationSubmissionBops(request.data?.submission)
       : null;

--- a/src/handlers/bops/v2/postComment.ts
+++ b/src/handlers/bops/v2/postComment.ts
@@ -25,7 +25,7 @@ export async function postComment(
   const appConfig = getAppConfig(council);
   let applicationId = undefined;
 
-  if (appConfig.features.getApplicationIdFromPrivateEndpoint) {
+  if (appConfig.features?.getApplicationIdFromPrivateEndpoint) {
     const privateApplicationData = await handleBopsGetRequest<
       ApiResponse<BopsV2PlanningApplicationDetail | null>
     >(council, `planning_applications/${reference}`);

--- a/src/handlers/bops/v2/search.ts
+++ b/src/handlers/bops/v2/search.ts
@@ -42,7 +42,7 @@ export async function search(
   const convertedData = {
     pagination: request.data?.metadata ?? defaultPagination,
     data: planningApplications.map((application) =>
-      convertBopsToDpr(council, application),
+      convertBopsToDpr(application),
     ),
   };
 

--- a/src/handlers/bops/v2/show.ts
+++ b/src/handlers/bops/v2/show.ts
@@ -22,22 +22,11 @@ export async function show(
 ): Promise<ApiResponse<DprShowApiResponse | null>> {
   const appConfig = getAppConfig(council);
 
-  // only get missing data if the feature is enabled
-  let missingData;
-  if (appConfig.features.getApplicantDetailsFromPrivateEndpoint) {
-    const privateApplication = await handleBopsGetRequest<
-      ApiResponse<BopsV2PlanningApplicationDetail | null>
-    >(council, `planning_applications/${reference}`);
-    missingData = privateApplication?.data;
-  }
-
   const request = await handleBopsGetRequest<
     ApiResponse<BopsV2PublicPlanningApplicationDetail | null>
   >(council, `public/planning_applications/${reference}`);
 
-  const convertedData = request?.data
-    ? convertBopsToDpr(council, request.data, missingData)
-    : null;
+  const convertedData = request?.data ? convertBopsToDpr(request.data) : null;
 
   return { ...request, data: convertedData };
 }


### PR DESCRIPTION
We no longer need to substitute in the agent applicant data because we know BOPs will send this data back for us in the right format now. Assuming the data comes through to them ok though. 

Either way the fix is on BOPs side as opposed to ours. 

Setting this to draft for the moment until I verify some things though!

- Remove `getApplicantDetailsFromPrivateEndpoint` flag
- Remove private application references from the conversion handlers we have for BOPs