### PR TITLE
Lint fix: Change `let` to `const` for variables that aren't ever reassigned

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -101,7 +101,7 @@ export const getCouncilConfig = (
  * @returns
  */
 const determineCouncilVisibility = (councilConfig: Council) => {
-  let { visibility: configVisibility, slug } = councilConfig;
+  const { visibility: configVisibility, slug } = councilConfig;
 
   const overrideVisibility =
     process.env[`${slug.toUpperCase().split("-").join("_")}_VISIBILITY`];

--- a/src/handlers/bops/formatters/application-submission--applicant.tsx
+++ b/src/handlers/bops/formatters/application-submission--applicant.tsx
@@ -180,7 +180,7 @@ const formatSiteContact = (
 ): DprApplicationSubmissionSubtopicValue => {
   let value = "";
   if (data?.role === "other") {
-    let other = [];
+    const other = [];
     if (data?.name) {
       other.push(data?.name);
     }
@@ -214,7 +214,7 @@ const formatAgent = (
 ): DprApplicationSubmissionSubtopicValue[] => {
   const agent = flattenObjectIntoRow(data, "Agent ", ["name"]);
 
-  let agentName = [];
+  const agentName = [];
   if (data?.name?.first) {
     agentName.push(data?.name?.first);
   }

--- a/src/handlers/local/v1/search.ts
+++ b/src/handlers/local/v1/search.ts
@@ -19,11 +19,11 @@ const responseQuery = (
   const appConfig = getAppConfig();
   const resultsPerPage = appConfig.defaults.resultsPerPage;
 
-  let applications = generateNResults<DprPlanningApplication>(
+  const applications = generateNResults<DprPlanningApplication>(
     resultsPerPage,
     generateDprApplication,
   );
-  let pagination = generatePagination(searchParams?.page);
+  const pagination = generatePagination(searchParams?.page);
 
   // if we've done a search just rename the first result to match the query
   if (searchParams?.query) {

--- a/src/lib/planningApplication/progress.tsx
+++ b/src/lib/planningApplication/progress.tsx
@@ -27,7 +27,7 @@ import { contentImportantDates } from "./date";
 export const buildApplicationProgress = (
   application: DprPlanningApplication,
 ): ProgressSectionBase[] => {
-  let progressData: ProgressSectionBase[] = [];
+  const progressData: ProgressSectionBase[] = [];
 
   // 01 received
   if (application.application?.receivedDate) {


### PR DESCRIPTION
Fixes linting error for `lets` that should have been `const`