### PR TITLE
Bug fix: variable and type with same name in ApiV1

### DIFF
--- a/src/actions/api/v1/search.ts
+++ b/src/actions/api/v1/search.ts
@@ -14,7 +14,7 @@ import { apiReturnError } from "@/handlers/lib";
 export async function search(
   source: string,
   council: string,
-  SearchParams?: SearchParams,
+  searchParams?: SearchParams,
 ): Promise<ApiResponse<DprSearchApiResponse | null>> {
   if (!council) {
     return apiReturnError("Council is required");
@@ -22,9 +22,9 @@ export async function search(
 
   switch (source) {
     case "bops":
-      return await BopsV2.search(council, SearchParams);
+      return await BopsV2.search(council, searchParams);
     case "local":
-      return await LocalV1.search(SearchParams);
+      return await LocalV1.search(searchParams);
     default:
       return apiReturnError("Invalid source");
   }


### PR DESCRIPTION
**Fix typo**
This typo has been bugging me forever, thankfully we've not been caught out by it yet!
`src/actions/api/v1/search.ts` had `SearchParams` as a prop and `SearchParams` as a type so we had `SearchParams?: SearchParams` 🤦‍♀️

