### PR TITLE
DSNPI 1024 / Choose a different council option should only be available on /[council] pages

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -23,11 +23,13 @@ export const Footer = ({
           <div className="govuk-footer__meta-item govuk-footer__meta-item--grow">
             <h2 className="govuk-visually-hidden">Support links</h2>
             <ul className="govuk-footer__inline-list">
-              <li className="govuk-footer__inline-list-item">
-                <a className="govuk-footer__link" href={`/`}>
-                  Choose a different council
-                </a>
-              </li>
+              {councilConfig && (
+                <li className="govuk-footer__inline-list-item">
+                  <a className="govuk-footer__link" href={`/`}>
+                    Choose a different council
+                  </a>
+                </li>
+              )}
               {privacyPolicy && (
                 <li className="govuk-footer__inline-list-item">
                   <a className="govuk-footer__link" href={privacyPolicy}>


### PR DESCRIPTION
[Ticket 1024](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-1024)

This PR makes sure we only show the 'choose a different council' footer link when on a council page and not on other pages such as the homepage.