### PR TITLE
DSNPI-1023 Add mocks and helpers for the new schema type

### DIFF
--- a/__mocks__/dprNewApplicationFactory.ts
+++ b/__mocks__/dprNewApplicationFactory.ts
@@ -1,0 +1,593 @@
+import { DprApplication, DprDecisionSummary, DprStatusSummary } from "@/types";
+import { faker, fakerEN_GB } from "@faker-js/faker";
+import dayjs, { Dayjs } from "dayjs";
+import { generateReference } from "./dprApplicationFactory";
+import { OSAddress, ProposedAddress } from "@/types/odp-types/shared/Addresses";
+import {
+  AdvertConsentApplicationType,
+  AmendmentApplicationType,
+  ApplicationType,
+  ApprovalApplicationType,
+  ComplianceConfirmationApplicationType,
+  EnvironmentalImpactApplicationType,
+  HazardousSubstanceConsentApplicationType,
+  HedgerowRemovalNoticeApplicationType,
+  LandDrainageConsentApplicationType,
+  LDCApplicationType,
+  ListedApplicationType,
+  NotifyCompletionApplicationType,
+  ObligationApplicationType,
+  OnshoreExtractionOilAndGasApplicationType,
+  PAApplicationType,
+  PPApplicationType,
+  PrimaryApplicationType,
+  RightsOfWayOrderApplicationType,
+  WTTApplicationType,
+} from "@/types/odp-types/schemas/prototypeApplication/enums/ApplicationType";
+import { ApplicationStatus } from "@/types/odp-types/schemas/postSubmissionApplication/enums/ApplicationStatus";
+import { ProcessStage } from "@/types/odp-types/schemas/postSubmissionApplication/enums/ProcessStage";
+import {
+  getApplicationDprDecisionSummary,
+  getApplicationDprStatusSummary,
+  getPrimaryApplicationTypeKey,
+  validApplicationTypes,
+} from "@/lib/planningApplication";
+import { planningPermissionFullHouseholderPrototype } from "./odp-submission-data/planningPermission/fullHouseholder";
+import { priorApprovalLargerExtensionPrototype } from "./odp-submission-data/priorApproval/largerExtension";
+import { lawfulDevelopmentCertificateProposedPrototype } from "./odp-submission-data/lawfulDevelopmentCertificate/proposed";
+import { PrototypeApplication } from "@/types/odp-types/schemas/prototypeApplication";
+import { PriorApprovalAssessment } from "@/types/odp-types/schemas/postSubmissionApplication/data/Assessment";
+import { PostSubmissionMetadata } from "@/types/odp-types/schemas/postSubmissionApplication/Metadata";
+import { PostSubmissionApplication } from "@/types/odp-types/schemas/postSubmissionApplication";
+
+type PossibleDates = {
+  application: {
+    withdrawnAt: Dayjs;
+  };
+  submission: {
+    submittedAt: Dayjs;
+  };
+  validation: {
+    receivedAt: Dayjs;
+    validatedAt: Dayjs;
+  };
+  publishedAt: Dayjs;
+  consultation: {
+    startAt: Dayjs;
+    endAt: Dayjs;
+  };
+  assessment: {
+    councilDecisionAt: Dayjs;
+    committeeSentAt: Dayjs;
+    committeeDecisionAt: Dayjs;
+  };
+  appeal: {
+    lodgedAt: Dayjs;
+    validatedAt: Dayjs;
+    startedAt: Dayjs;
+    decidedAt: Dayjs;
+    withdrawnAt: Dayjs;
+  };
+};
+
+export const generateAllPossibleDates = (): PossibleDates => {
+  // an application is submitted and some point in the last 10 years
+  const submittedAt = dayjs(faker.date.past({ years: 10 }));
+
+  // application received by back office system a few ms later because maybe theres latency
+  const receivedAt = dayjs(submittedAt).add(200, "millisecond");
+
+  // application validated in back office system the next day
+  const validatedAt = dayjs(receivedAt).add(1, "day");
+
+  // when its validated the reviewer sets it to be published (not always at this stage but it will be for these examples)
+  const publishedAt = dayjs(validatedAt).add(200, "millisecond");
+
+  // consultation (depending on application type) starts once it's valid and lasts 21 days (theres more nuance around business days etc but this is accurate enough)
+  // startDate - as soon as validated
+  const consultationStartAt = validatedAt;
+  const consultationEndAt = consultationStartAt.add(21, "day");
+
+  // the council decision is made sometime after the consultation ends
+  const councilDecisionAt = consultationEndAt.add(10, "day");
+
+  // if it's sent to committee it's sent after the council decision
+  const committeeSentAt = councilDecisionAt.add(1, "day");
+
+  // after it's sent to the committee the decision is made after that date
+  const committeeDecisionAt = committeeSentAt.add(10, "day");
+
+  // an appeal can be lodged within 6 months of determination being made
+  // lodgedDate
+  const appealLodgedAt = committeeDecisionAt.add(1, "month");
+
+  // appeal is validated
+  const appealValidatedAt = dayjs(appealLodgedAt).add(1, "day");
+
+  // appeal starts soon after
+  const appealStartedAt = dayjs(appealValidatedAt).add(200, "millisecond");
+
+  // appeal decided
+  const appealDecidedAt = dayjs(appealStartedAt).add(5, "day");
+
+  // application can be withdrawn any time between consultationStartAt and councilDecisionAt
+  const withdrawnAt = dayjs(consultationStartAt).add(1, "day");
+
+  // appeal is withdrawn any time between appealLodgedAt and appealDecidedAt
+  const appealWithdrawnAt = dayjs(appealLodgedAt).add(1, "day");
+
+  const dates = {
+    application: {
+      withdrawnAt: withdrawnAt,
+    },
+    submission: {
+      submittedAt: submittedAt,
+    },
+    validation: {
+      receivedAt: receivedAt,
+      validatedAt: validatedAt,
+    },
+    publishedAt: publishedAt,
+    consultation: {
+      startAt: consultationStartAt,
+      endAt: consultationEndAt,
+    },
+    assessment: {
+      councilDecisionAt: councilDecisionAt,
+      committeeSentAt: committeeSentAt,
+      committeeDecisionAt: committeeDecisionAt,
+    },
+    appeal: {
+      lodgedAt: appealLodgedAt,
+      validatedAt: appealValidatedAt,
+      startedAt: appealStartedAt,
+      decidedAt: appealDecidedAt,
+      withdrawnAt: appealWithdrawnAt,
+    },
+  };
+  return dates;
+};
+
+const proposedAddress: ProposedAddress = {
+  latitude: faker.location.latitude(),
+  longitude: faker.location.longitude(),
+  x: 502869.8591151078,
+  y: 180333.4537434135,
+  title: "House McHouseface Housing",
+  source: "Proposed by applicant",
+};
+
+const siteAddress: OSAddress = {
+  latitude: faker.location.latitude(),
+  longitude: faker.location.longitude(),
+  x: 493822,
+  y: 191603,
+  title: fakerEN_GB.location.streetAddress(true),
+  source: "Ordnance Survey",
+  uprn: "100080482163",
+  usrn: "35200844",
+  pao: "7",
+  street: fakerEN_GB.location.street(),
+  town: fakerEN_GB.location.city(),
+  postcode: fakerEN_GB.location.zipCode(),
+  singleLine: fakerEN_GB.location.streetAddress(true),
+};
+
+export const generateMetadata = (
+  dates?: PossibleDates,
+): PostSubmissionMetadata => {
+  if (!dates) {
+    dates = generateAllPossibleDates();
+  }
+  const metadata: PostSubmissionMetadata = {
+    organisation: "BOPS",
+    id: "1234",
+    publishedAt: dates.publishedAt.toISOString(),
+    submittedAt: dates.submission.submittedAt.toISOString(),
+    schema: `https://theopensystemslab.github.io/digital-planning-data-schemas/@next/schemas/postSubmissionApplication.json`,
+  };
+  return metadata;
+};
+
+const getApplicationStagesByType = (
+  applicationType: ApplicationType,
+): ProcessStage[] => {
+  const validStages = new Set<ProcessStage>([
+    "submission",
+    "validation",
+    "consultation",
+    "assessment",
+    "appeal",
+    // "highCourtAppeal",
+  ]);
+
+  if (applicationType === "ldc") {
+    validStages.delete("consultation");
+  }
+
+  return Array.from(validStages);
+};
+
+const getApplicationStatesByStage = (
+  applicationStage: ProcessStage,
+): ApplicationStatus[] => {
+  switch (applicationStage) {
+    case "submission":
+      return ["undetermined"];
+    case "validation":
+      return ["returned", "undetermined"];
+    case "consultation":
+      return ["withdrawn", "undetermined"];
+    case "assessment":
+      return ["withdrawn", "undetermined", "determined"];
+    case "appeal":
+      return ["determined"];
+    case "highCourtAppeal":
+      return ["determined"];
+  }
+};
+
+const applicationTypesWithNoConsultation = ["ldc"];
+
+const applicationTypesWithCommentsAcceptedUntilDecision = ["ldc"];
+
+export const generateDprApplication = ({
+  applicationType,
+  applicationStage,
+  applicationStatus,
+  customStatus,
+}: {
+  applicationType?: ApplicationType;
+  applicationStage?: ProcessStage;
+  applicationStatus?: ApplicationStatus;
+  customStatus?:
+    | "consultationInProgress"
+    | "assessmentInProgress"
+    | "assessmentCouncilDetermined"
+    | "assessmentInCommittee"
+    | "assessmentCommitteeDetermined"
+    | "appealLodged"
+    | "appealValidated"
+    | "appealStarted"
+    | "appealDetermined"
+    | "appealWithdrawn";
+} = {}): DprApplication => {
+  switch (customStatus) {
+    case "consultationInProgress":
+      applicationStage = "consultation";
+      applicationStatus = "undetermined";
+      break;
+    case "assessmentInProgress":
+    case "assessmentInCommittee":
+      applicationStage = "assessment";
+      applicationStatus = "undetermined";
+      break;
+    case "assessmentCouncilDetermined":
+    case "assessmentCommitteeDetermined":
+      applicationStage = "assessment";
+      applicationStatus = "determined";
+      break;
+    case "appealLodged":
+    case "appealValidated":
+    case "appealStarted":
+    case "appealDetermined":
+    case "appealWithdrawn":
+      applicationStage = "appeal";
+      applicationStatus = "determined";
+      break;
+  }
+
+  const dates = generateAllPossibleDates();
+
+  if (!applicationType) {
+    const applicationTypes = Object.values(validApplicationTypes).flat();
+    applicationType = faker.helpers.arrayElement(applicationTypes);
+  }
+  const primaryApplicationType = getPrimaryApplicationTypeKey(
+    applicationType,
+  ) as PrimaryApplicationType;
+  if (!primaryApplicationType) {
+    throw new Error(
+      `Unable to find primary application type fo ${applicationType}`,
+    );
+  }
+
+  const applicationStages = getApplicationStagesByType(applicationType);
+
+  if (!applicationStage) {
+    applicationStage = faker.helpers.arrayElement(applicationStages);
+  } else {
+    if (!applicationStages.includes(applicationStage)) {
+      throw new Error(
+        `Invalid application stage for application type ${applicationType}`,
+      );
+    }
+  }
+
+  const applicationStates = getApplicationStatesByStage(applicationStage);
+
+  if (!applicationStatus) {
+    applicationStatus = faker.helpers.arrayElement(applicationStates);
+  } else {
+    if (!applicationStates.includes(applicationStatus)) {
+      throw new Error(
+        `Invalid application status for application type ${applicationType} in stage ${applicationStage}`,
+      );
+    }
+  }
+
+  // determine the submission part - copied from ODP examples
+  let submission: PrototypeApplication =
+    planningPermissionFullHouseholderPrototype;
+  switch (primaryApplicationType) {
+    case "pp":
+      submission = planningPermissionFullHouseholderPrototype;
+      break;
+    case "pa":
+      submission = priorApprovalLargerExtensionPrototype;
+      break;
+    case "ldc":
+      submission = lawfulDevelopmentCertificateProposedPrototype;
+      break;
+  }
+
+  const metadata = generateMetadata(dates);
+
+  submission.metadata = {
+    ...submission.metadata,
+    submittedAt: dates.submission.submittedAt.toISOString(),
+  };
+
+  // there is no such thing as a 'valid' stage in this schema
+  if (applicationStage === "validation" && applicationStatus !== "returned") {
+    throw new Error(
+      `Invalid application stage (${applicationStage}) and status (${applicationStatus}) - validated applications go straight to consultation or assessment`,
+    );
+  }
+
+  // certain application types don't have consultation stage
+  if (
+    applicationStage === "consultation" &&
+    applicationTypesWithNoConsultation.includes(primaryApplicationType)
+  ) {
+    throw new Error(
+      `Invalid application stage (${applicationStage}) for application type ${primaryApplicationType} - this application type does not have a consultation stage`,
+    );
+  }
+
+  // applicationType musst be XApplicationType not ApplicationType for the data object to behave
+  switch (primaryApplicationType) {
+    case "advertConsent":
+      applicationType = applicationType as AdvertConsentApplicationType;
+    case "amendment":
+      applicationType = applicationType as AmendmentApplicationType;
+    case "approval":
+      applicationType = applicationType as ApprovalApplicationType;
+    case "complianceConfirmation":
+      applicationType =
+        applicationType as ComplianceConfirmationApplicationType;
+    case "environmentalImpact":
+      applicationType = applicationType as EnvironmentalImpactApplicationType;
+    case "hazardousSubstanceConsent":
+      applicationType =
+        applicationType as HazardousSubstanceConsentApplicationType;
+    case "hedgerowRemovalNotice":
+      applicationType = applicationType as HedgerowRemovalNoticeApplicationType;
+    case "landDrainageConsent":
+      applicationType = applicationType as LandDrainageConsentApplicationType;
+    case "ldc":
+      applicationType = applicationType as LDCApplicationType;
+    case "listed":
+      applicationType = applicationType as ListedApplicationType;
+    case "notifyCompletion":
+      applicationType = applicationType as NotifyCompletionApplicationType;
+    case "obligation":
+      applicationType = applicationType as ObligationApplicationType;
+    case "onshoreExtractionOilAndGas":
+      applicationType =
+        applicationType as OnshoreExtractionOilAndGasApplicationType;
+    case "pa":
+      applicationType = applicationType as PAApplicationType;
+    case "pp":
+      applicationType = applicationType as PPApplicationType;
+    case "rightsOfWayOrder":
+      applicationType = applicationType as RightsOfWayOrderApplicationType;
+    case "wtt":
+      applicationType = applicationType as WTTApplicationType;
+  }
+
+  // create the basics of all stages and manage further below
+  const data: PostSubmissionApplication = {
+    applicationType: applicationType,
+    data: {
+      application: {
+        reference: generateReference(),
+        stage: applicationStage,
+        status: applicationStatus,
+        // see below for withdrawnAt and withdrawnReason being added
+      },
+      localPlanningAuthority: {
+        commentsAcceptedUntilDecision: false,
+      },
+      submission: {
+        submittedAt: dates.submission.submittedAt.toISOString(),
+      },
+      validation: {
+        receivedAt: dates.validation.receivedAt.toISOString(),
+        validatedAt: dates.validation.validatedAt.toISOString(),
+        isValid: true,
+      },
+      consultation: {
+        startDate: dates.consultation.startAt.format("YYYY-MM-DD"),
+        endDate: dates.consultation.endAt.format("YYYY-MM-DD"),
+        siteNotice: true,
+      },
+      assessment: {
+        councilDecision: faker.helpers.arrayElement(["granted", "refused"]),
+        councilDecisionDate:
+          dates.assessment.councilDecisionAt.format("YYYY-MM-DD"),
+        decisionNotice: {
+          url: "https://planningregister.org",
+        },
+      },
+      appeal: {
+        lodgedDate: dates.appeal.lodgedAt.format("YYYY-MM-DD"),
+        reason:
+          "We don't believe the council took into consideration the environmental impact alleviation approach during their assessment.",
+        validatedDate: dates.appeal.validatedAt.format("YYYY-MM-DD"),
+        startedDate: dates.appeal.startedAt.format("YYYY-MM-DD"),
+        decisionDate: dates.appeal.decidedAt.format("YYYY-MM-DD"),
+        decision: faker.helpers.arrayElement([
+          "allowed",
+          "dismissed",
+          "split_decision",
+          "withdrawn",
+        ]),
+      },
+      caseOfficer: {
+        name: "Casey Officer",
+      },
+    },
+    submission,
+    metadata: metadata,
+  };
+
+  // This mocks camden allowing comments until a decision is made for certain application types
+  if (
+    applicationTypesWithCommentsAcceptedUntilDecision.includes(
+      primaryApplicationType,
+    )
+  ) {
+    data.data.localPlanningAuthority.commentsAcceptedUntilDecision = true;
+  }
+
+  // manage priorApprovalRequired field for prior approvals
+  if (primaryApplicationType === "pa") {
+    // 'Prior approval required and approved', 'Prior approval not required', 'Prior approval required and refused'
+    data.data.assessment = {
+      ...data.data.assessment,
+      priorApprovalRequired: faker.datatype.boolean(),
+    } as PriorApprovalAssessment;
+  }
+
+  // manage the data added at each stage and the states within them
+  if (applicationStage === "submission") {
+    const { validation, consultation, assessment, appeal, ...rest } = data.data;
+    data.data = rest;
+  }
+  if (applicationStage === "validation") {
+    const { consultation, assessment, appeal, ...rest } = data.data;
+    data.data = rest;
+
+    if (applicationStatus === "returned" && data.data.validation) {
+      data.data.validation.isValid = false;
+    }
+  }
+  if (applicationStage === "consultation") {
+    const { assessment, appeal, ...rest } = data.data;
+    data.data = rest;
+  }
+  if (applicationStage === "assessment") {
+    const { appeal, ...rest } = data.data;
+    data.data = rest;
+
+    if (applicationStatus === "undetermined") {
+      const { assessment, ...rest } = data.data;
+      data.data = rest;
+    }
+  }
+
+  // make sure theres no consultation section for those that don't have it
+  if (applicationTypesWithNoConsultation.includes(primaryApplicationType)) {
+    const { consultation, ...rest } = data.data;
+    data.data = rest;
+  }
+
+  // manage the withdrawn state
+
+  if (applicationStatus === "withdrawn") {
+    data.data.application = {
+      ...data.data.application,
+      withdrawnAt: dates.application.withdrawnAt.toISOString(),
+      withdrawnReason: "Applicant has decided to withdraw the application.",
+    };
+  }
+
+  // manage specific names we give our examples
+
+  // only get in committee if we request it using customStatus
+  if (customStatus === "assessmentInCommittee") {
+    data.data.assessment = {
+      councilRecommendation: faker.helpers.arrayElement(["granted", "refused"]),
+      committeeSentDate: dates.assessment.committeeSentAt.format("YYYY-MM-DD"),
+    };
+  }
+
+  // only get in committee determined if we request it using customStatus
+  if (customStatus === "assessmentCommitteeDetermined") {
+    data.data.assessment = {
+      councilRecommendation: faker.helpers.arrayElement(["granted", "refused"]),
+      committeeSentDate: dates.assessment.committeeSentAt.format("YYYY-MM-DD"),
+      committeeDecision: faker.helpers.arrayElement(["granted", "refused"]),
+      committeeDecisionDate:
+        dates.assessment.committeeDecisionAt.format("YYYY-MM-DD"),
+      decisionNotice: {
+        url: "https://planningregister.org",
+      },
+    };
+  }
+
+  // only get appealLodged if we request it using dprStatus
+  if (customStatus === "appealLodged") {
+    data.data.appeal = {
+      lodgedDate: dates.appeal.lodgedAt.format("YYYY-MM-DD"),
+      reason:
+        "We don't believe the council took into consideration the environmental impact alleviation approach during their assessment.",
+    };
+  }
+
+  // only get appealValidated if we request it using customStatus
+
+  if (customStatus === "appealValidated") {
+    data.data.appeal = {
+      lodgedDate: dates.appeal.lodgedAt.format("YYYY-MM-DD"),
+      reason:
+        "We don't believe the council took into consideration the environmental impact alleviation approach during their assessment.",
+      validatedDate: dates.appeal.validatedAt.format("YYYY-MM-DD"),
+    };
+  }
+
+  // only get appealStarted if we request it using customStatus
+
+  if (customStatus === "appealStarted") {
+    data.data.appeal = {
+      lodgedDate: dates.appeal.lodgedAt.format("YYYY-MM-DD"),
+      reason:
+        "We don't believe the council took into consideration the environmental impact alleviation approach during their assessment.",
+      validatedDate: dates.appeal.validatedAt.format("YYYY-MM-DD"),
+      startedDate: dates.appeal.startedAt.format("YYYY-MM-DD"),
+    };
+  }
+
+  // only get appealWithdrawn if we request it using customStatus
+
+  if (customStatus === "appealWithdrawn") {
+    data.data.appeal = {
+      lodgedDate: dates.appeal.lodgedAt.format("YYYY-MM-DD"),
+      reason:
+        "We don't believe the council took into consideration the environmental impact alleviation approach during their assessment.",
+      withdrawnAt: dates.appeal.withdrawnAt.toISOString(),
+      withdrawnReason: "Applicant has decided to withdraw the application.",
+    };
+  }
+
+  const applicationDecisionSummary = getApplicationDprDecisionSummary(data);
+  const applicationStatusSummary = getApplicationDprStatusSummary(data);
+  const application: DprApplication = {
+    applicationStatusSummary,
+    applicationDecisionSummary,
+    ...data,
+  };
+
+  return application;
+};

--- a/__mocks__/odp-submission-data/lawfulDevelopmentCertificate/proposed.ts
+++ b/__mocks__/odp-submission-data/lawfulDevelopmentCertificate/proposed.ts
@@ -1,0 +1,837 @@
+import { PrototypeApplication } from "@/types/odp-types/schemas/prototypeApplication";
+
+const version = process.env["VERSION"] || "@next";
+
+export const lawfulDevelopmentCertificateProposedPrototype: PrototypeApplication =
+  {
+    applicationType: "ldc.proposed",
+    data: {
+      application: {
+        fee: {
+          calculated: 129,
+          payable: 0,
+          category: {
+            sixAndSeven: 129,
+          },
+          exemption: {
+            disability: true,
+            resubmission: true,
+          },
+          reduction: {
+            sports: false,
+            parishCouncil: false,
+            alternative: false,
+          },
+        },
+        declaration: {
+          accurate: true,
+          connection: {
+            value: "none",
+          },
+        },
+      },
+      user: {
+        role: "applicant",
+      },
+      applicant: {
+        type: "individual",
+        name: {
+          first: "Enid",
+          last: "Blyton",
+        },
+        email: "famousfive@example.com",
+        phone: {
+          primary: "05555 555 555",
+        },
+        address: {
+          sameAsSiteAddress: true,
+        },
+        siteContact: {
+          role: "applicant",
+        },
+        ownership: {
+          interest: "owner",
+        },
+      },
+      property: {
+        address: {
+          latitude: 51.6154458,
+          longitude: -0.6463271,
+          x: 493822,
+          y: 191603,
+          title: "7, BLYTON CLOSE, BEACONSFIELD",
+          singleLine: "7, BLYTON CLOSE, BEACONSFIELD, HP9 2LX",
+          source: "Ordnance Survey",
+          uprn: "100080482163",
+          usrn: "35200844",
+          pao: "7",
+          street: "BLYTON CLOSE",
+          town: "BEACONSFIELD",
+          postcode: "HP9 2LX",
+        },
+        boundary: {
+          site: {
+            type: "Feature",
+            geometry: {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [-0.646633654832832, 51.61556919642334],
+                  [-0.6466296315193095, 51.61554504700152],
+                  [-0.6465049088001171, 51.61551173743314],
+                  [-0.6464512646198194, 51.61522027766699],
+                  [-0.6463131308555524, 51.61522943785954],
+                  [-0.6463037431240002, 51.61520695374722],
+                  [-0.6462487578391951, 51.615222775901515],
+                  [-0.6462393701076429, 51.61520861923739],
+                  [-0.6459456682205124, 51.615292726412235],
+                  [-0.6460489332675857, 51.61561499701554],
+                  [-0.646633654832832, 51.61556919642334],
+                ],
+              ],
+            },
+            properties: null,
+          },
+          area: {
+            hectares: 0.141826,
+            squareMetres: 1418.26,
+          },
+        },
+        planning: {
+          sources: [
+            "https://api.editor.planx.dev/gis/buckinghamshire?geom=POLYGON+%28%28-0.646633654832832+51.61556919642334%2C+-0.6466296315193095+51.61554504700152%2C+-0.6465049088001171+51.61551173743314%2C+-0.6464512646198194+51.61522027766699%2C+-0.6463131308555524+51.61522943785954%2C+-0.6463037431240002+51.61520695374722%2C+-0.6462487578391951+51.615222775901515%2C+-0.6462393701076429+51.61520861923739%2C+-0.6459456682205124+51.615292726412235%2C+-0.6460489332675857+51.61561499701554%2C+-0.646633654832832+51.61556919642334%29%29&analytics=false&sessionId=8da51c5b-a2a0-4386-a15d-29d66f9c121c",
+            "https://api.editor.planx.dev/roads?usrn=35200844",
+          ],
+          designations: [
+            {
+              value: "articleFour",
+              intersects: false,
+            },
+            {
+              value: "articleFour.caz",
+              intersects: false,
+            },
+            {
+              value: "tpo",
+              intersects: false,
+            },
+            {
+              value: "listed",
+              intersects: false,
+            },
+            {
+              value: "monument",
+              intersects: false,
+            },
+            {
+              value: "designated",
+              intersects: false,
+            },
+            {
+              value: "nature.SAC",
+              intersects: false,
+            },
+            {
+              value: "nature.ASNW",
+              intersects: false,
+            },
+            {
+              value: "nature.SSSI",
+              intersects: false,
+            },
+            {
+              value: "locallyListed",
+              intersects: false,
+            },
+            {
+              value: "nature.SPA",
+              intersects: false,
+            },
+            {
+              value: "designated.WHS",
+              intersects: false,
+            },
+            {
+              value: "registeredPark",
+              intersects: false,
+            },
+            {
+              value: "designated.AONB",
+              intersects: false,
+            },
+            {
+              value: "designated.nationalPark",
+              intersects: false,
+            },
+            {
+              value: "designated.conservationArea",
+              intersects: false,
+            },
+            {
+              value: "designated.nationalPark.broads",
+              intersects: false,
+            },
+            {
+              value: "road.classified",
+              intersects: false,
+            },
+          ],
+        },
+        localAuthorityDistrict: ["Buckinghamshire", "South Bucks"],
+        region: "South East",
+        type: "residential.dwelling.house.detached",
+      },
+      proposal: {
+        projectType: ["extend.rear"],
+        description: "Rear extension of a home",
+        boundary: {
+          site: {
+            type: "Feature",
+            geometry: {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [-0.646633654832832, 51.61556919642334],
+                  [-0.6466296315193095, 51.61554504700152],
+                  [-0.6465049088001171, 51.61551173743314],
+                  [-0.6464512646198194, 51.61522027766699],
+                  [-0.6463131308555524, 51.61522943785954],
+                  [-0.6463037431240002, 51.61520695374722],
+                  [-0.6462487578391951, 51.615222775901515],
+                  [-0.6462393701076429, 51.61520861923739],
+                  [-0.6459456682205124, 51.615292726412235],
+                  [-0.6460489332675857, 51.61561499701554],
+                  [-0.646633654832832, 51.61556919642334],
+                ],
+              ],
+            },
+            properties: null,
+          },
+          area: {
+            hectares: 0.141826,
+            squareMetres: 1418.26,
+          },
+        },
+        extend: {
+          area: {
+            squareMetres: 24,
+          },
+        },
+      },
+    },
+    preAssessment: [
+      {
+        value: "Planning permission / Permitted development",
+        description:
+          "It looks like the proposed changes may fall within the rules for Permitted Development and therefore would not need planning permission.",
+      },
+    ],
+    responses: [
+      {
+        question: "List the changes involved in the project",
+        responses: [
+          { value: "Add a rear or side extension (or conservatory)" },
+        ],
+        metadata: {
+          policyRefs: [
+            {
+              text: "Town and Country Planning Act 1990 (Section 55)",
+              url: "https://www.legislation.gov.uk/ukpga/1990/8/section/55",
+            },
+            {
+              text: "The Town and Country Planning (General Permitted Development) (England) Order 2015",
+              url: "https://www.legislation.gov.uk/uksi/2015/596/contents",
+            },
+          ],
+        },
+      },
+      {
+        question: "What type of property is it?",
+        responses: [{ value: "House" }],
+        metadata: {
+          autoAnswered: true,
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (General Permitted Development) (England) Order 2015",
+              url: "https://www.legislation.gov.uk/uksi/2015/596/contents/made",
+            },
+          ],
+        },
+      },
+      {
+        question: "What type of house is it?",
+        responses: [{ value: "Detached" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "How many storeys does the original house have?",
+        responses: [{ value: "2 or more" }],
+        metadata: {},
+      },
+      {
+        question: "Does the original house have a projection to the rear?",
+        responses: [{ value: "No" }],
+        metadata: {},
+      },
+      {
+        question: "Was the house always a house?",
+        responses: [{ value: "Yes, it was built as a house" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 1, Class A",
+              url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+            },
+          ],
+        },
+      },
+      {
+        question: "Was the house built before 2020?",
+        responses: [
+          {
+            value: "Yes, it was built before 2020",
+            metadata: {
+              flags: ["Planning permission / Permitted development"],
+            },
+          },
+        ],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class 1 A.",
+              url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+            },
+          ],
+        },
+      },
+      {
+        question: "How many storeys does the extension have?",
+        responses: [{ value: "1 storey" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Section 2, Part 1, Class A",
+              url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+            },
+          ],
+        },
+      },
+      {
+        question: "Does the original house have a projection to the rear?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "Which of these best describes your project?",
+        responses: [{ value: "Rear only" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "General Permitted Development Order 2015, Technical guidance",
+              url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/830643/190910_Tech_Guide_for_publishing.pdf",
+            },
+          ],
+        },
+      },
+      {
+        question: "Is the property on designated land?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "Is the property a site of special scientific interest?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "What type of house is it?",
+        responses: [{ value: "Detached" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question:
+          "How far does the new addition extend beyond the back wall of the original house?",
+        responses: [
+          {
+            value: "Less than 4m",
+            metadata: {
+              flags: ["Planning permission / Permitted development"],
+            },
+          },
+        ],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A.1 (f)(i)",
+              url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+            },
+          ],
+        },
+      },
+      {
+        question: "What is the shortest distance to the property boundary?",
+        responses: [{ value: "2m or more" }],
+        metadata: {},
+      },
+      {
+        question:
+          "Are the materials of the extension similar to the original house?",
+        responses: [
+          {
+            value: "Yes",
+            metadata: {
+              flags: ["Planning permission / Permitted development"],
+            },
+          },
+        ],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A",
+              url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+            },
+          ],
+        },
+      },
+      {
+        question: "Is the property on designated land?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question:
+          "How much of the property is covered by extensions and outbuildings?",
+        responses: [
+          {
+            value:
+              "50% or less of the available area around the original house",
+            metadata: {
+              flags: ["Planning permission / Permitted development"],
+            },
+          },
+        ],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A",
+              url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+            },
+          ],
+        },
+      },
+      {
+        question: "What types of changes does the project involve?",
+        responses: [{ value: "Extension" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question:
+          "Have you already told us that you are doing works to a tree or hedge?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "Are there any protected trees on the property?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "Is the site in a conservation area?",
+        responses: [
+          {
+            value: "No",
+            metadata: { flags: ["Works to trees & hedges / Not required"] },
+          },
+        ],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "What are you applying about?",
+        responses: [{ value: "Proposed changes I want to make in the future" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "What do the works involve?",
+        responses: [{ value: "Works to extend a property" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "What does the project involve?",
+        responses: [
+          { value: "Add a rear or side extension (or conservatory)" },
+        ],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question:
+          "How much is the internal floor area of the property increasing by?",
+        responses: [{ value: "24" }],
+        metadata: {},
+      },
+      {
+        question: "Is it a residential property?",
+        responses: [{ value: "Yes" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "Do the changes involve the creation of any new homes?",
+        responses: [{ value: "No" }],
+        metadata: {},
+      },
+      {
+        question:
+          "Do the changes involve creating any new bedrooms or bathrooms?",
+        responses: [{ value: "No" }],
+        metadata: {},
+      },
+      {
+        question: "Do the changes involve the creation of any new homes?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "Is the property in the Greater London Authority area?",
+        responses: [{ value: "No" }],
+        metadata: {
+          autoAnswered: true,
+          policyRefs: [
+            {
+              text: "Greater London Authority Act 1999",
+              url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+            },
+          ],
+        },
+      },
+      {
+        question: "Which of these best describes you?",
+        responses: [{ value: "Applicant" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "Which of these best describes your interest in the land?",
+        responses: [{ value: "Sole owner" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Development Management Procedure) (England) Order 2015",
+              url: "https://www.legislation.gov.uk/uksi/2015/595/article/39/made",
+            },
+          ],
+        },
+      },
+      {
+        question: "What types of changes does the project involve?",
+        responses: [{ value: "Extension" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question:
+          "Does the work involve any alterations to ground or floor levels?",
+        responses: [{ value: "No" }],
+        metadata: {},
+      },
+      {
+        question: "Would you like to upload any photographs?",
+        responses: [{ value: "No" }],
+        metadata: {},
+      },
+      {
+        question: "What types of extension are being added?",
+        responses: [{ value: "Rear or side" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "Do you also want to add existing internal floor plans?",
+        responses: [{ value: "No" }],
+        metadata: {},
+      },
+      {
+        question:
+          "Is the roof of the extension already shown on another set of drawings?",
+        responses: [{ value: "No" }],
+        metadata: {},
+      },
+      {
+        question:
+          "Would you like to upload any additional drawings, documents or images?",
+        responses: [{ value: "No" }],
+        metadata: {},
+      },
+      {
+        question: "What type of planning application are you making?",
+        responses: [{ value: "Lawful Development Certificate" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "What type of changes are you applying for?",
+        responses: [{ value: "Proposed changes" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "Is the property a home?",
+        responses: [{ value: "Yes" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "What types of changes does the application relate to?",
+        responses: [{ value: "Extension" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "How many homes does this application relate to?",
+        responses: [{ value: "1" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Schedule 1, Part 2",
+              url: "https://www.legislation.gov.uk/uksi/2012/2920/contents",
+            },
+          ],
+        },
+      },
+      {
+        question: "What type of extension is it?",
+        responses: [{ value: "Rear or side extension" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "Is the property a home?",
+        responses: [{ value: "Yes" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "What works does the project involve?",
+        responses: [{ value: "Extension" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question:
+          "Is the sole purpose of the project to support the needs of a disabled resident?",
+        responses: [{ value: "No" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 14",
+              url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/14",
+            },
+            {
+              text: "UK Statutory Instruments 2012 No. 2920 Regulation 4",
+              url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/4/made",
+            },
+            {
+              text: "Equalities Act 2010, Section 6",
+              url: "https://www.legislation.gov.uk/ukpga/2010/15/section/6",
+            },
+            {
+              text: "Children Act 1989, Part 3",
+              url: "https://www.legislation.gov.uk/ukpga/1989/41/part/III",
+            },
+          ],
+        },
+      },
+      {
+        question: "Is this application a resubmission?",
+        responses: [{ value: "Yes" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 9",
+              url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/9",
+            },
+          ],
+        },
+      },
+      {
+        question:
+          "Is this the first time you have resubmitted an application for this site?",
+        responses: [{ value: "Yes" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 8",
+              url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/8",
+            },
+          ],
+        },
+      },
+      {
+        question: "What type of application is this?",
+        responses: [{ value: "Lawful Development Certificate" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "What was the original application's reference number?",
+        responses: [{ value: "M8AG1C F4R4WAY TR33" }],
+        metadata: {},
+      },
+      {
+        question:
+          "To qualify for a fee exemption, the proposed works must be of a similar description to the original application",
+        responses: [{ value: "I understand" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 14",
+              url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/14",
+            },
+          ],
+        },
+      },
+      {
+        question: "What was the result of the original application?",
+        responses: [{ value: "Withdrawn" }],
+        metadata: {},
+      },
+      {
+        question: "When did you submit the original application?",
+        responses: [{ value: "Within the last 12 months" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "UK Statutory Instruments 2012 No. 2920 Regulation 8",
+              url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/8/made",
+            },
+          ],
+        },
+      },
+      {
+        question: "Does the application qualify for a disability exemption?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "Does the application qualify for a resubmission exemption?",
+        responses: [{ value: "Yes" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question:
+          "Did you get any pre-application advice before making this application?",
+        responses: [{ value: "No" }],
+        metadata: {},
+      },
+      {
+        question:
+          "What local planning authority is this application being sent to?",
+        responses: [{ value: "South Buckinghamshire" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "What type of application is it?",
+        responses: [{ value: "Lawful Development Certificate" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "What type of works are you applying about?",
+        responses: [{ value: "Proposed" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "What is the applicant's interest in the land?",
+        responses: [{ value: "Owner" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "What is the user's role?",
+        responses: [{ value: "Applicant" }],
+        metadata: { autoAnswered: true },
+      },
+      {
+        question: "What is the applicant's declared connections?",
+        responses: [{ value: "None" }],
+        metadata: { autoAnswered: true },
+      },
+    ],
+    files: [
+      {
+        name: "https://api.editor.planx.dev/file/private/tbp4kiba/myPlans.pdf",
+        type: [
+          "roofPlan.existing",
+          "roofPlan.proposed",
+          "sitePlan.existing",
+          "sitePlan.proposed",
+          "elevations.existing",
+          "elevations.proposed",
+        ],
+      },
+      {
+        name: "https://api.editor.planx.dev/file/private/311w2id6/floor_plans.pdf",
+        type: ["floorPlan.existing", "floorPlan.proposed"],
+      },
+    ],
+    metadata: {
+      organisation: "BKM",
+      id: "8da51c5b-a2a0-4386-a15d-29d66f9c121c",
+      source: "PlanX",
+      service: {
+        flowId: "824628b2-deeb-48b0-92b1-2ca7f3b17163",
+        url: "https://www.editor.planx.dev/buckinghamshire/apply-for-a-lawful-development-certificate/preview",
+        files: {
+          required: [
+            "roofPlan.existing",
+            "sitePlan.existing",
+            "roofPlan.proposed",
+            "sitePlan.proposed",
+            "elevations.existing",
+            "floorPlan.existing",
+            "elevations.proposed",
+            "floorPlan.proposed",
+          ],
+          recommended: [],
+          optional: [],
+        },
+        fee: {
+          category: {
+            sixAndSeven: [
+              {
+                description:
+                  "The plannning fee for an application for a Certificate of Lawfulness relating to the proposed alteration or extension of a single home is £129",
+                policyRefs: [
+                  {
+                    text: "UK Statutory Instruments 2023 No. 1197",
+                    url: "https://www.legislation.gov.uk/uksi/2023/1197/made",
+                  },
+                ],
+              },
+            ],
+          },
+          calculated: [
+            {
+              description:
+                "The plannning fee for an application for a Certificate of Lawfulness relating to the proposed alteration or extension of a single home is £129",
+              policyRefs: [
+                {
+                  text: "UK Statutory Instruments 2023 No. 1197",
+                  url: "https://www.legislation.gov.uk/uksi/2023/1197/made",
+                },
+              ],
+            },
+          ],
+          payable: [
+            {
+              description:
+                "If the proposed works (to either a home or within the curtilage of a home) is for the sole purpose of - providing either a means of access to (or within) the dwellinghouse for a disabled resident (current or future); providing facilities that are designed to ensure the disabled persons safety, health or comfort; or providing disabled access to a public building - then no planning fee will be payable for this application.",
+              policyRefs: [
+                {
+                  text: "UK Statutory Instruments 2012 No. 2920 Regulation 4",
+                  url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/4/made",
+                },
+              ],
+            },
+            {
+              description:
+                "In the case of an application that is the first resubmission of an application on the same site that is similar in character and description, no planning fee is payable.",
+              policyRefs: [
+                {
+                  text: "UK Statutory Instruments 2012 No. 2920 Regulation 8",
+                  url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/8/made",
+                },
+              ],
+            },
+          ],
+        },
+      },
+      submittedAt: "2023-10-02T00:00:00+01:00",
+      schema: `https://theopensystemslab.github.io/digital-planning-data-schemas/${version}/schemas/prototypeApplication.json`,
+    },
+  };

--- a/__mocks__/odp-submission-data/planningPermission/fullHouseholder.ts
+++ b/__mocks__/odp-submission-data/planningPermission/fullHouseholder.ts
@@ -1,0 +1,1133 @@
+import { PrototypeApplication } from "@/types/odp-types/schemas/prototypeApplication";
+
+const version = process.env["VERSION"] || "@next";
+
+export const planningPermissionFullHouseholderPrototype: PrototypeApplication =
+  {
+    applicationType: "pp.full.householder",
+    data: {
+      application: {
+        fee: {
+          calculated: 258,
+          payable: 258,
+          category: {
+            sixAndSeven: 258,
+          },
+          exemption: {
+            disability: false,
+            resubmission: false,
+          },
+          reduction: {
+            sports: false,
+            parishCouncil: false,
+            alternative: false,
+          },
+          reference: {
+            govPay: "sandbox-ref-456",
+          },
+        },
+        declaration: {
+          accurate: true,
+          connection: {
+            value: "none",
+          },
+        },
+      },
+      user: {
+        role: "proxy",
+      },
+      applicant: {
+        type: "individual",
+        name: {
+          first: "David",
+          last: "Bowie",
+        },
+        email: "ziggy@example.com",
+        phone: {
+          primary: "Not provided by agent",
+        },
+        address: {
+          sameAsSiteAddress: true,
+        },
+        siteContact: {
+          role: "proxy",
+        },
+        ownership: {
+          interest: "owner.sole",
+          certificate: "a",
+          agriculturalTenants: false,
+          declaration: {
+            accurate: true,
+          },
+        },
+        agent: {
+          name: {
+            first: "Ziggy",
+            last: "Stardust",
+          },
+          email: "ziggy@example.com",
+          phone: {
+            primary: "01100 0110 0011",
+          },
+          address: {
+            line1: "40 Stansfield Road",
+            line2: "Brixton",
+            town: "London",
+            county: "Greater London",
+            postcode: "SW9 9RZ",
+            country: "UK",
+          },
+        },
+      },
+      property: {
+        address: {
+          latitude: 51.4656522,
+          longitude: -0.1185926,
+          x: 530787,
+          y: 175754,
+          title: "40, STANSFIELD ROAD, LONDON",
+          singleLine: "40, STANSFIELD ROAD, LONDON, SW9 9RZ",
+          source: "Ordnance Survey",
+          uprn: "100021892955",
+          usrn: "21901294",
+          pao: "40",
+          street: "STANSFIELD ROAD",
+          town: "LONDON",
+          postcode: "SW9 9RZ",
+        },
+        boundary: {
+          site: {
+            type: "Feature",
+            geometry: {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [-0.1186569035053321, 51.465703531871384],
+                  [-0.1185938715934822, 51.465724418998775],
+                  [-0.1184195280075143, 51.46552473766957],
+                  [-0.11848390102387167, 51.4655038504508],
+                  [-0.1186569035053321, 51.465703531871384],
+                ],
+              ],
+            },
+            properties: null,
+          },
+          area: {
+            hectares: 0.012592,
+            squareMetres: 125.92,
+          },
+        },
+        planning: {
+          sources: [
+            "https://api.editor.planx.dev/gis/lambeth?geom=POLYGON+%28%28-0.1186569035053321+51.465703531871384%2C+-0.1185938715934822+51.465724418998775%2C+-0.1184195280075143+51.46552473766957%2C+-0.11848390102387167+51.4655038504508%2C+-0.1186569035053321+51.465703531871384%29%29&analytics=false&sessionId=81bcaa0f-baf5-4573-ba0a-ea868c573faf",
+            "https://api.editor.planx.dev/roads?usrn=21901294",
+          ],
+          designations: [
+            {
+              value: "articleFour",
+              intersects: false,
+            },
+            {
+              value: "articleFour.caz",
+              intersects: false,
+            },
+            {
+              value: "tpo",
+              intersects: false,
+            },
+            {
+              value: "listed",
+              intersects: false,
+            },
+            {
+              value: "monument",
+              intersects: false,
+            },
+            {
+              value: "designated",
+              intersects: false,
+            },
+            {
+              value: "nature.SAC",
+              intersects: false,
+            },
+            {
+              value: "nature.ASNW",
+              intersects: false,
+            },
+            {
+              value: "nature.SSSI",
+              intersects: false,
+            },
+            {
+              value: "locallyListed",
+              intersects: false,
+            },
+            {
+              value: "nature.SPA",
+              intersects: false,
+            },
+            {
+              value: "designated.WHS",
+              intersects: false,
+            },
+            {
+              value: "registeredPark",
+              intersects: false,
+            },
+            {
+              value: "designated.AONB",
+              intersects: false,
+            },
+            {
+              value: "designated.nationalPark",
+              intersects: false,
+            },
+            {
+              value: "designated.conservationArea",
+              intersects: false,
+            },
+            {
+              value: "designated.nationalPark.broads",
+              intersects: false,
+            },
+            {
+              value: "road.classified",
+              intersects: false,
+            },
+          ],
+        },
+        localAuthorityDistrict: ["Lambeth"],
+        region: "London",
+        type: "residential.dwelling.house.terrace",
+        titleNumber: {
+          known: "No",
+        },
+        EPC: {
+          known: "No",
+        },
+        parking: {
+          cars: {
+            count: 1,
+          },
+          cycles: {
+            count: 2,
+          },
+        },
+      },
+      proposal: {
+        projectType: ["extend.roof.dormer"],
+        description:
+          "Roof extension to the rear of the property, incorporating starship launchpad.",
+        boundary: {
+          site: {
+            type: "Feature",
+            geometry: {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [-0.1186569035053321, 51.465703531871384],
+                  [-0.1185938715934822, 51.465724418998775],
+                  [-0.1184195280075143, 51.46552473766957],
+                  [-0.11848390102387167, 51.4655038504508],
+                  [-0.1186569035053321, 51.465703531871384],
+                ],
+              ],
+            },
+            properties: null,
+          },
+          area: {
+            hectares: 0.012592,
+            squareMetres: 125.92,
+          },
+        },
+        date: {
+          start: "2024-05-01",
+          completion: "2024-05-02",
+        },
+        extend: {
+          area: {
+            squareMetres: 45,
+          },
+        },
+        parking: {
+          cars: {
+            count: 1,
+            difference: 0,
+          },
+          cycles: {
+            count: 2,
+            difference: 0,
+          },
+        },
+      },
+    },
+    responses: [
+      {
+        question: "Is the property in Lambeth?",
+        responses: [{ value: "Yes" }],
+        metadata: { autoAnswered: true, sectionName: "The property" },
+      },
+      {
+        question: "What type of property is it?",
+        responses: [{ value: "House" }],
+        metadata: { autoAnswered: true, sectionName: "The property" },
+      },
+      {
+        question: "What type of house it is?",
+        responses: [{ value: "Terrace" }],
+        metadata: { autoAnswered: true, sectionName: "The property" },
+      },
+      {
+        question: "Is the property in a flood zone?",
+        responses: [{ value: "No" }],
+        metadata: { sectionName: "The property" },
+      },
+      {
+        question: "What type of property is it?",
+        responses: [
+          {
+            value: "House",
+            metadata: { flags: ["Listed building consent / Not required"] },
+          },
+        ],
+        metadata: { autoAnswered: true, sectionName: "About the project" },
+      },
+      {
+        question: "List the changes involved in the project",
+        responses: [
+          {
+            value: "Add a roof extension",
+            metadata: { flags: ["Listed building consent / Not required"] },
+          },
+        ],
+        metadata: { sectionName: "About the project" },
+      },
+      {
+        question: "Have works already started?",
+        responses: [{ value: "No" }],
+        metadata: { sectionName: "About the project" },
+      },
+      {
+        question: "Is the property in a flood zone?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true, sectionName: "About the project" },
+      },
+      {
+        question: "What type of changes does the project involve?",
+        responses: [{ value: "Extension" }],
+        metadata: { autoAnswered: true, sectionName: "About the project" },
+      },
+      {
+        question: "Is the project to add an outbuilding?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true, sectionName: "About the project" },
+      },
+      {
+        question: "How much new floor area is being added to the house?",
+        responses: [{ value: "Less than 100m²" }],
+        metadata: { sectionName: "About the project" },
+      },
+      {
+        question:
+          "How much exactly is the internal floor area of the property increasing by?",
+        responses: [{ value: "45" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Development Management Procedure) (England) 2015 (as amended)",
+              url: "http://www.legislation.gov.uk/uksi/2015/595/article/7/made",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question:
+          "Does the project involve creating any new bedrooms or bathrooms?",
+        responses: [{ value: "No" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Development Management Procedure) (England) 2015 (as amended)",
+              url: "http://www.legislation.gov.uk/uksi/2015/595/article/7/made",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Describe the wall materials of the existing house",
+        responses: [{ value: "London stock brick" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Development Management Procedure) (England) 2015 (as amended)",
+              url: "http://www.legislation.gov.uk/uksi/2015/595/article/7/made",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Describe the wall materials of the new extension",
+        responses: [
+          { value: "Metallic cladding, reflective. Multiple colours." },
+        ],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Development Management Procedure) (England) 2015 (as amended)",
+              url: "http://www.legislation.gov.uk/uksi/2015/595/article/7/made",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Describe the material of the roof of the existing house",
+        responses: [{ value: "Grey slate" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Development Management Procedure) (England) 2015 (as amended)",
+              url: "http://www.legislation.gov.uk/uksi/2015/595/article/7/made",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Describe the material for the new roof of the extension",
+        responses: [{ value: "Zinc panels" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Development Management Procedure) (England) 2015 (as amended)",
+              url: "http://www.legislation.gov.uk/uksi/2015/595/article/7/made",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Describe the window materials of the existing house",
+        responses: [{ value: "Wooden sash windows, painted white" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Development Management Procedure) (England) 2015 (as amended)",
+              url: "http://www.legislation.gov.uk/uksi/2015/595/article/7/made",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Describe the window materials of the extension",
+        responses: [{ value: "Brushed steel." }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Development Management Procedure) (England) 2015 (as amended)",
+              url: "http://www.legislation.gov.uk/uksi/2015/595/article/7/made",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Describe the door materials of the existing house",
+        responses: [{ value: "Wood, painted." }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Development Management Procedure) (England) 2015 (as amended)",
+              url: "http://www.legislation.gov.uk/uksi/2015/595/article/7/made",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Describe the door materials of the extension",
+        responses: [{ value: "No door present" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Development Management Procedure) (England) 2015 (as amended)",
+              url: "http://www.legislation.gov.uk/uksi/2015/595/article/7/made",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question:
+          "Are there any trees that could fall within the property or the areas affected by the project (the previously drawn outline)?",
+        responses: [{ value: "No" }],
+        metadata: { sectionName: "About the project" },
+      },
+      {
+        question: "Does the project involve any of these?",
+        responses: [{ value: "No, none of these" }],
+        metadata: { sectionName: "About the project" },
+      },
+      {
+        question: "Is the property in Greater London?",
+        responses: [{ value: "Yes" }],
+        metadata: { autoAnswered: true, sectionName: "About the project" },
+      },
+      {
+        question: "Does the site include more than one property?",
+        responses: [{ value: "No" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "Greater London Authority Act 1999",
+              url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Do you know the title number of the property?",
+        responses: [{ value: "No" }],
+        metadata: { sectionName: "About the project" },
+      },
+      {
+        question:
+          "Does the property have an Energy Performance Certificate (EPC)?",
+        responses: [{ value: "No" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "Greater London Authority Act 1999",
+              url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "What type of application is this?",
+        responses: [{ value: "Planning permission for a home" }],
+        metadata: {
+          autoAnswered: true,
+          policyRefs: [
+            {
+              text: "Greater London Authority Act 1999",
+              url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "When will the works start?",
+        responses: [{ value: "2024-05-01" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "Greater London Authority Act 1999",
+              url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "When will the works be completed?",
+        responses: [{ value: "2024-05-02" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "Greater London Authority Act 1999",
+              url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Does the site include parking spaces for any of these?",
+        responses: [{ value: "Cars" }, { value: "Bicycles" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "Greater London Authority Act 1999",
+              url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Total number of car parking spaces before",
+        responses: [{ value: "1" }],
+        metadata: { sectionName: "About the project" },
+      },
+      {
+        question: "Total number of car parking spaces after",
+        responses: [{ value: "1" }],
+        metadata: { sectionName: "About the project" },
+      },
+      {
+        question: "What types of car parking space are present?",
+        responses: [{ value: "Off-street parking for residents only" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "Greater London Authority Act 1999",
+              url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Off-street, residents-only car spaces before",
+        responses: [{ value: "1" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "Greater London Authority Act 1999",
+              url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Off-street, residents-only car spaces after",
+        responses: [{ value: "1" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "Greater London Authority Act 1999",
+              url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "What type of bicycle parking is there?",
+        responses: [{ value: "Off-street cycle parking" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "Greater London Authority Act 1999",
+              url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Off-street bicycle spaces before",
+        responses: [{ value: "2" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "Greater London Authority Act 1999",
+              url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Off-street bicycle spaces after",
+        responses: [{ value: "2" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "Greater London Authority Act 1999",
+              url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Is the property on designated land?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true, sectionName: "About the project" },
+      },
+      {
+        question: "Does the property include any of these?",
+        responses: [{ value: "None of these" }],
+        metadata: {
+          autoAnswered: true,
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Development Management Procedure) (England) 2015 (as amended",
+              url: "http://www.legislation.gov.uk/uksi/2015/595/article/7/made",
+            },
+          ],
+          sectionName: "About the project",
+        },
+      },
+      {
+        question: "Heritage Statement needed?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true, sectionName: "About the project" },
+      },
+      {
+        question: "Is the property in a flood zone?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true, sectionName: "About the project" },
+      },
+      {
+        question: "What type of application is it?",
+        responses: [{ value: "Apply for planning permission" }],
+        metadata: { autoAnswered: true, sectionName: "About you" },
+      },
+      {
+        question: "Your contact details",
+        responses: [
+          { value: "Mx Ziggy Stardust 01100 0110 0011 ziggy@example.com" },
+        ],
+        metadata: { sectionName: "About you" },
+      },
+      {
+        question: "Is this a test?",
+        responses: [{ value: "No" }],
+        metadata: { sectionName: "About you" },
+      },
+      {
+        question: "Are you applying on behalf of someone else?",
+        responses: [{ value: "Yes" }],
+        metadata: { sectionName: "About you" },
+      },
+      {
+        question: "Which of these best describes you?",
+        responses: [{ value: "Friend or relative" }],
+        metadata: { sectionName: "About you" },
+      },
+      {
+        question: "Your contact address",
+        responses: [
+          {
+            value:
+              "40 Stansfield Road, Brixton, London, Greater London, SW9 9RZ, UK",
+          },
+        ],
+        metadata: { sectionName: "About you" },
+      },
+      {
+        question: "Which of these best describes the applicant?",
+        responses: [{ value: "Private individual" }],
+        metadata: { sectionName: "About you" },
+      },
+      {
+        question: "Applicant's title",
+        responses: [{ value: "Mr" }],
+        metadata: { sectionName: "About you" },
+      },
+      {
+        question: "Do you want to provide an email address for the applicant?",
+        responses: [{ value: "No" }],
+        metadata: { sectionName: "About you" },
+      },
+      {
+        question:
+          "Do you want to provide a telephone number for the applicant?",
+        responses: [{ value: "No" }],
+        metadata: { sectionName: "About you" },
+      },
+      {
+        question:
+          "Is the applicant's contact address the same as the property address?",
+        responses: [{ value: "Yes" }],
+        metadata: { sectionName: "About you" },
+      },
+      {
+        question: "Which of these best describes you?",
+        responses: [{ value: "Friend or relative" }],
+        metadata: { autoAnswered: true, sectionName: "About you" },
+      },
+      {
+        question:
+          "We may need to visit your site to assess your application. If we do, who should we contact to arrange the visit?",
+        responses: [{ value: "Me" }],
+        metadata: { sectionName: "About you" },
+      },
+      {
+        question: "Which of these best describes you?",
+        responses: [
+          { value: "Friend or relative acting on the applicant's behalf" },
+        ],
+        metadata: { autoAnswered: true, sectionName: "About you" },
+      },
+      {
+        question:
+          "Which of these best describes the applicant's interest in the land?",
+        responses: [{ value: "Sole owner" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Development Management Procedure) (England) Order 2015",
+              url: "https://www.legislation.gov.uk/uksi/2015/595/article/39/made",
+            },
+          ],
+          sectionName: "About you",
+        },
+      },
+      {
+        question:
+          "Did you get any pre-application advice from the council before making this application?",
+        responses: [{ value: "No" }],
+        metadata: { sectionName: "About this application" },
+      },
+      {
+        question: "What type of planning application are you making?",
+        responses: [{ value: "Full planning permission" }],
+        metadata: { autoAnswered: true, sectionName: "About this application" },
+      },
+      {
+        question: "Is the property a home?",
+        responses: [{ value: "Yes" }],
+        metadata: { autoAnswered: true, sectionName: "About this application" },
+      },
+      {
+        question: "What types of changes does the application relate to?",
+        responses: [{ value: "Extension" }],
+        metadata: { autoAnswered: true, sectionName: "About this application" },
+      },
+      {
+        question: "What type of extension is it?",
+        responses: [{ value: "Roof extension" }],
+        metadata: { autoAnswered: true, sectionName: "About this application" },
+      },
+      {
+        question: "List the changes involved in the roof extension",
+        responses: [{ value: "Add dormer" }],
+        metadata: { sectionName: "About this application" },
+      },
+      {
+        question:
+          "Is the purpose of the project to support the needs of a disabled resident?",
+        responses: [{ value: "No" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 14",
+              url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/14",
+            },
+            {
+              text: "UK Statutory Instruments 2012 No. 2920 Regulation 4",
+              url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/4/made",
+            },
+            {
+              text: "Equalities Act 2010, Section 6",
+              url: "https://www.legislation.gov.uk/ukpga/2010/15/section/6",
+            },
+            {
+              text: "Children Act 1989, Part 3",
+              url: "https://www.legislation.gov.uk/ukpga/1989/41/part/III",
+            },
+          ],
+          sectionName: "About this application",
+        },
+      },
+      {
+        question: "Is it a prior approval application?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true, sectionName: "About this application" },
+      },
+      {
+        question: "Is the property a home?",
+        responses: [{ value: "Yes" }],
+        metadata: { autoAnswered: true, sectionName: "About this application" },
+      },
+      {
+        question: "What works does the project involve?",
+        responses: [{ value: "Extension" }],
+        metadata: { autoAnswered: true, sectionName: "About this application" },
+      },
+      {
+        question: "Is this application a resubmission?",
+        responses: [{ value: "No" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 9",
+              url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/9",
+            },
+          ],
+          sectionName: "About this application",
+        },
+      },
+      {
+        question: "Does the application qualify for a disability exemption?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true, sectionName: "About this application" },
+      },
+      {
+        question: "Does the application qualify for a resubmission exemption?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true, sectionName: "About this application" },
+      },
+      {
+        question: "Is the site a sports field?",
+        responses: [{ value: "No" }],
+        metadata: {
+          autoAnswered: true,
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Chapter 2, Paragraph 3",
+              url: "https://www.legislation.gov.uk/uksi/2012/2920/schedule/1",
+            },
+          ],
+          sectionName: "About this application",
+        },
+      },
+      {
+        question:
+          "Is the application being made by (or on behalf of) a parish or community council?",
+        responses: [{ value: "No" }],
+        metadata: {
+          autoAnswered: true,
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 - Regulation 11",
+              url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/11",
+            },
+          ],
+          sectionName: "About this application",
+        },
+      },
+      {
+        question:
+          "Are you also submitting another proposal for the same site today?",
+        responses: [{ value: "No" }],
+        metadata: {
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Chapter 2, Paragraph 10",
+              url: "https://www.legislation.gov.uk/uksi/2012/2920/schedule/1",
+            },
+          ],
+          sectionName: "About this application",
+        },
+      },
+      {
+        question:
+          "Does the application qualify for the sports club fee reduction?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true, sectionName: "About this application" },
+      },
+      {
+        question:
+          "Does the application qualify for the parish council reduction?",
+        responses: [{ value: "No" }],
+        metadata: {
+          autoAnswered: true,
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 - Regulation 11",
+              url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/11",
+            },
+          ],
+          sectionName: "About this application",
+        },
+      },
+      {
+        question:
+          "Does the application qualify for the alternative application reduction?",
+        responses: [{ value: "No" }],
+        metadata: {
+          autoAnswered: true,
+          policyRefs: [
+            {
+              text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Chapter 2, Paragraph 10",
+              url: "https://www.legislation.gov.uk/uksi/2012/2920/schedule/1",
+            },
+          ],
+          sectionName: "About this application",
+        },
+      },
+      {
+        question: "What type of application is it?",
+        responses: [{ value: "Full planning permission" }],
+        metadata: { autoAnswered: true, sectionName: "About this application" },
+      },
+      {
+        question: "What does the project involve?",
+        responses: [{ value: "Extension" }],
+        metadata: { autoAnswered: true, sectionName: "About this application" },
+      },
+      {
+        question: "How much new floor area is being created?",
+        responses: [
+          {
+            value: "Less than 100m²",
+            metadata: { flags: ["Community infrastructure levy / Not liable"] },
+          },
+        ],
+        metadata: {
+          autoAnswered: true,
+          policyRefs: [
+            {
+              text: "The Community Infrastructure Levy Regulations 2010, Regulation 42",
+              url: "https://www.legislation.gov.uk/uksi/2010/948/regulation/42",
+            },
+          ],
+          sectionName: "About this application",
+        },
+      },
+      {
+        question: "Is this a householder planning application?",
+        responses: [
+          {
+            value: "Yes",
+            metadata: { flags: ["Community infrastructure levy / Not liable"] },
+          },
+        ],
+        metadata: {
+          autoAnswered: true,
+          policyRefs: [
+            {
+              text: "The Community Infrastructure Levy Regulations 2010, Regulation 42",
+              url: "https://www.legislation.gov.uk/uksi/2010/948/regulation/42",
+            },
+          ],
+          sectionName: "About this application",
+        },
+      },
+      {
+        question: "Have the works already started?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true, sectionName: "Upload drawings" },
+      },
+      {
+        question: "What changes does the project involve?",
+        responses: [{ value: "Extension" }],
+        metadata: { autoAnswered: true, sectionName: "Upload drawings" },
+      },
+      {
+        question: "Is the project to add an outbuilding?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true, sectionName: "Upload drawings" },
+      },
+      {
+        question: "Which Local Planning authority is it?",
+        responses: [{ value: "Lambeth" }],
+        metadata: { autoAnswered: true, sectionName: "Check" },
+      },
+      {
+        question: "Connections with London Borough of Lambeth",
+        responses: [{ value: "None of the above apply to me" }],
+        metadata: { sectionName: "Check" },
+      },
+      {
+        question: "I confirm that:",
+        responses: [
+          {
+            value:
+              "The information contained in this application is truthful, accurate and complete, to the best of my knowledge",
+          },
+        ],
+        metadata: { sectionName: "Check" },
+      },
+      {
+        question: "Does the application qualify for a disability exemption?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true, sectionName: "Pay and send" },
+      },
+      {
+        question: "Does the application qualify for a resubmission exemption?",
+        responses: [{ value: "No" }],
+        metadata: { autoAnswered: true, sectionName: "Pay and send" },
+      },
+      {
+        question: "Which Local Planning authority is it?",
+        responses: [{ value: "Lambeth" }],
+        metadata: { autoAnswered: true, sectionName: "Pay and send" },
+      },
+    ],
+    files: [
+      {
+        name: "https://api.editor.planx.dev/file/private/tbp4kiba/myPlans.pdf",
+        type: ["roofPlan.existing", "roofPlan.proposed"],
+      },
+      {
+        name: "https://api.editor.planx.dev/file/private/5w5v8s8z/other.pdf",
+        type: ["sitePlan.existing", "sitePlan.proposed"],
+      },
+      {
+        name: "https://api.editor.planx.dev/file/private/7nrefxnn/elevations.pdf",
+        type: ["elevations.existing", "elevations.proposed"],
+      },
+      {
+        name: "https://api.editor.planx.dev/file/private/311w2id6/floor_plans.pdf",
+        type: ["floorPlan.existing", "floorPlan.proposed"],
+      },
+    ],
+    metadata: {
+      organisation: "LBH",
+      id: "81bcaa0f-baf5-4573-ba0a-ea868c573faf",
+      source: "PlanX",
+      service: {
+        flowId: "01e38c5d-e701-4e44-acdc-4d6b5cc3b854",
+        url: "https://www.editor.planx.dev/lambeth/apply-for-planning-permission/preview",
+        files: {
+          required: [
+            "roofPlan.existing",
+            "roofPlan.proposed",
+            "sitePlan.existing",
+            "sitePlan.proposed",
+            "elevations.existing",
+            "elevations.proposed",
+          ],
+          recommended: ["floorPlan.existing", "floorPlan.proposed"],
+          optional: [],
+        },
+        fee: {
+          category: {
+            sixAndSeven: [
+              {
+                description:
+                  "The fee to apply for planning permission to alter or extend a single home is £258.",
+                policyRefs: [
+                  {
+                    text: "UK Statutory Instruments 2023 No. 1197",
+                    url: "https://www.legislation.gov.uk/uksi/2023/1197/made",
+                  },
+                ],
+              },
+            ],
+          },
+          calculated: [
+            {
+              description:
+                "The fee to apply for planning permission to alter or extend a single home is £258.",
+              policyRefs: [
+                {
+                  text: "UK Statutory Instruments 2023 No. 1197",
+                  url: "https://www.legislation.gov.uk/uksi/2023/1197/made",
+                },
+              ],
+            },
+          ],
+          payable: [
+            {
+              description:
+                "The fee to apply for planning permission to alter or extend a single home is £258.",
+              policyRefs: [
+                {
+                  text: "UK Statutory Instruments 2023 No. 1197",
+                  url: "https://www.legislation.gov.uk/uksi/2023/1197/made",
+                },
+              ],
+            },
+          ],
+        },
+      },
+      submittedAt: "2023-10-02T00:00:00.00Z",
+      schema: `https://theopensystemslab.github.io/digital-planning-data-schemas/${version}/schemas/prototypeApplication.json`,
+    },
+  };

--- a/__mocks__/odp-submission-data/priorApproval/largerExtension.ts
+++ b/__mocks__/odp-submission-data/priorApproval/largerExtension.ts
@@ -1,0 +1,1474 @@
+import { PrototypeApplication } from "@/types/odp-types/schemas/prototypeApplication";
+
+const version = process.env["VERSION"] || "@next";
+
+export const priorApprovalLargerExtensionPrototype: PrototypeApplication = {
+  applicationType: "pa.part1.classA",
+  data: {
+    user: {
+      role: "applicant",
+    },
+    applicant: {
+      type: "individual",
+      name: {
+        first: "William",
+        last: "Zane",
+      },
+      email: "areyouon@email.org",
+      phone: {
+        primary: "01234000000",
+      },
+      address: {
+        sameAsSiteAddress: true,
+      },
+      siteContact: {
+        role: "applicant",
+      },
+    },
+    property: {
+      address: {
+        latitude: 51.3304155,
+        longitude: -0.1043842,
+        x: 532161,
+        y: 160741,
+        title: "32, ST JAMES ROAD, PURLEY",
+        source: "Ordnance Survey",
+        uprn: "100020623888",
+        usrn: "20502851",
+        pao: "32",
+        street: "ST JAMES ROAD",
+        town: "PURLEY",
+        postcode: "CR8 2DL",
+        singleLine: "32 ST JAMES ROAD, PURLEY, CROYDON, CR8 2DL",
+      },
+      localAuthorityDistrict: ["Croydon"],
+      region: "London",
+      type: "residential.dwelling.house.detached",
+      planning: {
+        sources: [
+          "https://api.editor.planx.dev/gis/southwark?geom=MULTIPOLYGON+%28%28%28-0.072763+51.456622%2C+-0.072749+51.456669%2C+-0.073167+51.456732%2C+-0.073195+51.456736%2C+-0.073213+51.456688%2C+-0.072763+51.456622%29%29%29&analytics=false&sessionId=80d3c3c2-0d1c-4a79-be99-912f488c2f02",
+          "https://api.editor.planx.dev/roads?usrn=22500947",
+        ],
+        designations: [
+          {
+            value: "tpo",
+            intersects: false,
+          },
+          {
+            value: "flood",
+            intersects: false,
+          },
+          {
+            value: "listed",
+            intersects: false,
+          },
+          {
+            value: "articleFour",
+            intersects: false,
+          },
+          {
+            value: "monument",
+            intersects: false,
+          },
+          {
+            value: "greenBelt",
+            intersects: false,
+          },
+          {
+            value: "designated",
+            intersects: false,
+          },
+          {
+            value: "nature.SAC",
+            intersects: false,
+          },
+          {
+            value: "nature.SPA",
+            intersects: false,
+          },
+          {
+            value: "nature.ASNW",
+            intersects: false,
+          },
+          {
+            value: "nature.SSSI",
+            intersects: false,
+          },
+          {
+            value: "brownfieldSite",
+            intersects: false,
+          },
+          {
+            value: "designated.WHS",
+            intersects: false,
+          },
+          {
+            value: "registeredPark",
+            intersects: false,
+          },
+          {
+            value: "designated.AONB",
+            intersects: false,
+          },
+          {
+            value: "nature.ramsarSite",
+            intersects: false,
+          },
+          {
+            value: "designated.nationalPark",
+            intersects: false,
+          },
+          {
+            value: "designated.conservationArea",
+            intersects: false,
+          },
+          {
+            value: "designated.nationalPark.broads",
+            intersects: false,
+          },
+          {
+            value: "road.classified",
+            intersects: false,
+          },
+        ],
+      },
+      boundary: {
+        site: {
+          type: "Feature",
+          geometry: {
+            type: "MultiPolygon",
+            coordinates: [
+              [
+                [
+                  [-0.072763, 51.456622],
+                  [-0.072749, 51.456669],
+                  [-0.073167, 51.456732],
+                  [-0.073195, 51.456736],
+                  [-0.073213, 51.456688],
+                  [-0.072763, 51.456622],
+                ],
+              ],
+            ],
+          },
+          properties: {
+            name: "",
+            entity: 12000593377,
+            prefix: "title-boundary",
+            dataset: "title-boundary",
+            "end-date": "",
+            typology: "geography",
+            reference: "37786766",
+            "entry-date": "2024-05-06",
+            "start-date": "2002-06-26",
+            "organisation-entity": "13",
+          },
+        },
+        area: {
+          hectares: 0.017289,
+          squareMetres: 172.89,
+        },
+      },
+    },
+    application: {
+      fee: {
+        calculated: 120,
+        payable: 0,
+        exemption: {
+          disability: true,
+          resubmission: false,
+        },
+        reduction: {
+          sports: false,
+          parishCouncil: false,
+          alternative: false,
+        },
+      },
+      declaration: {
+        accurate: true,
+        connection: {
+          value: "none",
+        },
+      },
+    },
+    proposal: {
+      projectType: ["extend.rear"],
+      description:
+        "A 2 storey rear extension with a roof garden and built in pizza oven",
+      date: {
+        start: "2024-06-17",
+        completion: "2050-06-18",
+      },
+      boundary: {
+        site: {
+          type: "Feature",
+          geometry: {
+            type: "MultiPolygon",
+            coordinates: [
+              [
+                [
+                  [-0.072763, 51.456622],
+                  [-0.072749, 51.456669],
+                  [-0.073167, 51.456732],
+                  [-0.073195, 51.456736],
+                  [-0.073213, 51.456688],
+                  [-0.072763, 51.456622],
+                ],
+              ],
+            ],
+          },
+          properties: {
+            name: "",
+            entity: 12000593377,
+            prefix: "title-boundary",
+            dataset: "title-boundary",
+            "end-date": "",
+            typology: "geography",
+            reference: "37786766",
+            "entry-date": "2024-05-06",
+            "start-date": "2002-06-26",
+            "organisation-entity": "13",
+            planx_user_action: "Accepted the title boundary",
+          },
+        },
+        area: {
+          hectares: 0.017289,
+          squareMetres: 172.89,
+        },
+      },
+    },
+  },
+  preAssessment: [
+    {
+      value: "Planning permission / Prior approval",
+      description:
+        "It looks like the proposed changes do not require planning permission, however the applicant must apply for Prior Approval before proceeding.",
+    },
+  ],
+  responses: [
+    {
+      question: "Is the property in Southwark?",
+      responses: [
+        {
+          value: "Yes",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "The property",
+      },
+    },
+    {
+      question: "What type of property is it?",
+      responses: [
+        {
+          value: "House",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "The property",
+      },
+    },
+    {
+      question: "What type of house is it?",
+      responses: [
+        {
+          value: "Terrace",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "The property",
+      },
+    },
+    {
+      question: "Have the works already started?",
+      responses: [
+        {
+          value: "No",
+        },
+      ],
+      metadata: {
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Describe the project.",
+      responses: [
+        {
+          value:
+            "A 2 storey rear extension with a roof garden and built in pizza oven.",
+        },
+      ],
+      metadata: {
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "What type of property is it?",
+      responses: [
+        {
+          value: "House",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Select your project",
+      responses: [
+        {
+          value: "Add a rear extension",
+        },
+      ],
+      metadata: {
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "What type of property is it?",
+      responses: [
+        {
+          value: "House",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (General Permitted Development) (England) Order 2015",
+            url: "https://www.legislation.gov.uk/uksi/2015/596/contents/made",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "What type of house is it?",
+      responses: [
+        {
+          value: "Mid terrace",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "How many storeys does the original house have?",
+      responses: [
+        {
+          value: "2 or more",
+        },
+      ],
+      metadata: {
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Does the original house have a projection to the rear?",
+      responses: [
+        {
+          value: "Yes",
+        },
+      ],
+      metadata: {
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Was the house always a house?",
+      responses: [
+        {
+          value: "Yes, it was built as a house",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 1, Class A",
+            url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Was the house built before 2020?",
+      responses: [
+        {
+          value: "Yes, it was built before 2020",
+          metadata: {
+            flags: ["Planning permission / Permitted development"],
+          },
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class 1 A.",
+            url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Which of these best describes the new extension?",
+      responses: [
+        {
+          value: "Single storey",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Section 2, Part 1, Class A",
+            url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Does the original house have a projection to the rear?",
+      responses: [
+        {
+          value: "Yes",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Which of these best describes your extension?",
+      responses: [
+        {
+          value: "Rear",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "General Permitted Development Order 2015, Technical Guidance (PDF, 500KB)",
+            url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/830643/190910_Tech_Guide_for_publishing.pdf",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Is any part of the extension within 2 metres of the boundary?",
+      responses: [
+        {
+          value: "No",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A",
+            url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Is the property on designated land?",
+      responses: [
+        {
+          value: "No",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Is the property a site of special scientific interest?",
+      responses: [
+        {
+          value: "No",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "What type of house is it?",
+      responses: [
+        {
+          value: "A terrace",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question:
+        "How far does the new rear addition extend beyond the back wall of the original house?",
+      responses: [
+        {
+          value: "3 to 6m",
+          metadata: {
+            flags: ["Planning permission / Prior approval"],
+          },
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A.1 (f)(i)",
+            url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question:
+        "Is this a prior approval application for a larger rear extension?",
+      responses: [
+        {
+          value: "Yes",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question:
+        "Exactly how far will the new addition extend beyond the back wall of the original house?",
+      responses: [
+        {
+          value: "5",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A",
+            url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "What type of roof does the extension have?",
+      responses: [
+        {
+          value: "Flat",
+        },
+      ],
+      metadata: {
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Will any part of the extension be higher than 4m?",
+      responses: [
+        {
+          value: "No",
+          metadata: {
+            flags: ["Planning permission / Permitted development"],
+          },
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A.1 (g)(ii)",
+            url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+          },
+          {
+            text: "Permitted Development Rights for Householders Technical Guidance (PDF, 500KB)",
+            url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/830643/190910_Tech_Guide_for_publishing.pdf",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question:
+        "Is this a prior approval application for a larger rear extension?",
+      responses: [
+        {
+          value: "Yes",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "What is the exact height of the extension?",
+      responses: [
+        {
+          value: "3.6",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A",
+            url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "How many storeys does the original house have?",
+      responses: [
+        {
+          value: "2 or more",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question:
+        "Is any part of the extension within 2 metres of a boundary of the house?",
+      responses: [
+        {
+          value: "No",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "How many storeys does the original house have?",
+      responses: [
+        {
+          value: "2 or more",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question:
+        "Are the materials of the extension similar to the original house?",
+      responses: [
+        {
+          value: "Yes",
+          metadata: {
+            flags: ["Planning permission / Permitted development"],
+          },
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A",
+            url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Is the property on designated land?",
+      responses: [
+        {
+          value: "No",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question:
+        "How much of the available area around the house is covered by extensions and outbuildings?",
+      responses: [
+        {
+          value: "50% or less of the available area around the original house",
+          metadata: {
+            flags: ["Planning permission / Permitted development"],
+          },
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A",
+            url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "What will you use the extension for?",
+      responses: [
+        {
+          value: "Hobby space or similar",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A",
+            url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1",
+          },
+          {
+            text: "Town and Country Planning Act 1990, Section 55",
+            url: "https://www.legislation.gov.uk/ukpga/1990/8/section/55",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Who will use the hobby space?",
+      responses: [
+        {
+          value: "Me and my family, personal use only",
+          metadata: {
+            flags: ["Planning permission / Permitted development"],
+          },
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "Town and Country Planning Act 1990, Section 55",
+            url: "https://www.legislation.gov.uk/ukpga/1990/8/section/55",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "What type of application is being applied for?",
+      responses: [
+        {
+          value: "Part 1 Class A",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Is the property subject to any Article 4 directions?",
+      responses: [
+        {
+          value: "No",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "What type of prior approval application is it?",
+      responses: [
+        {
+          value: "Larger extension to a house",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "How many properties adjoin yours?",
+      responses: [
+        {
+          value: "2",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 1, Class A.4 (5)",
+            url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-a-enlargement-improvement-or-other-alteration-of-a-dwellinghouse",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Enter the address of the first adjoining property",
+      responses: [
+        {
+          value: "21 Fellbrigg Road, London, SE22 9HQ",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 1, Class A.4 (5)",
+            url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-a-enlargement-improvement-or-other-alteration-of-a-dwellinghouse",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Enter the address of the second adjoining property",
+      responses: [
+        {
+          value: "25 Fellbrigg Road, London, SE22 9HQ",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 1, Class A.4 (5)",
+            url: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-a-enlargement-improvement-or-other-alteration-of-a-dwellinghouse",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Is the proposal within the Greater London Authority?",
+      responses: [
+        {
+          value: "Yes",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Does the site include more than one property?",
+      responses: [
+        {
+          value: "No",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "Greater London Authority Act 1999",
+            url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Do you know the title number of the property?",
+      responses: [
+        {
+          value: "No",
+        },
+      ],
+      metadata: {
+        sectionName: "About the project",
+      },
+    },
+    {
+      question:
+        "Does the property have an Energy Performance Certificate (EPC)?",
+      responses: [
+        {
+          value: "Yes",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "Greater London Authority Act 1999",
+            url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "Enter the reference number (RRN) from the most recent EPC",
+      responses: [
+        {
+          value: "1234-1234-1234-1234-1234",
+        },
+      ],
+      metadata: {
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "What type of application is this?",
+      responses: [
+        {
+          value: "Prior approval",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "When are the works planned to start?",
+      responses: [
+        {
+          value: "2024-06-17",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "Greater London Authority Act 1999",
+            url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "When are the works planned to be completed?",
+      responses: [
+        {
+          value: "2050-06-18",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "Greater London Authority Act 1999",
+            url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question:
+        "[HIDDEN] Is the application for prior approval for an extension to a dwelling house?",
+      responses: [
+        {
+          value: "Yes",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "What is the gross internal floor area to be added?",
+      responses: [
+        {
+          value: "40",
+        },
+      ],
+      metadata: {
+        sectionName: "About the project",
+      },
+    },
+    {
+      question:
+        "Do the changes involve creating any new bedrooms or bathrooms?",
+      responses: [
+        {
+          value: "No",
+        },
+      ],
+      metadata: {
+        sectionName: "About the project",
+      },
+    },
+    {
+      question:
+        "Are there existing or are you proposing parking spaces for any of these on the site?",
+      responses: [
+        {
+          value: "Bicycles",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "Greater London Authority Act 1999",
+            url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "What is the number of existing bicycle parking spaces?",
+      responses: [
+        {
+          value: "2",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "Greater London Authority Act 1999",
+            url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "What is the proposed total number of bicycle parking spaces?",
+      responses: [
+        {
+          value: "2",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "Greater London Authority Act 1999",
+            url: "https://www.legislation.gov.uk/ukpga/1999/29/section/346",
+          },
+        ],
+        sectionName: "About the project",
+      },
+    },
+    {
+      question: "What type of application is it?",
+      responses: [
+        {
+          value: "Apply for prior approval",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "About you",
+      },
+    },
+    {
+      question: "Are you applying on behalf of someone else?",
+      responses: [
+        {
+          value: "No",
+        },
+      ],
+      metadata: {
+        sectionName: "About you",
+      },
+    },
+    {
+      question: "Which of these best describes you?",
+      responses: [
+        {
+          value: "Private individual",
+        },
+      ],
+      metadata: {
+        sectionName: "About you",
+      },
+    },
+    {
+      question: "Your contact details",
+      responses: [
+        {
+          value: "William Zane 01234000000 areyouon@email.org",
+        },
+      ],
+      metadata: {
+        sectionName: "About you",
+      },
+    },
+    {
+      question: "Is your contact address the same as the property address?",
+      responses: [
+        {
+          value: "Yes",
+        },
+      ],
+      metadata: {
+        sectionName: "About you",
+      },
+    },
+    {
+      question: "Can a planning officer see the works from public land?",
+      responses: [
+        {
+          value: "Yes, it's visible from the road or somewhere else",
+        },
+      ],
+      metadata: {
+        sectionName: "About you",
+      },
+    },
+    {
+      question:
+        "We may need to visit the site to assess your application. If we do, who should we contact to arrange the visit?",
+      responses: [
+        {
+          value: "Me, the applicant",
+        },
+      ],
+      metadata: {
+        sectionName: "About you",
+      },
+    },
+    {
+      question: "What type of prior approval application is it?",
+      responses: [
+        {
+          value: "Larger extension to a house",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "Upload drawings",
+      },
+    },
+    {
+      question: "Has the house already been extended?",
+      responses: [
+        {
+          value: "No",
+        },
+      ],
+      metadata: {
+        sectionName: "Upload drawings",
+      },
+    },
+    {
+      question: "Is this for submission or information only?",
+      responses: [
+        {
+          value: "Submission",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "Upload drawings",
+      },
+    },
+    {
+      question: "What type of application is it?",
+      responses: [
+        {
+          value: "Prior approval",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "Check your application",
+      },
+    },
+    {
+      question: "What type of prior approval application is it?",
+      responses: [
+        {
+          value: "Larger extension to a house",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "Check your application",
+      },
+    },
+    {
+      question: "Is the property a home?",
+      responses: [
+        {
+          value: "Yes",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "Check your application",
+      },
+    },
+    {
+      question: "What works does the project involve?",
+      responses: [
+        {
+          value: "Extension",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "Check your application",
+      },
+    },
+    {
+      question:
+        "Is the purpose of the project to support the needs of a disabled resident?",
+      responses: [
+        {
+          value: "Yes",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 14",
+            url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/14",
+          },
+          {
+            text: "UK Statutory Instruments 2012 No. 2920 Regulation 4",
+            url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/4/made",
+          },
+          {
+            text: "Equalities Act 2010, Section 6",
+            url: "https://www.legislation.gov.uk/ukpga/2010/15/section/6",
+          },
+          {
+            text: "Children Act 1989, Part 3",
+            url: "https://www.legislation.gov.uk/ukpga/1989/41/part/III",
+          },
+        ],
+        sectionName: "Check your application",
+      },
+    },
+    {
+      question: "Are you the applicant?",
+      responses: [
+        {
+          value: "Yes",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "Check your application",
+      },
+    },
+    {
+      question: "Would you like to upload evidence of your disability?",
+      responses: [
+        {
+          value: "No",
+        },
+      ],
+      metadata: {
+        sectionName: "Check your application",
+      },
+    },
+    {
+      question: "What type of prior approval application is it?",
+      responses: [
+        {
+          value: "Larger extension to a house",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "Check your application",
+      },
+    },
+    {
+      question:
+        "Are you submitting any other planning applications about the same works or changes?",
+      responses: [
+        {
+          value: "No",
+        },
+      ],
+      metadata: {
+        policyRefs: [
+          {
+            text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 14",
+            url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/14",
+          },
+        ],
+        sectionName: "Check your application",
+      },
+    },
+    {
+      question: "Does the application qualify for a disability exemption?",
+      responses: [
+        {
+          value: "Yes",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "Check your application",
+      },
+    },
+    {
+      question: "Is it any of these?",
+      responses: [
+        {
+          value: "None of these",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "Check your application",
+      },
+    },
+    {
+      question: "Check for multiple fees?",
+      responses: [
+        {
+          value: "No",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "Check your application",
+      },
+    },
+    {
+      question: "What type of application is it?",
+      responses: [
+        {
+          value: "Prior approval",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "Check your application",
+      },
+    },
+    {
+      question: "Which Local Planning authority is it?",
+      responses: [
+        {
+          value: "Southwark",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "Check your application",
+      },
+    },
+    {
+      question: "Connections with Southwark Council",
+      responses: [
+        {
+          value: "None of the above apply to me",
+        },
+      ],
+      metadata: {
+        sectionName: "Check your application",
+      },
+    },
+    {
+      question: "I confirm that:",
+      responses: [
+        {
+          value:
+            "The information contained in this application is truthful, accurate and complete, to the best of my knowledge",
+        },
+      ],
+      metadata: {
+        sectionName: "Check your application",
+      },
+    },
+    {
+      question: "Which Local Planning authority is it?",
+      responses: [
+        {
+          value: "Southwark",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "Pay and submit",
+      },
+    },
+    {
+      question:
+        "What type of prior approval application is it?application.type",
+      responses: [
+        {
+          value: "Larger extension to a house",
+        },
+      ],
+      metadata: {
+        autoAnswered: true,
+        sectionName: "Pay and submit",
+      },
+    },
+  ],
+  files: [
+    {
+      name: "https://api.editor.planx.dev/file/private/dfaz9qu5/location%20plan_proposed_01.jpg",
+      type: ["sitePlan.proposed"],
+    },
+    {
+      name: "https://api.editor.planx.dev/file/private/avilhq1j/elevations_existing_01.jpg",
+      type: ["elevations.existing"],
+    },
+    {
+      name: "https://api.editor.planx.dev/file/private/tis6f8hh/elevations_proposed_01.jpg",
+      type: ["elevations.proposed"],
+    },
+  ],
+  metadata: {
+    id: "80d3c3c2-0d1c-4a79-be99-912f488c2f02",
+    organisation: "SWK",
+    submittedAt: "2024-06-26T18:14:45.726Z",
+    source: "PlanX",
+    service: {
+      flowId: "c6628103-c648-4663-81e1-bfa0a1a18340",
+      url: "https://editor.planx.dev/southwark/apply-for-prior-approval/published",
+      files: {
+        required: ["sitePlan.proposed"],
+        recommended: ["elevations.existing", "elevations.proposed"],
+        optional: [
+          "photographs.existing",
+          "otherDrawing",
+          "otherDocument",
+          "visualisations",
+        ],
+      },
+      fee: {
+        calculated: [
+          {
+            policyRefs: [
+              {
+                text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) (Amendment) Regulations 2023",
+                url: "https://www.legislation.gov.uk/uksi/2023/1197/made",
+              },
+            ],
+          },
+        ],
+        payable: [
+          {
+            description:
+              "<p>If the proposed works (to either a home or within the curtilage of a home) is for the <strong>sole</strong> purpose of providing either:</p>\n<p></p>\n<p>- A means of access to (or within) the dwellinghouse for a disabled resident (current or future)</p>\n<p></p>\n<p>OR</p>\n<p></p>\n<p>- Providing facilities that are designed to ensure the disabled persons safety, health or comfort</p>\n<p></p>\n<p>OR</p>\n<p></p>\n<p>- Providing disabled access to a public building</p>\n<p></p>\n<p>Then no planning fee will be payable for this application.</p>",
+            policyRefs: [
+              {
+                text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 14",
+                url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/14",
+              },
+              {
+                text: "Regulation 4",
+                url: "https://www.legislation.gov.uk/uksi/2012/2920/regulation/4/made",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    schema: `https://theopensystemslab.github.io/digital-planning-data-schemas/${version}/schemas/prototypeApplication.json`,
+  },
+};

--- a/__tests__/lib/planningApplication/decision.test.ts
+++ b/__tests__/lib/planningApplication/decision.test.ts
@@ -1,8 +1,9 @@
 import {
   getApplicationDecisionSummary,
   getApplicationDecisionSummarySentiment,
+  getApplicationDprDecisionSummary,
 } from "@/lib/planningApplication";
-import { DprPlanningApplication } from "@/types";
+import { DprApplication, DprPlanningApplication } from "@/types";
 
 describe("getApplicationDecisionSummary", () => {
   it('should return "Prior approval required and approved" for prior approval application type and "granted" decision', () => {
@@ -88,5 +89,206 @@ describe("getApplicationDecisionSummarySentiment", () => {
     const status = "Unknown status";
     const result = getApplicationDecisionSummarySentiment(status);
     expect(result).toBeUndefined();
+  });
+});
+
+describe("getApplicationDprDecisionSummary", () => {
+  describe("getApplicationDprDecisionSummary with council decisions", () => {
+    it('should return "Granted" if priorApprovalRequired is undefined and councilDecision is granted ', () => {
+      const application = {
+        data: {
+          assessment: {
+            councilDecision: "granted",
+          },
+        },
+      };
+      const result = getApplicationDprDecisionSummary(
+        application as unknown as DprApplication,
+      );
+      expect(result).toBe("Granted");
+    });
+
+    it('should return "Refused" if priorApprovalRequired is undefined and councilDecision is refused ', () => {
+      const application = {
+        data: {
+          assessment: {
+            councilDecision: "refused",
+          },
+        },
+      };
+      const result = getApplicationDprDecisionSummary(
+        application as unknown as DprApplication,
+      );
+      expect(result).toBe("Refused");
+    });
+
+    it('should return "Prior approval required and approved" if priorApprovalRequired is true and councilDecision is granted ', () => {
+      const application = {
+        data: {
+          assessment: {
+            councilDecision: "granted",
+            priorApprovalRequired: true,
+          },
+        },
+      };
+      const result = getApplicationDprDecisionSummary(
+        application as unknown as DprApplication,
+      );
+      expect(result).toBe("Prior approval required and approved");
+    });
+
+    it('should return "Prior approval required and refused" if priorApprovalRequired is true and councilDecision is refused ', () => {
+      const application = {
+        data: {
+          assessment: {
+            councilDecision: "refused",
+            priorApprovalRequired: true,
+          },
+        },
+      };
+      const result = getApplicationDprDecisionSummary(
+        application as unknown as DprApplication,
+      );
+      expect(result).toBe("Prior approval required and refused");
+    });
+
+    it('should return "Prior approval not required" if priorApprovalRequired is false and councilDecision is granted ', () => {
+      const application = {
+        data: {
+          assessment: {
+            councilDecision: "granted",
+            priorApprovalRequired: false,
+          },
+        },
+      };
+      const result = getApplicationDprDecisionSummary(
+        application as unknown as DprApplication,
+      );
+      expect(result).toBe("Prior approval not required");
+    });
+
+    it('should return "Prior approval not required" if priorApprovalRequired is false and councilDecision is refused ', () => {
+      const application = {
+        data: {
+          assessment: {
+            councilDecision: "refused",
+            priorApprovalRequired: false,
+          },
+        },
+      };
+      const result = getApplicationDprDecisionSummary(
+        application as unknown as DprApplication,
+      );
+      expect(result).toBe("Prior approval not required");
+    });
+
+    it("should return undefined if no councilDecision is set", () => {
+      const application = {
+        data: {},
+      };
+      const result = getApplicationDprDecisionSummary(
+        application as unknown as DprApplication,
+      );
+      expect(result).toBeUndefined();
+    });
+  });
+  describe("getApplicationDprDecisionSummary with committee decisions", () => {
+    it('should return "Granted" if priorApprovalRequired is undefined and committeeDecision is granted ', () => {
+      const application = {
+        data: {
+          assessment: {
+            committeeDecision: "granted",
+          },
+        },
+      };
+      const result = getApplicationDprDecisionSummary(
+        application as unknown as DprApplication,
+      );
+      expect(result).toBe("Granted");
+    });
+
+    it('should return "Refused" if priorApprovalRequired is undefined and committeeDecision is refused ', () => {
+      const application = {
+        data: {
+          assessment: {
+            committeeDecision: "refused",
+          },
+        },
+      };
+      const result = getApplicationDprDecisionSummary(
+        application as unknown as DprApplication,
+      );
+      expect(result).toBe("Refused");
+    });
+
+    it('should return "Prior approval required and approved" if priorApprovalRequired is true and committeeDecision is granted ', () => {
+      const application = {
+        data: {
+          assessment: {
+            committeeDecision: "granted",
+            priorApprovalRequired: true,
+          },
+        },
+      };
+      const result = getApplicationDprDecisionSummary(
+        application as unknown as DprApplication,
+      );
+      expect(result).toBe("Prior approval required and approved");
+    });
+
+    it('should return "Prior approval required and refused" if priorApprovalRequired is true and committeeDecision is refused ', () => {
+      const application = {
+        data: {
+          assessment: {
+            committeeDecision: "refused",
+            priorApprovalRequired: true,
+          },
+        },
+      };
+      const result = getApplicationDprDecisionSummary(
+        application as unknown as DprApplication,
+      );
+      expect(result).toBe("Prior approval required and refused");
+    });
+
+    it('should return "Prior approval not required" if priorApprovalRequired is false and committeeDecision is granted ', () => {
+      const application = {
+        data: {
+          assessment: {
+            committeeDecision: "granted",
+            priorApprovalRequired: false,
+          },
+        },
+      };
+      const result = getApplicationDprDecisionSummary(
+        application as unknown as DprApplication,
+      );
+      expect(result).toBe("Prior approval not required");
+    });
+
+    it('should return "Prior approval not required" if priorApprovalRequired is false and committeeDecision is refused ', () => {
+      const application = {
+        data: {
+          assessment: {
+            committeeDecision: "refused",
+            priorApprovalRequired: false,
+          },
+        },
+      };
+      const result = getApplicationDprDecisionSummary(
+        application as unknown as DprApplication,
+      );
+      expect(result).toBe("Prior approval not required");
+    });
+
+    it("should return undefined if no committeeDecision is set", () => {
+      const application = {
+        data: {},
+      };
+      const result = getApplicationDprDecisionSummary(
+        application as unknown as DprApplication,
+      );
+      expect(result).toBeUndefined();
+    });
   });
 });

--- a/__tests__/lib/planningApplication/status.test.ts
+++ b/__tests__/lib/planningApplication/status.test.ts
@@ -1,9 +1,17 @@
 import {
+  getApplicationDprStatusSummary,
   getApplicationStatusSummary,
   getApplicationStatusSummarySentiment,
 } from "@/lib/planningApplication";
 import { DprPlanningApplication } from "@/types";
+import { PostSubmissionApplication } from "@/types/odp-types/schemas/postSubmissionApplication";
 import { formatDateToYmd } from "@/util";
+import {
+  generateAllPossibleDates,
+  generateMetadata,
+} from "@mocks/dprNewApplicationFactory";
+import { planningPermissionFullHouseholderPrototype } from "@mocks/odp-submission-data/planningPermission/fullHouseholder";
+import { format } from "path";
 
 describe("getApplicationStatusSummary", () => {
   describe("Assessment-related statuses", () => {
@@ -182,5 +190,812 @@ describe("getApplicationStatusSummarySentiment", () => {
     expect(
       getApplicationStatusSummarySentiment(undefined as any),
     ).toBeUndefined();
+  });
+});
+
+describe("getApplicationDprStatusSummary", () => {
+  it("should return Unknown for invalid status", () => {
+    const dates = generateAllPossibleDates();
+    const application: PostSubmissionApplication = {
+      applicationType: "pp.full.householder",
+      data: {
+        application: {
+          reference: "ABC-123-XYZ",
+          stage: "consultation",
+          status: "determined",
+        },
+        localPlanningAuthority: {
+          commentsAcceptedUntilDecision: false,
+        },
+        submission: {
+          submittedAt: dates.submission.submittedAt.toISOString(),
+        },
+        caseOfficer: {
+          name: "Casey Officer",
+        },
+      },
+      submission: planningPermissionFullHouseholderPrototype,
+      metadata: generateMetadata(dates),
+    };
+    const statusSummary = getApplicationDprStatusSummary(application);
+    expect(statusSummary).toBe("Unknown");
+  });
+
+  describe("Withdrawn status", () => {
+    it("should return Withdrawn if withdrawn date set", () => {
+      const dates = generateAllPossibleDates();
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "assessment",
+            status: "undetermined",
+            withdrawnAt: dates.application.withdrawnAt.toISOString(),
+            withdrawnReason: "No longer needed",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          validation: {
+            receivedAt: dates.validation.receivedAt.toISOString(),
+            validatedAt: dates.validation.validatedAt.toISOString(),
+            isValid: false,
+          },
+          consultation: {
+            startDate: formatDateToYmd(dates.consultation.startAt.toDate()),
+            endDate: formatDateToYmd(dates.consultation.endAt.toDate()),
+            siteNotice: true,
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Withdrawn");
+    });
+  });
+
+  describe("Application submitted status", () => {
+    it("should return Application submitted", () => {
+      const dates = generateAllPossibleDates();
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "submission",
+            status: "undetermined",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Application submitted");
+    });
+  });
+
+  describe("Application returned status", () => {
+    it("should return Application returned", () => {
+      const dates = generateAllPossibleDates();
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "validation",
+            status: "returned",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          validation: {
+            receivedAt: dates.validation.receivedAt.toISOString(),
+            validatedAt: dates.validation.validatedAt.toISOString(),
+            isValid: false,
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Application returned");
+    });
+  });
+
+  describe("Consultation in progress status", () => {
+    it("should return Consultation in progress if the current date is on the consultation start date", () => {
+      const dates = generateAllPossibleDates();
+      const today = new Date();
+      const startDate = formatDateToYmd(today);
+      // const startDate = formatDateToYmd(new Date(today.getTime() - 86400000));
+      const endDate = formatDateToYmd(new Date(today.getTime() + 86400000));
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "consultation",
+            status: "undetermined",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          validation: {
+            receivedAt: dates.validation.receivedAt.toISOString(),
+            validatedAt: dates.validation.validatedAt.toISOString(),
+            isValid: false,
+          },
+          consultation: {
+            startDate: startDate,
+            endDate: endDate,
+            siteNotice: true,
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Consultation in progress");
+    });
+
+    it("should return Consultation in progress if the current date is between the start date and end date", () => {
+      const dates = generateAllPossibleDates();
+      const today = new Date();
+      const startDate = formatDateToYmd(new Date(today.getTime() - 86400000));
+      const endDate = formatDateToYmd(new Date(today.getTime() + 86400000));
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "consultation",
+            status: "undetermined",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          validation: {
+            receivedAt: dates.validation.receivedAt.toISOString(),
+            validatedAt: dates.validation.validatedAt.toISOString(),
+            isValid: false,
+          },
+          consultation: {
+            startDate: startDate,
+            endDate: endDate,
+            siteNotice: true,
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Consultation in progress");
+    });
+
+    it("should return Assessment in progress if the current date is the before the consultation end date", () => {
+      const dates = generateAllPossibleDates();
+      const today = new Date();
+      const startDate = formatDateToYmd(new Date(today.getTime() - 86400000));
+      const endDate = formatDateToYmd(today);
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "consultation",
+            status: "undetermined",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          validation: {
+            receivedAt: dates.validation.receivedAt.toISOString(),
+            validatedAt: dates.validation.validatedAt.toISOString(),
+            isValid: false,
+          },
+          consultation: {
+            startDate: startDate,
+            endDate: endDate,
+            siteNotice: true,
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Assessment in progress");
+    });
+  });
+
+  describe("Determined & Assessment in progress status", () => {
+    it("should return Assessment in progress if no determination has been made yet", () => {
+      const dates = generateAllPossibleDates();
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "assessment",
+            status: "undetermined",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          validation: {
+            receivedAt: dates.validation.receivedAt.toISOString(),
+            validatedAt: dates.validation.validatedAt.toISOString(),
+            isValid: false,
+          },
+          consultation: {
+            startDate: formatDateToYmd(dates.consultation.startAt.toDate()),
+            endDate: formatDateToYmd(dates.consultation.endAt.toDate()),
+            siteNotice: true,
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Assessment in progress");
+    });
+
+    it("should return Assessment in progress if application is in committee", () => {
+      const dates = generateAllPossibleDates();
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "assessment",
+            status: "undetermined",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          validation: {
+            receivedAt: dates.validation.receivedAt.toISOString(),
+            validatedAt: dates.validation.validatedAt.toISOString(),
+            isValid: false,
+          },
+          consultation: {
+            startDate: formatDateToYmd(dates.consultation.startAt.toDate()),
+            endDate: formatDateToYmd(dates.consultation.endAt.toDate()),
+            siteNotice: true,
+          },
+          assessment: {
+            councilRecommendation: "refused",
+            committeeSentDate: formatDateToYmd(
+              dates.assessment.committeeSentAt.toDate(),
+            ),
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Assessment in progress");
+    });
+
+    it("should return Determined if application has a council decision", () => {
+      const dates = generateAllPossibleDates();
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "assessment",
+            status: "determined",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          validation: {
+            receivedAt: dates.validation.receivedAt.toISOString(),
+            validatedAt: dates.validation.validatedAt.toISOString(),
+            isValid: false,
+          },
+          consultation: {
+            startDate: formatDateToYmd(dates.consultation.startAt.toDate()),
+            endDate: formatDateToYmd(dates.consultation.endAt.toDate()),
+            siteNotice: true,
+          },
+          assessment: {
+            councilDecision: "granted",
+            councilDecisionDate: formatDateToYmd(
+              dates.assessment.councilDecisionAt.toDate(),
+            ),
+            decisionNotice: {
+              url: "https://planningregister.org",
+            },
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Determined");
+    });
+
+    it("should return Determined if application has a committee decision", () => {
+      const dates = generateAllPossibleDates();
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "assessment",
+            status: "determined",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          validation: {
+            receivedAt: dates.validation.receivedAt.toISOString(),
+            validatedAt: dates.validation.validatedAt.toISOString(),
+            isValid: false,
+          },
+          consultation: {
+            startDate: formatDateToYmd(dates.consultation.startAt.toDate()),
+            endDate: formatDateToYmd(dates.consultation.endAt.toDate()),
+            siteNotice: true,
+          },
+          assessment: {
+            councilRecommendation: "refused",
+            committeeSentDate: formatDateToYmd(
+              dates.assessment.committeeSentAt.toDate(),
+            ),
+            committeeDecision: "granted",
+            committeeDecisionDate: formatDateToYmd(
+              dates.assessment.committeeDecisionAt.toDate(),
+            ),
+            decisionNotice: {
+              url: "https://planningregister.org",
+            },
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Determined");
+    });
+
+    it("should return Assessment in progress if no council decision", () => {
+      const dates = generateAllPossibleDates();
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "assessment",
+            status: "determined",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          validation: {
+            receivedAt: dates.validation.receivedAt.toISOString(),
+            validatedAt: dates.validation.validatedAt.toISOString(),
+            isValid: false,
+          },
+          consultation: {
+            startDate: formatDateToYmd(dates.consultation.startAt.toDate()),
+            endDate: formatDateToYmd(dates.consultation.endAt.toDate()),
+            siteNotice: true,
+          },
+          assessment: {
+            councilDecisionDate: formatDateToYmd(
+              dates.assessment.councilDecisionAt.toDate(),
+            ),
+            decisionNotice: {
+              url: "https://planningregister.org",
+            },
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Assessment in progress");
+    });
+
+    it("should return Assessment in progress if no committee decision", () => {
+      const dates = generateAllPossibleDates();
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "assessment",
+            status: "determined",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          validation: {
+            receivedAt: dates.validation.receivedAt.toISOString(),
+            validatedAt: dates.validation.validatedAt.toISOString(),
+            isValid: false,
+          },
+          consultation: {
+            startDate: formatDateToYmd(dates.consultation.startAt.toDate()),
+            endDate: formatDateToYmd(dates.consultation.endAt.toDate()),
+            siteNotice: true,
+          },
+          assessment: {
+            councilRecommendation: "refused",
+            committeeSentDate: formatDateToYmd(
+              dates.assessment.committeeSentAt.toDate(),
+            ),
+            committeeDecisionDate: formatDateToYmd(
+              dates.assessment.committeeDecisionAt.toDate(),
+            ),
+            decisionNotice: {
+              url: "https://planningregister.org",
+            },
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Assessment in progress");
+    });
+  });
+
+  describe("Appeal status", () => {
+    it("should return Appeal lodged when appeal has been lodged", () => {
+      const dates = generateAllPossibleDates();
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "appeal",
+            status: "determined",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          validation: {
+            receivedAt: dates.validation.receivedAt.toISOString(),
+            validatedAt: dates.validation.validatedAt.toISOString(),
+            isValid: false,
+          },
+          consultation: {
+            startDate: formatDateToYmd(dates.consultation.startAt.toDate()),
+            endDate: formatDateToYmd(dates.consultation.endAt.toDate()),
+            siteNotice: true,
+          },
+          assessment: {
+            councilRecommendation: "refused",
+            committeeSentDate: formatDateToYmd(
+              dates.assessment.committeeSentAt.toDate(),
+            ),
+            committeeDecisionDate: formatDateToYmd(
+              dates.assessment.committeeDecisionAt.toDate(),
+            ),
+            decisionNotice: {
+              url: "https://planningregister.org",
+            },
+          },
+          appeal: {
+            lodgedDate: formatDateToYmd(dates.appeal.lodgedAt.toDate()),
+            reason: "The council's decision was unfair",
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Appeal lodged");
+    });
+
+    it("should return Appeal validated when appeal has been validated", () => {
+      const dates = generateAllPossibleDates();
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "appeal",
+            status: "determined",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          validation: {
+            receivedAt: dates.validation.receivedAt.toISOString(),
+            validatedAt: dates.validation.validatedAt.toISOString(),
+            isValid: false,
+          },
+          consultation: {
+            startDate: formatDateToYmd(dates.consultation.startAt.toDate()),
+            endDate: formatDateToYmd(dates.consultation.endAt.toDate()),
+            siteNotice: true,
+          },
+          assessment: {
+            councilRecommendation: "refused",
+            committeeSentDate: formatDateToYmd(
+              dates.assessment.committeeSentAt.toDate(),
+            ),
+            committeeDecisionDate: formatDateToYmd(
+              dates.assessment.committeeDecisionAt.toDate(),
+            ),
+            decisionNotice: {
+              url: "https://planningregister.org",
+            },
+          },
+          appeal: {
+            lodgedDate: formatDateToYmd(dates.appeal.lodgedAt.toDate()),
+            validatedDate: formatDateToYmd(dates.appeal.validatedAt.toDate()),
+            reason: "The council's decision was unfair",
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Appeal validated");
+    });
+
+    it("should return Appeal in progress when appeal has started", () => {
+      const dates = generateAllPossibleDates();
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "appeal",
+            status: "determined",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          validation: {
+            receivedAt: dates.validation.receivedAt.toISOString(),
+            validatedAt: dates.validation.validatedAt.toISOString(),
+            isValid: false,
+          },
+          consultation: {
+            startDate: formatDateToYmd(dates.consultation.startAt.toDate()),
+            endDate: formatDateToYmd(dates.consultation.endAt.toDate()),
+            siteNotice: true,
+          },
+          assessment: {
+            councilRecommendation: "refused",
+            committeeSentDate: formatDateToYmd(
+              dates.assessment.committeeSentAt.toDate(),
+            ),
+            committeeDecisionDate: formatDateToYmd(
+              dates.assessment.committeeDecisionAt.toDate(),
+            ),
+            decisionNotice: {
+              url: "https://planningregister.org",
+            },
+          },
+          appeal: {
+            lodgedDate: formatDateToYmd(dates.appeal.lodgedAt.toDate()),
+            validatedDate: formatDateToYmd(dates.appeal.validatedAt.toDate()),
+            startedDate: formatDateToYmd(dates.appeal.startedAt.toDate()),
+            reason: "The council's decision was unfair",
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Appeal in progress");
+    });
+
+    it("should return Appeal decided when appeal has been determined", () => {
+      const dates = generateAllPossibleDates();
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "appeal",
+            status: "determined",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          validation: {
+            receivedAt: dates.validation.receivedAt.toISOString(),
+            validatedAt: dates.validation.validatedAt.toISOString(),
+            isValid: false,
+          },
+          consultation: {
+            startDate: formatDateToYmd(dates.consultation.startAt.toDate()),
+            endDate: formatDateToYmd(dates.consultation.endAt.toDate()),
+            siteNotice: true,
+          },
+          assessment: {
+            councilRecommendation: "refused",
+            committeeSentDate: formatDateToYmd(
+              dates.assessment.committeeSentAt.toDate(),
+            ),
+            committeeDecisionDate: formatDateToYmd(
+              dates.assessment.committeeDecisionAt.toDate(),
+            ),
+            decisionNotice: {
+              url: "https://planningregister.org",
+            },
+          },
+          appeal: {
+            lodgedDate: formatDateToYmd(dates.appeal.lodgedAt.toDate()),
+            validatedDate: formatDateToYmd(dates.appeal.validatedAt.toDate()),
+            startedDate: formatDateToYmd(dates.appeal.startedAt.toDate()),
+            decisionDate: formatDateToYmd(dates.appeal.decidedAt.toDate()),
+            decision: "allowed",
+            reason: "The council's decision was unfair",
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Appeal decided");
+    });
+
+    it("should return Appeal withdrawn when appeal has been withdrawn", () => {
+      const dates = generateAllPossibleDates();
+      const application: PostSubmissionApplication = {
+        applicationType: "pp.full.householder",
+        data: {
+          application: {
+            reference: "ABC-123-XYZ",
+            stage: "appeal",
+            status: "determined",
+          },
+          localPlanningAuthority: {
+            commentsAcceptedUntilDecision: false,
+          },
+          submission: {
+            submittedAt: dates.submission.submittedAt.toISOString(),
+          },
+          validation: {
+            receivedAt: dates.validation.receivedAt.toISOString(),
+            validatedAt: dates.validation.validatedAt.toISOString(),
+            isValid: false,
+          },
+          consultation: {
+            startDate: formatDateToYmd(dates.consultation.startAt.toDate()),
+            endDate: formatDateToYmd(dates.consultation.endAt.toDate()),
+            siteNotice: true,
+          },
+          assessment: {
+            councilRecommendation: "refused",
+            committeeSentDate: formatDateToYmd(
+              dates.assessment.committeeSentAt.toDate(),
+            ),
+            committeeDecisionDate: formatDateToYmd(
+              dates.assessment.committeeDecisionAt.toDate(),
+            ),
+            decisionNotice: {
+              url: "https://planningregister.org",
+            },
+          },
+          appeal: {
+            lodgedDate: formatDateToYmd(dates.appeal.lodgedAt.toDate()),
+            validatedDate: formatDateToYmd(dates.appeal.validatedAt.toDate()),
+            startedDate: formatDateToYmd(dates.appeal.startedAt.toDate()),
+            withdrawnAt: formatDateToYmd(dates.appeal.withdrawnAt.toDate()),
+            withdrawnReason: "No longer needed",
+            decision: "allowed",
+            reason: "The council's decision was unfair",
+          },
+          caseOfficer: {
+            name: "Casey Officer",
+          },
+        },
+        submission: planningPermissionFullHouseholderPrototype,
+        metadata: generateMetadata(dates),
+      };
+      const statusSummary = getApplicationDprStatusSummary(application);
+      expect(statusSummary).toBe("Appeal withdrawn");
+    });
   });
 });

--- a/__tests__/mocks/dprNewApplicationFactory.test.ts
+++ b/__tests__/mocks/dprNewApplicationFactory.test.ts
@@ -1,0 +1,1635 @@
+import {
+  AssessmentBase,
+  PriorApprovalAssessment,
+} from "@/types/odp-types/schemas/postSubmissionApplication/data/Assessment";
+import { generateDprApplication } from "@mocks/dprNewApplicationFactory";
+import fs from "fs";
+import path from "path";
+
+function saveApplicationToJson(application: object, filePath: string): void {
+  const jsonData = JSON.stringify(application, null, 2);
+  fs.writeFileSync(filePath, jsonData, "utf-8");
+}
+
+describe("generateDprApplication", () => {
+  // 01 the application is submitted via planX into BOPS
+  it("Generates the correct structure for a post-submission application just after submission", () => {
+    const planningPermissionFullHouseholderSubmission = generateDprApplication({
+      applicationType: "pp.full.householder",
+      applicationStage: "submission",
+    });
+
+    // basic checks
+    expect(planningPermissionFullHouseholderSubmission.applicationType).toEqual(
+      "pp.full.householder",
+    );
+    expect(
+      planningPermissionFullHouseholderSubmission.metadata.publishedAt,
+    ).toBeDefined();
+    expect(
+      Object.values(planningPermissionFullHouseholderSubmission.submission)
+        .length,
+    ).toBeGreaterThan(0);
+
+    // application section checks
+    expect(
+      planningPermissionFullHouseholderSubmission.data.application.reference,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderSubmission.data.application.stage,
+    ).toEqual("submission");
+    expect(
+      planningPermissionFullHouseholderSubmission.data.application.status,
+    ).toEqual("undetermined");
+
+    // submission data checks
+    expect(
+      planningPermissionFullHouseholderSubmission.data.submission.submittedAt,
+    ).toBeDefined();
+
+    // validation data checks
+    expect(
+      planningPermissionFullHouseholderSubmission.data.validation,
+    ).toBeUndefined();
+
+    // consultation data checks
+    expect(
+      planningPermissionFullHouseholderSubmission.data.consultation,
+    ).toBeUndefined();
+
+    // assessment data checks
+    expect(
+      planningPermissionFullHouseholderSubmission.data.assessment,
+    ).toBeUndefined();
+
+    // appeal data checks
+    expect(
+      planningPermissionFullHouseholderSubmission.data.appeal,
+    ).toBeUndefined();
+  });
+
+  // 02 The application is validated in BOPS - it passes - so it goes straight to consultation/assessment depending on application type
+  it("Generates an error if we request a valid application still in the validation stage", () => {
+    expect(() => {
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        applicationStage: "validation",
+        applicationStatus: "undetermined",
+      });
+    }).toThrow(
+      "Invalid application stage (validation) and status (undetermined) - validated applications go straight to consultation or assessment",
+    );
+  });
+
+  // 02.01 The application is validated in BOPS - uhoh it fails so its now returned
+  it("Generates the correct structure for a post-submission application that has failed validation", () => {
+    const planningPermissionFullHouseholderValidationFail =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        applicationStage: "validation",
+        applicationStatus: "returned",
+      });
+
+    // basic checks
+    expect(
+      planningPermissionFullHouseholderValidationFail.applicationType,
+    ).toEqual("pp.full.householder");
+    expect(
+      planningPermissionFullHouseholderValidationFail.metadata.publishedAt,
+    ).toBeDefined();
+    expect(
+      Object.values(planningPermissionFullHouseholderValidationFail.submission)
+        .length,
+    ).toBeGreaterThan(0);
+
+    // application section checks
+    expect(
+      planningPermissionFullHouseholderValidationFail.data.application
+        .reference,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderValidationFail.data.application.stage,
+    ).toEqual("validation");
+    expect(
+      planningPermissionFullHouseholderValidationFail.data.application.status,
+    ).toEqual("returned");
+
+    // submission data checks
+    expect(
+      planningPermissionFullHouseholderValidationFail.data.submission
+        .submittedAt,
+    ).toBeDefined();
+
+    // validation data checks
+    expect(
+      planningPermissionFullHouseholderValidationFail.data.validation
+        ?.receivedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderValidationFail.data.validation
+        ?.validatedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderValidationFail.data.validation?.isValid,
+    ).toBe(false);
+
+    // consultation data checks
+    expect(
+      planningPermissionFullHouseholderValidationFail.data.consultation,
+    ).toBeUndefined();
+
+    // assessment data checks
+    expect(
+      planningPermissionFullHouseholderValidationFail.data.assessment,
+    ).toBeUndefined();
+
+    // appeal data checks
+    expect(
+      planningPermissionFullHouseholderValidationFail.data.appeal,
+    ).toBeUndefined();
+  });
+
+  // 03 Applications move immediately into consultation from validation except for those that don't have consultation stage (ldc) which go to assessment
+  it("Generates the correct structure for a valid post-submission that is in consultation", () => {
+    // throws an error for the wrong application type
+    expect(() => {
+      generateDprApplication({
+        applicationType: "ldc.proposed",
+        customStatus: "consultationInProgress",
+      });
+    }).toThrow(
+      "Invalid application stage (consultation) for application type ldc - this application type does not have a consultation stage",
+    );
+
+    const planningPermissionFullHouseholderConsultation =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "consultationInProgress",
+      });
+
+    // basic checks
+    expect(
+      planningPermissionFullHouseholderConsultation.applicationType,
+    ).toEqual("pp.full.householder");
+    expect(
+      planningPermissionFullHouseholderConsultation.metadata.publishedAt,
+    ).toBeDefined();
+    expect(
+      Object.values(planningPermissionFullHouseholderConsultation.submission)
+        .length,
+    ).toBeGreaterThan(0);
+
+    // application section checks
+    expect(
+      planningPermissionFullHouseholderConsultation.data.application.reference,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderConsultation.data.application.stage,
+    ).toEqual("consultation");
+    expect(
+      planningPermissionFullHouseholderConsultation.data.application.status,
+    ).toEqual("undetermined");
+
+    // submission data checks
+    expect(
+      planningPermissionFullHouseholderConsultation.data.submission.submittedAt,
+    ).toBeDefined();
+
+    // validation data checks
+    expect(
+      planningPermissionFullHouseholderConsultation.data.validation?.receivedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderConsultation.data.validation
+        ?.validatedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderConsultation.data.validation?.isValid,
+    ).toBe(true);
+
+    // consultation data checks
+    expect(
+      planningPermissionFullHouseholderConsultation.data.consultation
+        ?.startDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderConsultation.data.consultation?.endDate,
+    ).toBeDefined();
+
+    // assessment data checks
+    expect(
+      planningPermissionFullHouseholderConsultation.data.assessment,
+    ).toBeUndefined();
+
+    // appeal data checks
+    expect(
+      planningPermissionFullHouseholderConsultation.data.appeal,
+    ).toBeUndefined();
+  });
+
+  // 04 Applications now moves to assessment and comments are no longer allowed unless the council allows it until a decision is made (ldc)
+  it("Generates the correct structure for a valid post-submission that is in assessment", () => {
+    const planningPermissionFullHouseholderAssessmentInProgress =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "assessmentInProgress",
+      });
+
+    // basic checks
+    expect(
+      planningPermissionFullHouseholderAssessmentInProgress.applicationType,
+    ).toEqual("pp.full.householder");
+    expect(
+      planningPermissionFullHouseholderAssessmentInProgress.metadata
+        .publishedAt,
+    ).toBeDefined();
+    expect(
+      Object.values(
+        planningPermissionFullHouseholderAssessmentInProgress.submission,
+      ).length,
+    ).toBeGreaterThan(0);
+
+    // application section checks
+    expect(
+      planningPermissionFullHouseholderAssessmentInProgress.data.application
+        .reference,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentInProgress.data.application
+        .stage,
+    ).toEqual("assessment");
+    expect(
+      planningPermissionFullHouseholderAssessmentInProgress.data.application
+        .status,
+    ).toEqual("undetermined");
+
+    // submission data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentInProgress.data.submission
+        .submittedAt,
+    ).toBeDefined();
+
+    // validation data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentInProgress.data.validation
+        ?.receivedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentInProgress.data.validation
+        ?.validatedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentInProgress.data.validation
+        ?.isValid,
+    ).toBe(true);
+
+    // consultation data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentInProgress.data.consultation
+        ?.startDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentInProgress.data.consultation
+        ?.endDate,
+    ).toBeDefined();
+
+    // assessment data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentInProgress.data.assessment,
+    ).toBeUndefined();
+
+    // appeal data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentInProgress.data.appeal,
+    ).toBeUndefined();
+  });
+
+  // 04 01 council makes a decision on the application (comments are no longer allowed for those exempted per council)
+  it("Generates the correct structure for a valid post-submission that is council determined", () => {
+    const planningPermissionFullHouseholderAssessmentCouncilDetermined =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "assessmentCouncilDetermined",
+      });
+
+    // basic checks
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.applicationType,
+    ).toEqual("pp.full.householder");
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.metadata
+        .publishedAt,
+    ).toBeDefined();
+    expect(
+      Object.values(
+        planningPermissionFullHouseholderAssessmentCouncilDetermined.submission,
+      ).length,
+    ).toBeGreaterThan(0);
+
+    // application section checks
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .application.reference,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .application.stage,
+    ).toEqual("assessment");
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .application.status,
+    ).toEqual("determined");
+
+    // submission data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .submission.submittedAt,
+    ).toBeDefined();
+
+    // validation data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .validation?.receivedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .validation?.validatedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .validation?.isValid,
+    ).toBe(true);
+
+    // consultation data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .consultation?.startDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .consultation?.endDate,
+    ).toBeDefined();
+
+    // assessment data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .assessment?.councilDecision,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .assessment?.councilDecisionDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .assessment?.decisionNotice?.url,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .assessment?.councilRecommendation,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .assessment?.committeeSentDate,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .assessment?.committeeDecision,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .assessment?.committeeDecisionDate,
+    ).not.toBeDefined();
+    const ppAssessment =
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data
+        .assessment as any;
+    expect(ppAssessment.priorApprovalRequired).not.toBeDefined();
+
+    // appeal data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined.data.appeal,
+    ).toBeUndefined();
+
+    const PriorApprovalLargerExtensionAssessmentCouncilDetermined =
+      generateDprApplication({
+        applicationType: "pa.part1.classA",
+        customStatus: "assessmentCouncilDetermined",
+      });
+    const paAssessment = PriorApprovalLargerExtensionAssessmentCouncilDetermined
+      .data.assessment as PriorApprovalAssessment;
+    expect(paAssessment.priorApprovalRequired).toBeDefined();
+  });
+
+  // 04 02 Alternatively application goes to committee for a decision
+  it("Generates the correct structure for a valid post-submission that is being assessed by committee", () => {
+    const planningPermissionFullHouseholderAssessmentInCommittee =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "assessmentInCommittee",
+      });
+
+    // basic checks
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.applicationType,
+    ).toEqual("pp.full.householder");
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.metadata
+        .publishedAt,
+    ).toBeDefined();
+    expect(
+      Object.values(
+        planningPermissionFullHouseholderAssessmentInCommittee.submission,
+      ).length,
+    ).toBeGreaterThan(0);
+
+    // application section checks
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.application
+        .reference,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.application
+        .stage,
+    ).toEqual("assessment");
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.application
+        .status,
+    ).toEqual("undetermined");
+
+    // submission data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.submission
+        .submittedAt,
+    ).toBeDefined();
+
+    // validation data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.validation
+        ?.receivedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.validation
+        ?.validatedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.validation
+        ?.isValid,
+    ).toBe(true);
+
+    // consultation data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.consultation
+        ?.startDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.consultation
+        ?.endDate,
+    ).toBeDefined();
+
+    // assessment data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.assessment
+        ?.councilDecision,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.assessment
+        ?.councilDecisionDate,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.assessment
+        ?.decisionNotice?.url,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.assessment
+        ?.councilRecommendation,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.assessment
+        ?.committeeSentDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.assessment
+        ?.committeeDecision,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.assessment
+        ?.committeeDecisionDate,
+    ).not.toBeDefined();
+
+    // appeal data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentInCommittee.data.appeal,
+    ).toBeUndefined();
+  });
+
+  // 04 03 The committee then makes a decision
+  it("Generates the correct structure for a valid post-submission that is commitee determined", () => {
+    const planningPermissionFullHouseholderAssessmentCommitteeDetermined =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "assessmentCommitteeDetermined",
+      });
+
+    // basic checks
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.applicationType,
+    ).toEqual("pp.full.householder");
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.metadata
+        .publishedAt,
+    ).toBeDefined();
+    expect(
+      Object.values(
+        planningPermissionFullHouseholderAssessmentCommitteeDetermined.submission,
+      ).length,
+    ).toBeGreaterThan(0);
+
+    // application section checks
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .application.reference,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .application.stage,
+    ).toEqual("assessment");
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .application.status,
+    ).toEqual("determined");
+
+    // submission data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .submission.submittedAt,
+    ).toBeDefined();
+
+    // validation data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .validation?.receivedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .validation?.validatedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .validation?.isValid,
+    ).toBe(true);
+
+    // consultation data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .consultation?.startDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .consultation?.endDate,
+    ).toBeDefined();
+
+    // assessment data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .assessment?.councilDecision,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .assessment?.councilDecisionDate,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .assessment?.decisionNotice?.url,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .assessment?.councilRecommendation,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .assessment?.committeeSentDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .assessment?.committeeDecision,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .assessment?.committeeDecisionDate,
+    ).toBeDefined();
+
+    // appeal data checks
+    expect(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined.data
+        .appeal,
+    ).toBeUndefined();
+  });
+
+  // 05 Things can end before this but within 6 months of the decision a decision can be appealed
+  it("Generates the correct structure for a valid post-submission that has an appeal lodged", () => {
+    const planningPermissionFullHouseholderAppealLodged =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "appealLodged",
+      });
+    // basic checks
+    expect(
+      planningPermissionFullHouseholderAppealLodged.applicationType,
+    ).toEqual("pp.full.householder");
+    expect(
+      planningPermissionFullHouseholderAppealLodged.metadata.publishedAt,
+    ).toBeDefined();
+    expect(
+      Object.values(planningPermissionFullHouseholderAppealLodged.submission)
+        .length,
+    ).toBeGreaterThan(0);
+
+    // application section checks
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.application.reference,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.application.stage,
+    ).toEqual("appeal");
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.application.status,
+    ).toEqual("determined");
+
+    // submission data checks
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.submission.submittedAt,
+    ).toBeDefined();
+
+    // validation data checks
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.validation?.receivedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.validation
+        ?.validatedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.validation?.isValid,
+    ).toBe(true);
+
+    // consultation data checks
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.consultation
+        ?.startDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.consultation?.endDate,
+    ).toBeDefined();
+
+    // assessment data checks
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.assessment
+        ?.councilDecision,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.assessment
+        ?.councilDecisionDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.assessment
+        ?.decisionNotice?.url,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.assessment
+        ?.councilRecommendation,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.assessment
+        ?.committeeSentDate,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.assessment
+        ?.committeeDecision,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.assessment
+        ?.committeeDecisionDate,
+    ).not.toBeDefined();
+
+    // appeal data checks
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.appeal?.lodgedDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.appeal?.reason,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.appeal?.validatedDate,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.appeal?.startedDate,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.appeal?.decisionDate,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealLodged.data.appeal?.decision,
+    ).not.toBeDefined();
+  });
+
+  // 05 01 After the appeal starts its validated
+  it("Generates the correct structure for a valid post-submission that has a validated appeal lodged", () => {
+    const planningPermissionFullHouseholderAppealValidated =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "appealValidated",
+      });
+    // basic checks
+    expect(
+      planningPermissionFullHouseholderAppealValidated.applicationType,
+    ).toEqual("pp.full.householder");
+    expect(
+      planningPermissionFullHouseholderAppealValidated.metadata.publishedAt,
+    ).toBeDefined();
+    expect(
+      Object.values(planningPermissionFullHouseholderAppealValidated.submission)
+        .length,
+    ).toBeGreaterThan(0);
+
+    // application section checks
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.application
+        .reference,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.application.stage,
+    ).toEqual("appeal");
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.application.status,
+    ).toEqual("determined");
+
+    // submission data checks
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.submission
+        .submittedAt,
+    ).toBeDefined();
+
+    // validation data checks
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.validation
+        ?.receivedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.validation
+        ?.validatedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.validation?.isValid,
+    ).toBe(true);
+
+    // consultation data checks
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.consultation
+        ?.startDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.consultation
+        ?.endDate,
+    ).toBeDefined();
+
+    // assessment data checks
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.assessment
+        ?.councilDecision,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.assessment
+        ?.councilDecisionDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.assessment
+        ?.decisionNotice?.url,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.assessment
+        ?.councilRecommendation,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.assessment
+        ?.committeeSentDate,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.assessment
+        ?.committeeDecision,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.assessment
+        ?.committeeDecisionDate,
+    ).not.toBeDefined();
+
+    // appeal data checks
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.appeal?.lodgedDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.appeal?.reason,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.appeal
+        ?.validatedDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.appeal?.startedDate,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.appeal
+        ?.decisionDate,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealValidated.data.appeal?.decision,
+    ).not.toBeDefined();
+  });
+
+  // 05 02 Then it starts
+  it("Generates the correct structure for a valid post-submission that has a validated appeal in progress", () => {
+    const planningPermissionFullHouseholderAppealStarted =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "appealStarted",
+      });
+    // basic checks
+    expect(
+      planningPermissionFullHouseholderAppealStarted.applicationType,
+    ).toEqual("pp.full.householder");
+    expect(
+      planningPermissionFullHouseholderAppealStarted.metadata.publishedAt,
+    ).toBeDefined();
+    expect(
+      Object.values(planningPermissionFullHouseholderAppealStarted.submission)
+        .length,
+    ).toBeGreaterThan(0);
+
+    // application section checks
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.application.reference,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.application.stage,
+    ).toEqual("appeal");
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.application.status,
+    ).toEqual("determined");
+
+    // submission data checks
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.submission
+        .submittedAt,
+    ).toBeDefined();
+
+    // validation data checks
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.validation
+        ?.receivedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.validation
+        ?.validatedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.validation?.isValid,
+    ).toBe(true);
+
+    // consultation data checks
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.consultation
+        ?.startDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.consultation?.endDate,
+    ).toBeDefined();
+
+    // assessment data checks
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.assessment
+        ?.councilDecision,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.assessment
+        ?.councilDecisionDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.assessment
+        ?.decisionNotice?.url,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.assessment
+        ?.councilRecommendation,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.assessment
+        ?.committeeSentDate,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.assessment
+        ?.committeeDecision,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.assessment
+        ?.committeeDecisionDate,
+    ).not.toBeDefined();
+
+    // appeal data checks
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.appeal?.lodgedDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.appeal?.reason,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.appeal?.validatedDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.appeal?.startedDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.appeal?.decisionDate,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealStarted.data.appeal?.decision,
+    ).not.toBeDefined();
+  });
+
+  // 05 03 and a decision is made by the appeal
+  it("Generates the correct structure for a valid post-submission that has a validated appeal decision", () => {
+    const planningPermissionFullHouseholderAppealDetermined =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "appealDetermined",
+      });
+    // basic checks
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.applicationType,
+    ).toEqual("pp.full.householder");
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.metadata.publishedAt,
+    ).toBeDefined();
+    expect(
+      Object.values(
+        planningPermissionFullHouseholderAppealDetermined.submission,
+      ).length,
+    ).toBeGreaterThan(0);
+
+    // application section checks
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.application
+        .reference,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.application.stage,
+    ).toEqual("appeal");
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.application.status,
+    ).toEqual("determined");
+
+    // submission data checks
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.submission
+        .submittedAt,
+    ).toBeDefined();
+
+    // validation data checks
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.validation
+        ?.receivedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.validation
+        ?.validatedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.validation
+        ?.isValid,
+    ).toBe(true);
+
+    // consultation data checks
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.consultation
+        ?.startDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.consultation
+        ?.endDate,
+    ).toBeDefined();
+
+    // assessment data checks
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.assessment
+        ?.councilDecision,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.assessment
+        ?.councilDecisionDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.assessment
+        ?.decisionNotice?.url,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.assessment
+        ?.councilRecommendation,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.assessment
+        ?.committeeSentDate,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.assessment
+        ?.committeeDecision,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.assessment
+        ?.committeeDecisionDate,
+    ).not.toBeDefined();
+
+    // appeal data checks
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.appeal?.lodgedDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.appeal?.reason,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.appeal
+        ?.validatedDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.appeal
+        ?.startedDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.appeal
+        ?.decisionDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealDetermined.data.appeal?.decision,
+    ).toBeDefined();
+  });
+
+  // 05 04 appeal is withdrawn
+  it("Generates the correct structure for a valid post-submission that has a withdrawn appeal decision", () => {
+    const planningPermissionFullHouseholderAppealWithdrawn =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "appealWithdrawn",
+      });
+    // basic checks
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.applicationType,
+    ).toEqual("pp.full.householder");
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.metadata.publishedAt,
+    ).toBeDefined();
+    expect(
+      Object.values(planningPermissionFullHouseholderAppealWithdrawn.submission)
+        .length,
+    ).toBeGreaterThan(0);
+
+    // application section checks
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.application
+        .reference,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.application.stage,
+    ).toEqual("appeal");
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.application.status,
+    ).toEqual("determined");
+
+    // submission data checks
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.submission
+        .submittedAt,
+    ).toBeDefined();
+
+    // validation data checks
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.validation
+        ?.receivedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.validation
+        ?.validatedAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.validation?.isValid,
+    ).toBe(true);
+
+    // consultation data checks
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.consultation
+        ?.startDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.consultation
+        ?.endDate,
+    ).toBeDefined();
+
+    // assessment data checks
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.assessment
+        ?.councilDecision,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.assessment
+        ?.councilDecisionDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.assessment
+        ?.decisionNotice?.url,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.assessment
+        ?.councilRecommendation,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.assessment
+        ?.committeeSentDate,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.assessment
+        ?.committeeDecision,
+    ).not.toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.assessment
+        ?.committeeDecisionDate,
+    ).not.toBeDefined();
+
+    // appeal data checks
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.appeal?.lodgedDate,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.appeal?.reason,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.appeal?.withdrawnAt,
+    ).toBeDefined();
+    expect(
+      planningPermissionFullHouseholderAppealWithdrawn.data.appeal
+        ?.withdrawnReason,
+    ).toBeDefined();
+  });
+
+  it("Certain application types don't have consultation phases", () => {
+    const lawfulDevelopmentCertificateProposedAssessmentCouncilDetermined =
+      generateDprApplication({
+        applicationType: "ldc.proposed",
+        customStatus: "assessmentCouncilDetermined",
+      });
+    expect(
+      lawfulDevelopmentCertificateProposedAssessmentCouncilDetermined.data
+        .consultation,
+    ).toBeUndefined();
+  });
+
+  it("Certain local authorities allow comments until the decision is made", () => {
+    const planningPermissionFullHouseholderAssessmentInProgress =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "assessmentInProgress",
+      });
+    expect(
+      planningPermissionFullHouseholderAssessmentInProgress.data
+        .localPlanningAuthority.commentsAcceptedUntilDecision,
+    ).toBe(false);
+
+    const lawfulDevelopmentCertificateProposedAssessmentInProgress =
+      generateDprApplication({
+        applicationType: "ldc.proposed",
+        customStatus: "assessmentInProgress",
+      });
+
+    expect(
+      lawfulDevelopmentCertificateProposedAssessmentInProgress.data
+        .localPlanningAuthority.commentsAcceptedUntilDecision,
+    ).toBe(true);
+  });
+
+  it.skip("Generates valid JSON files", () => {
+    // 01 the application is submitted via planX into BOPS
+
+    const planningPermissionFullHouseholderSubmission = generateDprApplication({
+      applicationType: "pp.full.householder",
+      applicationStage: "submission",
+    });
+    saveApplicationToJson(
+      planningPermissionFullHouseholderSubmission,
+      path.join(__dirname, "fullHouseholder-01-submission.json"),
+    );
+
+    const PriorApprovalLargerExtensionSubmission = generateDprApplication({
+      applicationType: "pa.part1.classA",
+      applicationStage: "submission",
+    });
+    saveApplicationToJson(
+      PriorApprovalLargerExtensionSubmission,
+      path.join(__dirname, "largerExtension-01-submission.json"),
+    );
+
+    const lawfulDevelopmentCertificateProposedSubmission =
+      generateDprApplication({
+        applicationType: "ldc.proposed",
+        applicationStage: "submission",
+      });
+    saveApplicationToJson(
+      lawfulDevelopmentCertificateProposedSubmission,
+      path.join(__dirname, "proposed-01-submission.json"),
+    );
+
+    // 02 The application is validated in BOPS - it passes - so it goes straight to consultation/assessment depending on application type
+    // 02.01 The application is validated in BOPS - uhoh it fails so its now returned
+
+    const planningPermissionFullHouseholderValidationFail =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        applicationStage: "validation",
+        applicationStatus: "returned",
+      });
+    saveApplicationToJson(
+      planningPermissionFullHouseholderValidationFail,
+      path.join(__dirname, "fullHouseholder-02-validation-01-invalid.json"),
+    );
+
+    const PriorApprovalLargerExtensionValidationFail = generateDprApplication({
+      applicationType: "pa.part1.classA",
+      applicationStage: "validation",
+      applicationStatus: "returned",
+    });
+    saveApplicationToJson(
+      PriorApprovalLargerExtensionValidationFail,
+      path.join(__dirname, "largerExtension-02-validation-01-invalid.json"),
+    );
+
+    const lawfulDevelopmentCertificateProposedValidationFail =
+      generateDprApplication({
+        applicationType: "ldc.proposed",
+        applicationStage: "validation",
+        applicationStatus: "returned",
+      });
+    saveApplicationToJson(
+      lawfulDevelopmentCertificateProposedValidationFail,
+      path.join(__dirname, "proposed-02-validation-01-invalid.json"),
+    );
+
+    // 03 Applications move immediately into consultation from validation except for those that don't have consultation stage (ldc) which go to assessment
+
+    const planningPermissionFullHouseholderConsultation =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "consultationInProgress",
+      });
+    saveApplicationToJson(
+      planningPermissionFullHouseholderConsultation,
+      path.join(__dirname, "fullHouseholder-03-consultation.json"),
+    );
+
+    const PriorApprovalLargerExtensionConsultation = generateDprApplication({
+      applicationType: "pa.part1.classA",
+      customStatus: "consultationInProgress",
+    });
+    saveApplicationToJson(
+      PriorApprovalLargerExtensionConsultation,
+      path.join(__dirname, "largerExtension-03-consultation.json"),
+    );
+
+    // 04 Applications now moves to assessment and comments are no longer allowed unless the council allows it until a decision is made (ldc)
+
+    const planningPermissionFullHouseholderAssessmentInProgress =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "assessmentInProgress",
+      });
+    saveApplicationToJson(
+      planningPermissionFullHouseholderAssessmentInProgress,
+      path.join(
+        __dirname,
+        "fullHouseholder-04-assessment-00-assessment-in-progress.json",
+      ),
+    );
+
+    const PriorApprovalLargerExtensionAssessmentInProgress =
+      generateDprApplication({
+        applicationType: "pa.part1.classA",
+        customStatus: "assessmentInProgress",
+      });
+    saveApplicationToJson(
+      PriorApprovalLargerExtensionAssessmentInProgress,
+      path.join(
+        __dirname,
+        "largerExtension-04-assessment-00-assessment-in-progress.json",
+      ),
+    );
+
+    const lawfulDevelopmentCertificateProposedAssessmentInProgress =
+      generateDprApplication({
+        applicationType: "ldc.proposed",
+        customStatus: "assessmentInProgress",
+      });
+    saveApplicationToJson(
+      lawfulDevelopmentCertificateProposedAssessmentInProgress,
+      path.join(
+        __dirname,
+        "proposed-04-assessment-00-assessment-in-progress.json",
+      ),
+    );
+
+    // 04 01 council makes a decision on the application (comments are no longer allowed for those exempted per council)
+
+    const planningPermissionFullHouseholderAssessmentCouncilDetermined =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "assessmentCouncilDetermined",
+      });
+    saveApplicationToJson(
+      planningPermissionFullHouseholderAssessmentCouncilDetermined,
+      path.join(
+        __dirname,
+        "fullHouseholder-04-assessment-01-council-determined.json",
+      ),
+    );
+
+    const PriorApprovalLargerExtensionAssessmentCouncilDetermined =
+      generateDprApplication({
+        applicationType: "pa.part1.classA",
+        customStatus: "assessmentCouncilDetermined",
+      });
+    saveApplicationToJson(
+      PriorApprovalLargerExtensionAssessmentCouncilDetermined,
+      path.join(
+        __dirname,
+        "largerExtension-04-assessment-01-council-determined.json",
+      ),
+    );
+
+    const lawfulDevelopmentCertificateProposedAssessmentCouncilDetermined =
+      generateDprApplication({
+        applicationType: "ldc.proposed",
+        customStatus: "assessmentCouncilDetermined",
+      });
+    saveApplicationToJson(
+      lawfulDevelopmentCertificateProposedAssessmentCouncilDetermined,
+      path.join(__dirname, "proposed-04-assessment-01-council-determined.json"),
+    );
+
+    // 04 02 Alternatively application goes to committee for a decision
+
+    const planningPermissionFullHouseholderAssessmentInCommittee =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "assessmentInCommittee",
+      });
+    saveApplicationToJson(
+      planningPermissionFullHouseholderAssessmentInCommittee,
+      path.join(
+        __dirname,
+        "fullHouseholder-04-assessment-02-assessment-in-committee.json",
+      ),
+    );
+
+    const PriorApprovalLargerExtensionAssessmentInCommittee =
+      generateDprApplication({
+        applicationType: "pa.part1.classA",
+        customStatus: "assessmentInCommittee",
+      });
+    saveApplicationToJson(
+      PriorApprovalLargerExtensionAssessmentInCommittee,
+      path.join(
+        __dirname,
+        "largerExtension-04-assessment-02-assessment-in-committee.json",
+      ),
+    );
+
+    const lawfulDevelopmentCertificateProposedAssessmentInCommittee =
+      generateDprApplication({
+        applicationType: "ldc.proposed",
+        customStatus: "assessmentInCommittee",
+      });
+    saveApplicationToJson(
+      lawfulDevelopmentCertificateProposedAssessmentInCommittee,
+      path.join(
+        __dirname,
+        "proposed-04-assessment-02-assessment-in-committee.json",
+      ),
+    );
+
+    // 04 03 The committee then makes a decision
+    const planningPermissionFullHouseholderAssessmentCommitteeDetermined =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "assessmentCommitteeDetermined",
+      });
+    saveApplicationToJson(
+      planningPermissionFullHouseholderAssessmentCommitteeDetermined,
+      path.join(
+        __dirname,
+        "fullHouseholder-04-assessment-03-committee-determined.json",
+      ),
+    );
+
+    const PriorApprovalLargerExtensionAssessmentCommitteeDetermined =
+      generateDprApplication({
+        applicationType: "pa.part1.classA",
+        customStatus: "assessmentCommitteeDetermined",
+      });
+    saveApplicationToJson(
+      PriorApprovalLargerExtensionAssessmentCommitteeDetermined,
+      path.join(
+        __dirname,
+        "largerExtension-04-assessment-03-committee-determined.json",
+      ),
+    );
+
+    const lawfulDevelopmentCertificateProposedAssessmentCommitteeDetermined =
+      generateDprApplication({
+        applicationType: "ldc.proposed",
+        customStatus: "assessmentCommitteeDetermined",
+      });
+    saveApplicationToJson(
+      lawfulDevelopmentCertificateProposedAssessmentCommitteeDetermined,
+      path.join(
+        __dirname,
+        "proposed-04-assessment-03-committee-determined.json",
+      ),
+    );
+
+    // 05 Things can end before this but within 6 months of the decision a decision can be appealed
+
+    const planningPermissionFullHouseholderAppealLodged =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "appealLodged",
+      });
+    saveApplicationToJson(
+      planningPermissionFullHouseholderAppealLodged,
+      path.join(__dirname, "fullHouseholder-05-appeal-00-appeal-lodged.json"),
+    );
+
+    const PriorApprovalLargerExtensionAppealLodged = generateDprApplication({
+      applicationType: "pa.part1.classA",
+      customStatus: "appealLodged",
+    });
+    saveApplicationToJson(
+      PriorApprovalLargerExtensionAppealLodged,
+      path.join(__dirname, "largerExtension-05-appeal-00-appeal-lodged.json"),
+    );
+
+    const lawfulDevelopmentCertificateProposedAppealLodged =
+      generateDprApplication({
+        applicationType: "ldc.proposed",
+        customStatus: "appealLodged",
+      });
+    saveApplicationToJson(
+      lawfulDevelopmentCertificateProposedAppealLodged,
+      path.join(__dirname, "proposed-05-appeal-00-appeal-lodged.json"),
+    );
+
+    // 05 01 After the appeal starts its validated
+
+    const planningPermissionFullHouseholderAppealValidated =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "appealValidated",
+      });
+    saveApplicationToJson(
+      planningPermissionFullHouseholderAppealValidated,
+      path.join(
+        __dirname,
+        "fullHouseholder-05-appeal-01-appeal-validated.json",
+      ),
+    );
+
+    const PriorApprovalLargerExtensionAppealValidated = generateDprApplication({
+      applicationType: "pa.part1.classA",
+      customStatus: "appealValidated",
+    });
+    saveApplicationToJson(
+      PriorApprovalLargerExtensionAppealValidated,
+      path.join(
+        __dirname,
+        "largerExtension-05-appeal-01-appeal-validated.json",
+      ),
+    );
+
+    const lawfulDevelopmentCertificateProposedAppealValidated =
+      generateDprApplication({
+        applicationType: "ldc.proposed",
+        customStatus: "appealValidated",
+      });
+    saveApplicationToJson(
+      lawfulDevelopmentCertificateProposedAppealValidated,
+      path.join(__dirname, "proposed-05-appeal-01-appeal-validated.json"),
+    );
+
+    // 05 02 Then it starts
+
+    const planningPermissionFullHouseholderAppealStarted =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "appealStarted",
+      });
+    saveApplicationToJson(
+      planningPermissionFullHouseholderAppealStarted,
+      path.join(__dirname, "fullHouseholder-05-appeal-02-appeal-started.json"),
+    );
+
+    const PriorApprovalLargerExtensionAppealStarted = generateDprApplication({
+      applicationType: "pa.part1.classA",
+      customStatus: "appealStarted",
+    });
+    saveApplicationToJson(
+      PriorApprovalLargerExtensionAppealStarted,
+      path.join(__dirname, "largerExtension-05-appeal-02-appeal-started.json"),
+    );
+
+    const lawfulDevelopmentCertificateProposedAppealStarted =
+      generateDprApplication({
+        applicationType: "ldc.proposed",
+        customStatus: "appealStarted",
+      });
+    saveApplicationToJson(
+      lawfulDevelopmentCertificateProposedAppealStarted,
+      path.join(__dirname, "proposed-05-appeal-02-appeal-started.json"),
+    );
+
+    // 05 03 and a decision is made by the appeal
+
+    const planningPermissionFullHouseholderAppealDetermined =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "appealDetermined",
+      });
+    saveApplicationToJson(
+      planningPermissionFullHouseholderAppealDetermined,
+      path.join(
+        __dirname,
+        "fullHouseholder-05-appeal-03-appeal-determined.json",
+      ),
+    );
+
+    const PriorApprovalLargerExtensionAppealDetermined = generateDprApplication(
+      {
+        applicationType: "pa.part1.classA",
+        customStatus: "appealDetermined",
+      },
+    );
+    saveApplicationToJson(
+      PriorApprovalLargerExtensionAppealDetermined,
+      path.join(
+        __dirname,
+        "largerExtension-05-appeal-03-appeal-determined.json",
+      ),
+    );
+
+    const lawfulDevelopmentCertificateProposedAppealDetermined =
+      generateDprApplication({
+        applicationType: "ldc.proposed",
+        customStatus: "appealDetermined",
+      });
+    saveApplicationToJson(
+      lawfulDevelopmentCertificateProposedAppealDetermined,
+      path.join(__dirname, "proposed-05-appeal-03-appeal-determined.json"),
+    );
+
+    // 05 04 appeal is withdrawn
+
+    const planningPermissionFullHouseholderAppealWithdrawn =
+      generateDprApplication({
+        applicationType: "pp.full.householder",
+        customStatus: "appealWithdrawn",
+      });
+    saveApplicationToJson(
+      planningPermissionFullHouseholderAppealWithdrawn,
+      path.join(
+        __dirname,
+        "fullHouseholder-05-appeal-04-appeal-withdrawn.json",
+      ),
+    );
+
+    const PriorApprovalLargerExtensionAppealWithdrawn = generateDprApplication({
+      applicationType: "pa.part1.classA",
+      customStatus: "appealWithdrawn",
+    });
+    saveApplicationToJson(
+      PriorApprovalLargerExtensionAppealWithdrawn,
+      path.join(
+        __dirname,
+        "largerExtension-05-appeal-04-appeal-withdrawn.json",
+      ),
+    );
+
+    const lawfulDevelopmentCertificateProposedAppealWithdrawn =
+      generateDprApplication({
+        applicationType: "ldc.proposed",
+        customStatus: "appealWithdrawn",
+      });
+    saveApplicationToJson(
+      lawfulDevelopmentCertificateProposedAppealWithdrawn,
+      path.join(__dirname, "proposed-05-appeal-04-appeal-withdrawn.json"),
+    );
+  });
+});

--- a/src/types/definitions.d.ts
+++ b/src/types/definitions.d.ts
@@ -11,6 +11,25 @@
 import { Applicant } from "@/types/odp-types/schemas/prototypeApplication/data/Applicant";
 import { ApplicationType } from "@/types/odp-types/schemas/prototypeApplication/enums/ApplicationType.ts";
 import { GeoBoundary } from "@/types/odp-types/shared/Boundaries";
+import { PostSubmissionApplication } from "@/types/odp-types/schemas/postSubmissionApplication/index";
+import { DprStatusSummary, DprDecisionSummary } from "@/types";
+
+/**
+ *
+ *
+ *
+ * DprApplication
+ * the most important object, contains all the information about a planning application
+ *
+ * NB this will need to be changes to PublishedApplication when the redacted version is made
+ * NB this doesn't exclude email address etc yet that will be done through the redacted application submission schema
+ *
+ *
+ */
+export type DprApplication = PostSubmissionApplication & {
+  applicationStatusSummary: DprStatusSummary;
+  applicationDecisionSummary?: DprDecisionSummary;
+};
 
 /**
  *

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,3 +1,5 @@
+import { AssessmentDecision } from "@/types/odp-types/schemas/postSubmissionApplication/enums/AssessmentDecision";
+
 /**
  * This file contains the definitions for common objects used accross the application
  *
@@ -5,6 +7,8 @@
  * DprPagination - the object that describes the pagination of a list of objects
  * SearchParams - common object to represent search parameters
  * Documentation - common object to represent documentation for a handler
+ * DprStatusSummary - the dpr version of the application status
+ * DprDecisionSummary - the dpr version of the decision summary
  */
 
 /**
@@ -97,3 +101,44 @@ export interface Documentation {
   }[];
   source?: string[];
 }
+
+/**
+ *
+ *
+ *
+ * DprStatusSummary
+ * the dpr version of the application status
+ *
+ *
+ *
+ */
+export type DprStatusSummary =
+  | "Application submitted"
+  | "Application returned"
+  | "Consultation in progress"
+  | "Assessment in progress"
+  | "Determined"
+  | "Withdrawn"
+  | "Appeal lodged"
+  | "Appeal validated"
+  | "Appeal in progress"
+  | "Appeal decided"
+  | "Appeal withdrawn"
+  | "Unknown";
+
+/**
+ *
+ *
+ *
+ * DprDecisionSummary
+ * the dpr version of the decision summary
+ *
+ *
+ *
+ */
+type DprPriorApprovalDecision =
+  | "Prior approval required and approved"
+  | "Prior approval not required"
+  | "Prior approval required and refused";
+
+export type DprDecisionSummary = AssessmentDecision | DprPriorApprovalDecision;


### PR DESCRIPTION
Now that we've proposed the postSubmission schema this PR updates our mocks to allow generating (hopefully) valid example applications to enable the future tickets we have coming!

It also includes new types to represent our internal status' and new methods to generate them.

* adds `generateDprApplication` to generate applications, they can be random or defined it uses some example json from the ODP repo as the submission data
* adds a **lot** of tests to ensure they are valid examples!
* Includes some additional code to generate example json which I used for the ODP schema examples, I've left this in for now as I think we will find it useful when we're working in bops
* adds `getApplicationDprDecisionSummary` method which will return the new `DprDecisionSummary` type based on the new schema
* adds `getApplicationDprStatusSummary` method which will return the new `DprStatusSummary` type based on the new schema

