### PR TITLE
DSNPI 1043 / WCAG feedback pagination

### DIFF
--- a/__tests__/components/govuk/Pagination/PageItem.test.tsx
+++ b/__tests__/components/govuk/Pagination/PageItem.test.tsx
@@ -25,7 +25,7 @@ describe("PageItem", () => {
     render(<PageItem page={page} link={link} />);
     const linkElement = screen.getByRole("listitem");
     expect(linkElement).toBeInTheDocument();
-    expect(linkElement).toHaveTextContent("⋅⋅⋅");
+    expect(linkElement).toHaveTextContent(/\u22EF|\u2026|\.\.\./);
     expect(linkElement).toHaveClass("govuk-pagination__item--ellipses");
   });
 });

--- a/src/components/govuk/Pagination/PageItem.tsx
+++ b/src/components/govuk/Pagination/PageItem.tsx
@@ -14,7 +14,7 @@ export const PageItem = ({ page, link, searchParams }: PageItemProps) => {
       className={`govuk-pagination__item ${page.current ? "govuk-pagination__item--current" : ""} ${page.number === -1 ? "govuk-pagination__item--ellipses" : ""}`}
     >
       {page.number === -1 ? (
-        <>&sdot;&sdot;&sdot;</>
+        <>&#x022EF;</>
       ) : (
         <Link
           className="govuk-link govuk-pagination__link"


### PR DESCRIPTION
[Ticket 1043
](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?assignee=62a6f3cb6085950068acebf7&selectedIssue=DSNPI-1043)
Replaces the `&sdot;&sdot;&sdot; ` with `&#x022EF;` so that the ellipsis is read out by screenreaders
