### PR TITLE
DSNPI-1035 Council selector wcag

### DIFF
--- a/__tests__/components/CouncilCards.test.tsx
+++ b/__tests__/components/CouncilCards.test.tsx
@@ -46,10 +46,10 @@ describe("CouncilCards", () => {
     render(<CouncilCards councils={appConfig.councils} />);
     // Use getByRole to find the links by their accessible name
     const link1 = screen.getByRole("link", {
-      name: /Public Council 1/i,
+      name: "Public Council 1",
     });
     const link2 = screen.getByRole("link", {
-      name: /Public Council 2/i,
+      name: "Public Council 2",
     });
 
     expect(link1).toHaveAttribute("href", "/public-council-1");

--- a/__tests__/util/addCouncilToName.test.tsx
+++ b/__tests__/util/addCouncilToName.test.tsx
@@ -1,0 +1,28 @@
+import { addCouncilToName } from "@/util";
+
+describe("addCouncilToName", () => {
+  it("should add 'Council' to the end of the name if it doesn't contain 'council'", () => {
+    expect(addCouncilToName("Camden")).toBe("Camden Council");
+    expect(addCouncilToName("Barnet")).toBe("Barnet Council");
+  });
+
+  it("should not add 'Council' if the name already contains 'council'", () => {
+    expect(addCouncilToName("Camden Council")).toBe("Camden Council");
+    expect(addCouncilToName("Barnet Borough Council")).toBe(
+      "Barnet Borough Council",
+    );
+  });
+
+  it("should be case insensitive when checking for 'council'", () => {
+    expect(addCouncilToName("Camden council")).toBe("Camden council");
+    expect(addCouncilToName("BARNET COUNCIL")).toBe("BARNET COUNCIL");
+  });
+
+  it("should handle empty strings", () => {
+    expect(addCouncilToName("")).toBe("");
+  });
+
+  it("should handle strings with only whitespace", () => {
+    expect(addCouncilToName(" ")).toBe(" ");
+  });
+});

--- a/src/components/CouncilCards/CouncilCards.scss
+++ b/src/components/CouncilCards/CouncilCards.scss
@@ -1,4 +1,5 @@
 @import "src/styles/component-base";
+@import "node_modules/govuk-frontend/dist/govuk/core/index";
 @import "node_modules/govuk-frontend/dist/govuk/components/button/index";
 
 .dpr-council-cards {
@@ -45,8 +46,10 @@ $dpr-council-card-shadow-colour: govuk-shade($dpr-council-card-colour, 40%);
 
   // our custom styles
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
+  gap: $govuk-gutter-half;
 
   > svg {
     width: 100%;
@@ -56,8 +59,15 @@ $dpr-council-card-shadow-colour: govuk-shade($dpr-council-card-colour, 40%);
   margin: 0;
   @include govuk-font($size: 24, $weight: bold);
 
-  height: 140px;
+  height: 160px;
   padding: govuk-spacing(3);
+
+  &__title {
+    @extend %govuk-body-m;
+    margin: 0;
+    padding: 0;
+  }
+
   @include govuk-media-query($from: tablet) {
   }
 }

--- a/src/components/CouncilCards/CouncilCards.tsx
+++ b/src/components/CouncilCards/CouncilCards.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import Image from "next/image";
 import { AppConfig } from "@/config/types";
 import "./CouncilCards.scss";
 import { councilLogos } from "../CouncilLogos";
@@ -28,19 +27,11 @@ export const CouncilCards = ({
                 key={council.slug}
                 className={`dpr-council-card ${logo ? "dpr-council-card--logo" : ""}`}
                 href={`/${council.slug}`}
-                title={`${council.name} Council`}
+                aria-label={council.name}
                 data-council-slug={council.slug}
               >
-                {logo ? (
-                  <>
-                    {councilLogos[council.slug]}
-                    <span className="govuk-visually-hidden">
-                      {council.name}
-                    </span>
-                  </>
-                ) : (
-                  <span>{council.name}</span>
-                )}
+                {logo && <>{councilLogos[council.slug]}</>}
+                <div className={`dpr-council-card__title`}>{council.name}</div>
               </Link>
             );
           })}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import { AppConfig } from "@/config/types";
 import { councilLogos } from "../CouncilLogos";
 import "./Header.scss";
+import { addCouncilToName, capitaliseWord } from "@/util";
 
 export const Header = ({ appConfig }: { appConfig: AppConfig }) => {
   const currentPath = usePathname();
@@ -52,10 +53,7 @@ export const Header = ({ appConfig }: { appConfig: AppConfig }) => {
               </>
             ) : (
               <span>
-                {councilConfig.name}
-                {!councilConfig.name?.toLowerCase().includes("council")
-                  ? " Council"
-                  : ""}
+                {capitaliseWord(addCouncilToName(councilConfig.name))}
               </span>
             )}
           </Link>

--- a/src/util/addCouncilToName.ts
+++ b/src/util/addCouncilToName.ts
@@ -1,0 +1,15 @@
+/**
+ * Adds the word "Council" to the end of a string if it is not already present.
+ * @param name
+ * @returns
+ */
+export const addCouncilToName = (name: string): string => {
+  if (name === "" || name === " ") {
+    return name;
+  }
+  const lowerCaseName = name.toLowerCase();
+  if (!lowerCaseName.includes("council")) {
+    return `${name} Council`;
+  }
+  return name;
+};

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -8,3 +8,4 @@ export * from "./slugify";
 export * from "./concatenateFieldsInOrder";
 export * from "./flattenObject";
 export * from "./findItemByKey";
+export * from "./addCouncilToName";


### PR DESCRIPTION
- updated tests so that the accessible role name must exactly match
- changed title to aria-label so that the accessible name is `Public Council 1` not `Public Council 1 Public Council 1`
- I had previously used `council.name + council` as the title but removed this after speaking to bobbu but I've left in the util I added because I know we have some other instances on the content pages where  that method will come in useful

![image](https://github.com/user-attachments/assets/27c76904-8556-476d-8d5c-ceb177732011)
