### PR TITLE
Lint fix: jsx-a11y fixes

### DIFF
--- a/__tests__/components/ApplicationConstraints.test.js
+++ b/__tests__/components/ApplicationConstraints.test.js
@@ -4,6 +4,6 @@ describe("Render ApplicationConstraints", () => {
   it("should render correct", () => {
     render(<ApplicationConstraints />);
 
-    expect(screen.getByRole("constraints-title", { Name: "Constraints" }));
+    expect(screen.getByRole("heading", { name: "Constraints" }));
   });
 });

--- a/__tests__/components/ApplicationLocation.test.js
+++ b/__tests__/components/ApplicationLocation.test.js
@@ -5,6 +5,6 @@ describe("Render ApplicationLocation", () => {
   it("should render correct", () => {
     render(<ApplicationLocation />);
 
-    expect(screen.getByRole("location-title", { Name: "Location" }));
+    expect(screen.getByRole("heading", { name: "Location" }));
   });
 });

--- a/src/components/ApplicationConstraints/ApplicationConstraints.tsx
+++ b/src/components/ApplicationConstraints/ApplicationConstraints.tsx
@@ -1,9 +1,7 @@
 export const ApplicationConstraints = () => {
   return (
     <>
-      <h2 className="govuk-heading-l" role="constraints-title">
-        Constraints
-      </h2>
+      <h2 className="govuk-heading-l">Constraints</h2>
       <p className="govuk-body">
         <em>
           Planning constraints, guidance and designations that intersect with
@@ -16,7 +14,7 @@ export const ApplicationConstraints = () => {
           <h3 className="govuk-heading-s">General policy</h3>
           <p className="govuk-body">Article 4 direction areas</p>
           <p className="govuk-body">
-            <a href="#" className="govuk-link govuk-link--no-visited-state">
+            <a href="/" className="govuk-link govuk-link--no-visited-state">
               Source
             </a>
           </p>
@@ -25,7 +23,7 @@ export const ApplicationConstraints = () => {
         <div className="govuk-grid-column-one-third">
           <h3 className="govuk-heading-s">Heritage conservation area</h3>
           <p className="govuk-body">
-            <a href="#" className="govuk-link govuk-link--no-visited-state">
+            <a href="/" className="govuk-link govuk-link--no-visited-state">
               Source
             </a>
           </p>
@@ -35,7 +33,7 @@ export const ApplicationConstraints = () => {
           <h3 className="govuk-heading-s">General policy</h3>
           <p className="govuk-body">Classified roads</p>
           <p className="govuk-body">
-            <a href="#" className="govuk-link govuk-link--no-visited-state">
+            <a href="/" className="govuk-link govuk-link--no-visited-state">
               Source
             </a>
           </p>
@@ -52,7 +50,7 @@ export const ApplicationConstraints = () => {
             </em>
           </p>
           <p className="govuk-body">
-            <a href="#" className="govuk-link govuk-link--no-visited-state">
+            <a href="/" className="govuk-link govuk-link--no-visited-state">
               DE-9IM spatial relationship definition of intersects
             </a>
           </p>

--- a/src/components/ApplicationLocation/ApplicationLocation.tsx
+++ b/src/components/ApplicationLocation/ApplicationLocation.tsx
@@ -2,9 +2,7 @@ export const ApplicationLocation = () => {
   return (
     <>
       {/* Add real data when available */}
-      <h2 className="govuk-heading-l" role="location-title">
-        Location
-      </h2>
+      <h2 className="govuk-heading-l">Location</h2>
       <div className="govuk-grid-row  grid-row-extra-bottom-margin">
         <div className="govuk-grid-column">
           <div className="govuk-grid-column-one-quarter">

--- a/src/components/ApplicationMoreDetails/ApplicationMoreDetails.tsx
+++ b/src/components/ApplicationMoreDetails/ApplicationMoreDetails.tsx
@@ -38,12 +38,12 @@ export const ApplicationMoreDetails = () => {
       <h2 className="govuk-heading-l">Related Applications</h2>
       <ul className="govuk-list govuk-list--bullet grid-row-extra-bottom-margin">
         <li>
-          <a href="#" className="govuk-link govuk-link--no-visited-state">
+          <a href="/" className="govuk-link govuk-link--no-visited-state">
             Pre-application - 2024/0452/C
           </a>
         </li>
         <li>
-          <a href="#" className="govuk-link govuk-link--no-visited-state">
+          <a href="/" className="govuk-link govuk-link--no-visited-state">
             Conditions of construction - 2024/0685/A
           </a>
         </li>

--- a/src/components/ContentSignposting/ContentSignposting.tsx
+++ b/src/components/ContentSignposting/ContentSignposting.tsx
@@ -14,7 +14,7 @@ export const ContentSignposting: React.FC<ContentSignpostingProps> = ({
 }) => {
   return (
     <nav aria-label="Table of contents" className="dpr-content-signposting">
-      <ul className="dpr-content-signposting__links" role="list">
+      <ul className="dpr-content-signposting__links">
         {pages.map((page) => (
           <li key={page.key} className="dpr-content-signposting__links-item">
             <h3 className="govuk-heading-s">

--- a/src/components/govuk/NotificationBanner/NotificationBanner.stories.tsx
+++ b/src/components/govuk/NotificationBanner/NotificationBanner.stories.tsx
@@ -29,7 +29,7 @@ export const Success: Story = {
     content: (
       <>
         You&rsquo;ve set your cookie preferences.{" "}
-        <a href="#" className="govuk-notification-banner__link">
+        <a href="/" className="govuk-notification-banner__link">
           Go back to the page you were looking at
         </a>
         .

--- a/src/components/govuk/SummaryList/SummaryList.stories.tsx
+++ b/src/components/govuk/SummaryList/SummaryList.stories.tsx
@@ -108,7 +108,7 @@ const meta = {
         value: {
           text: (
             <>
-              <a href="#" className="govuk-link">
+              <a href="/" className="govuk-link">
                 Enter contact information
               </a>
             </>
@@ -122,7 +122,7 @@ const meta = {
         value: {
           text: (
             <>
-              <a href="#" className="govuk-link">
+              <a href="/" className="govuk-link">
                 Enter contact details
               </a>
             </>


### PR DESCRIPTION
The new eslint config in the todo.md has additional a11y checks this pr fixes some of those errors.

> 46:11 Error: The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md jsx-a11y/anchor-is-valid


> 5:39 Error: Elements with ARIA roles must use a valid, non-abstract ARIA role. jsx-a11y/aria-role

> 17:7 Error: The element ul has an implicit role of list. Defining this explicitly is redundant and should be avoided. jsx-a11y/no-redundant-roles


---


./src/components/ApplicationConstraints/ApplicationConstraints.tsx
```
4:39 Error: Elements with ARIA roles must use a valid, non-abstract ARIA role. jsx-a11y/aria-role
19:13 Error: The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md jsx-a11y/anchor-is-valid
28:13 Error: The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md jsx-a11y/anchor-is-valid
38:13 Error: The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md jsx-a11y/anchor-is-valid
55:13 Error: The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md jsx-a11y/anchor-is-valid
```

./src/components/ApplicationLocation/ApplicationLocation.tsx
```
5:39 Error: Elements with ARIA roles must use a valid, non-abstract ARIA role. jsx-a11y/aria-role
```


./src/components/ApplicationMoreDetails/ApplicationMoreDetails.tsx
```
41:11 Error: The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md jsx-a11y/anchor-is-valid
46:11 Error: The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md jsx-a11y/anchor-is-valid
```


./src/components/ContentSignposting/ContentSignposting.tsx
```
17:7 Error: The element ul has an implicit role of list. Defining this explicitly is redundant and should be avoided. jsx-a11y/no-redundant-roles
```

./src/components/govuk/NotificationBanner/NotificationBanner.stories.tsx
```
32:9 Error: The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md jsx-a11y/anchor-is-valid
```

./src/components/govuk/SummaryList/SummaryList.stories.tsx
```
111:15 Error: The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md jsx-a11y/anchor-is-valid
125:15 Error: The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md jsx-a11y/anchor-is-valid
```
