### PR TITLE
Remove documents from bops schema

### DIFF
--- a/__mocks__/dprApplicationFactory.ts
+++ b/__mocks__/dprApplicationFactory.ts
@@ -161,16 +161,6 @@ export const generateDprApplication = ({
       publishedDate: formatDateToYmd(faker.date.anytime()),
       determinedAt: determinedAt,
       decision: decision,
-      documents: [
-        {
-          url: "/camden/24-00135-HAPP/application-form",
-          title: "Application form",
-          metadata: {
-            contentType: "text/html",
-          },
-        },
-        ...generateNResults<DprDocument>(20, generateDocument),
-      ],
     },
     property: {
       address: {

--- a/src/handlers/bops/converters/planningApplication.ts
+++ b/src/handlers/bops/converters/planningApplication.ts
@@ -6,8 +6,6 @@ import {
 } from "../types";
 import { sortComments } from "@/lib/comments";
 import { convertCommentBops } from "./comments";
-import { applicationFormObject } from "@/lib/planningApplication";
-import { convertDocumentBopsNonStandard } from "./documents";
 import { getCommentsAllowed } from "@/lib/planningApplication";
 import { convertDateNoTimeToDprDate, convertDateTimeToUtc } from "@/util";
 
@@ -47,11 +45,6 @@ export const convertBopsApplicationToDpr = (
       ? sortComments(publishedComments?.map(convertCommentBops))
       : null;
 
-  const reference = application.reference;
-
-  // add fake application form document
-  const applicationFormDocument = applicationFormObject(council, reference);
-
   return {
     reference: application.reference,
     type: {
@@ -77,14 +70,6 @@ export const convertBopsApplicationToDpr = (
       ? convertDateTimeToUtc(application.determinedAt)
       : null,
     decision: application.decision ?? null,
-
-    // missing fields from public endpoint
-    documents: privateApplication?.documents
-      ? [
-          applicationFormDocument,
-          ...privateApplication.documents.map(convertDocumentBopsNonStandard),
-        ]
-      : null,
   };
 };
 

--- a/src/handlers/local/v1/search.ts
+++ b/src/handlers/local/v1/search.ts
@@ -55,7 +55,6 @@ const responseDsn: ApiResponse<DprSearchApiResponse> = {
           publishedDate: "2024-04-25",
           determinedAt: null,
           decision: null,
-          documents: null,
         },
         property: {
           address: { singleLine: "5, PANCRAS SQUARE, LONDON, N1C 4AG" },

--- a/src/types/definitions.d.ts
+++ b/src/types/definitions.d.ts
@@ -66,11 +66,6 @@ export interface DprPlanningApplication {
      */
     determinedAt?: string | null;
     decision?: string | null;
-
-    /**
-     * @todo this is missing from the public BOPS response BUT we have a new public endpoint for them
-     */
-    documents: DprDocument[] | null;
   };
   property: {
     address: {


### PR DESCRIPTION
Removed `applicationFormObject` from the converter as we're now using the /documents endpoint exclusively and don't need it in the converters 

- removed documents from `DprPlanningApplication`
- removed redundant call to add the form object to the documents from the converter as we now add that in the getDocuments api call