### PR TITLE
Lint fix: Remove `any` type from documentation files

### DIFF
--- a/src/actions/api/v1/applicationSubmission.documentation.tsx
+++ b/src/actions/api/v1/applicationSubmission.documentation.tsx
@@ -23,7 +23,7 @@ export const documentation: Documentation = {
   file: `src/actions/api/v1/applicationSubmission.ts`,
   description: "applicationSubmission",
   arguments: ["source", "council", "reference"],
-  run: async (args: [any, any, any]) => {
+  run: async (args: [string, string, string]) => {
     return await applicationSubmission(...args);
   },
   examples: [

--- a/src/actions/api/v1/documents.documentation.tsx
+++ b/src/actions/api/v1/documents.documentation.tsx
@@ -23,7 +23,7 @@ export const documentation: Documentation = {
   file: `src/actions/api/v1/documents.ts`,
   description: "documents",
   arguments: ["source", "council", "reference"],
-  run: async (args: [any, any, any]) => {
+  run: async (args: [string, string, string]) => {
     return await documents(...args);
   },
   examples: [

--- a/src/actions/api/v1/postComment.documentation.tsx
+++ b/src/actions/api/v1/postComment.documentation.tsx
@@ -23,7 +23,7 @@ export const documentation: Documentation = {
   file: `src/actions/api/v1/postComment.ts`,
   description: "Post a comment to BOPS",
   arguments: ["source", "council", "applicationId"],
-  run: async (args: [any, any, any, any]) => {
+  run: async (args: [string, string, string, object]) => {
     return await postComment(...args);
   },
   examples: [

--- a/src/actions/api/v1/search.documentation.tsx
+++ b/src/actions/api/v1/search.documentation.tsx
@@ -14,8 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
-
-import { Documentation } from "@/types";
+import { Documentation, SearchParams } from "@/types";
 import { search } from "./search";
 
 export const documentation: Documentation = {
@@ -23,8 +22,8 @@ export const documentation: Documentation = {
   file: `src/actions/api/v1/search.ts`,
   description: "getPlanningApplications",
   arguments: ["source", "council", "page", "resultsPerPage", "searchQuery"],
-  run: async (args: [any, any, any, any, any]) => {
-    const searchObj = {
+  run: async (args: [string, string, number, number, string]) => {
+    const searchObj: SearchParams = {
       page: args[2],
       resultsPerPage: args[3],
       query: args[4],

--- a/src/actions/api/v1/show.documentation.tsx
+++ b/src/actions/api/v1/show.documentation.tsx
@@ -23,7 +23,7 @@ export const documentation: Documentation = {
   file: `src/actions/api/v1/show.ts`,
   description: "show",
   arguments: ["source", "council", "reference"],
-  run: async (args: [any, any, any]) => {
+  run: async (args: [string, string, string]) => {
     return await show(...args);
   },
   examples: [

--- a/src/app/docs/json/route.ts
+++ b/src/app/docs/json/route.ts
@@ -24,8 +24,9 @@ import { NextResponse, NextRequest } from "next/server";
 import { LocalV1Documentation } from "@/handlers/local";
 import { BopsV2Documentation } from "@/handlers/bops";
 import { ApiV1Documentation } from "@/actions/api/v1";
+import { Documentation } from "@/types";
 
-const apis: Record<string, any> = {
+const apis: Record<string, Record<string, Documentation>> = {
   ApiV1: {
     ...ApiV1Documentation,
   },
@@ -37,7 +38,7 @@ const apis: Record<string, any> = {
   },
 };
 
-const getResponse = async (searchParams: URLSearchParams, body?: any) => {
+const getResponse = async (searchParams: URLSearchParams, body?: string) => {
   const handler = searchParams.get("handler");
   const method = searchParams.get("method");
   let response;
@@ -56,7 +57,7 @@ const getResponse = async (searchParams: URLSearchParams, body?: any) => {
     let args = handlerMethod.arguments?.map((arg: string) => {
       return searchParams.get(arg);
     });
-    if (body) {
+    if (body && args) {
       args = [...args, body];
     }
     response = await handlerMethod.run(args);
@@ -69,7 +70,7 @@ const getResponse = async (searchParams: URLSearchParams, body?: any) => {
 /**
  * Shows the data returned from the server actions for development only!!
  */
-export async function GET(request: NextRequest, params: Record<string, any>) {
+export async function GET(request: NextRequest) {
   if (process.env.NODE_ENV !== "development") {
     return NextResponse.json(
       { error: "Internal Server Error" },
@@ -77,14 +78,14 @@ export async function GET(request: NextRequest, params: Record<string, any>) {
     );
   }
   const searchParams = request.nextUrl.searchParams;
-  let response = await getResponse(searchParams);
+  const response = await getResponse(searchParams);
   return NextResponse.json(response);
 }
 
 /**
  * Shows the data returned from the server actions for development only!!
  */
-export async function POST(request: NextRequest, params: Record<string, any>) {
+export async function POST(request: NextRequest) {
   if (process.env.NODE_ENV !== "development") {
     return NextResponse.json(
       { error: "Internal Server Error" },
@@ -93,6 +94,6 @@ export async function POST(request: NextRequest, params: Record<string, any>) {
   }
   const body = await request.json();
   const searchParams = request.nextUrl.searchParams;
-  let response = await getResponse(searchParams, body);
+  const response = await getResponse(searchParams, body);
   return NextResponse.json(response);
 }

--- a/src/handlers/bops/v2/applicationSubmission.documentation.tsx
+++ b/src/handlers/bops/v2/applicationSubmission.documentation.tsx
@@ -23,7 +23,7 @@ export const documentation: Documentation = {
   file: `src/handlers/bops/v2/applicationSubmission.ts`,
   description: "applicationSubmission",
   arguments: ["council", "reference"],
-  run: async (args: [any, any]) => {
+  run: async (args: [string, string]) => {
     return await applicationSubmission(...args);
   },
   examples: [

--- a/src/handlers/bops/v2/documents.documentation.tsx
+++ b/src/handlers/bops/v2/documents.documentation.tsx
@@ -23,7 +23,7 @@ export const documentation: Documentation = {
   file: `src/handlers/bops/v2/documents.ts`,
   description: "documents",
   arguments: ["council", "reference"],
-  run: async (args: [any, any]) => {
+  run: async (args: [string, string]) => {
     return await documents(...args);
   },
   examples: [

--- a/src/handlers/bops/v2/postComment.documentation.tsx
+++ b/src/handlers/bops/v2/postComment.documentation.tsx
@@ -23,7 +23,7 @@ export const documentation: Documentation = {
   file: `src/handlers/bops/v2/postComment.ts`,
   description: "Post a comment to BOPS",
   arguments: ["council", "applicationId"],
-  run: async (args: [any, any, any]) => {
+  run: async (args: [string, string, object]) => {
     return await postComment(...args);
   },
   examples: [

--- a/src/handlers/bops/v2/search.documentation.tsx
+++ b/src/handlers/bops/v2/search.documentation.tsx
@@ -15,7 +15,7 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Documentation } from "@/types";
+import { Documentation, SearchParams } from "@/types";
 import { search } from "./search";
 
 export const documentation: Documentation = {
@@ -23,8 +23,8 @@ export const documentation: Documentation = {
   file: `src/handlers/bops/v2/search.ts`,
   description: "getPlanningApplications",
   arguments: ["council", "page", "resultsPerPage", "searchQuery"],
-  run: async (args: [any, any, any, any]) => {
-    const searchObj = {
+  run: async (args: [string, number, number, string]) => {
+    const searchObj: SearchParams = {
       page: args[1],
       resultsPerPage: args[2],
       query: args[3],

--- a/src/handlers/bops/v2/show.documentation.tsx
+++ b/src/handlers/bops/v2/show.documentation.tsx
@@ -26,7 +26,7 @@ export const documentation: Documentation = {
   ],
   description: "show",
   arguments: ["council", "reference"],
-  run: async (args: [any, any]) => {
+  run: async (args: [string, string]) => {
     return await show(...args);
   },
   examples: [

--- a/src/handlers/local/v1/postComment.documentation.tsx
+++ b/src/handlers/local/v1/postComment.documentation.tsx
@@ -23,7 +23,7 @@ export const documentation: Documentation = {
   file: `src/handlers/local/v1/postComment.ts`,
   description: "postComment",
   arguments: ["council", "applicationId"],
-  run: async (args: [any, any, any]) => {
+  run: async (args: [string, number]) => {
     return await postComment(...args);
   },
 };

--- a/src/handlers/local/v1/postComment.ts
+++ b/src/handlers/local/v1/postComment.ts
@@ -58,10 +58,10 @@ const responseQuery = (
 export const postComment = (
   council: string,
   applicationId: number,
-  apiData: object,
+  // apiData: object,
 ): Promise<ApiResponse<BopsV1PlanningApplicationsNeighbourResponse | null>> => {
   // console.log("apiData", apiData);
-  let error = false;
+  const error = false;
   // uncomment for testing
   // error = true;
   return Promise.resolve(responseQuery(council, applicationId, error));

--- a/src/handlers/local/v1/search.documentation.tsx
+++ b/src/handlers/local/v1/search.documentation.tsx
@@ -15,7 +15,7 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Documentation } from "@/types";
+import { Documentation, SearchParams } from "@/types";
 import { search } from "./search";
 
 export const documentation: Documentation = {
@@ -23,8 +23,8 @@ export const documentation: Documentation = {
   file: `src/handlers/local/v1/search.ts`,
   description: "search",
   arguments: ["page", "resultsPerPage", "council", "searchQuery", "searchType"],
-  run: async (args: any) => {
-    const searchObj = {
+  run: async (args: [number, number, string, string, string]) => {
+    const searchObj: SearchParams = {
       page: args[0],
       resultsPerPage: args[1],
       query: args[3],

--- a/src/handlers/local/v1/show.documentation.tsx
+++ b/src/handlers/local/v1/show.documentation.tsx
@@ -33,7 +33,7 @@ export const documentation: Documentation = {
     },
   ],
   arguments: ["council", "reference"],
-  run: async (args: [any, any]) => {
+  run: async (args: [string, string]) => {
     return await show(...args);
   },
   examples: [


### PR DESCRIPTION
These changes affect the documentation files that we access through `/docs/json` in development mode and the `./src/handlers/local/v1/postComment.ts` file has an unused prop removed

Fixes `Error: Unexpected any. Specify a different type. @typescript-eslint/no-explicit-any` in:

- ./src/app/docs/json/route.ts
- ./src/actions/api/v1/applicationSubmission.documentation.tsx
- ./src/actions/api/v1/documents.documentation.tsx
- ./src/actions/api/v1/postComment.documentation.tsx
- ./src/actions/api/v1/search.documentation.tsx
- ./src/actions/api/v1/show.documentation.tsx
- ./src/handlers/bops/v2/applicationSubmission.documentation.tsx
- ./src/handlers/bops/v2/documents.documentation.tsx
- ./src/handlers/bops/v2/postComment.documentation.tsx
- ./src/handlers/bops/v2/search.documentation.tsx
- ./src/handlers/bops/v2/show.documentation.tsx
- ./src/handlers/local/v1/postComment.documentation.tsx
- ./src/handlers/local/v1/search.documentation.tsx
- ./src/handlers/local/v1/show.documentation.tsx

Also fixes these errors in the following files

- ./src/app/docs/json/route.ts
```
55:49 Error: 'params' is defined but never used. @typescript-eslint/no-unused-vars
63:7 Error: 'response' is never reassigned. Use 'const' instead. prefer-const
70:50 Error: 'params' is defined but never used. @typescript-eslint/no-unused-vars
79:7 Error: 'response' is never reassigned. Use 'const' instead. prefer-const
```

- ./src/handlers/local/v1/postComment.ts
```
44:3 Error: 'apiData' is defined but never used. @typescript-eslint/no-unused-vars
47:7 Error: 'error' is never reassigned. Use 'const' instead. prefer-const
```