### PR TITLE
Lint fix: ApplicationProgressInfo fix linting errors

### DIFF
--- a/__tests__/components/ApplicationProgressInfo.test.tsx
+++ b/__tests__/components/ApplicationProgressInfo.test.tsx
@@ -30,8 +30,6 @@ describe("ApplicationProgressInfo", () => {
 
   it("renders closed section", async () => {
     const defaultProps = {
-      councilSlug: "public-council-1",
-      reference: "ABC123",
       sections: [
         {
           title: "Section 1",

--- a/src/components/ApplicationDetails/ApplicationDetails.tsx
+++ b/src/components/ApplicationDetails/ApplicationDetails.tsx
@@ -136,8 +136,6 @@ export const ApplicationDetails = ({
         </div>
         <div className="govuk-grid-column-two-thirds-from-desktop dpr-application-details--flow">
           <ApplicationProgressInfo
-            councilSlug={appConfig.council.slug}
-            reference={reference}
             sections={applicationProgress}
             decisionNoticeUrl={decisionNoticeUrl}
           />

--- a/src/components/ApplicationProgressInfo/ApplicationProgressInfo.stories.tsx
+++ b/src/components/ApplicationProgressInfo/ApplicationProgressInfo.stories.tsx
@@ -12,7 +12,6 @@ const meta = {
     layout: "fullscreen",
   },
   args: {
-    withReadMore: true,
     sections: [
       {
         title: "Received",
@@ -118,8 +117,6 @@ const meta = {
         ),
       },
     ],
-    councilSlug: "public-council-1",
-    reference: "ABC123",
   },
 } satisfies Meta<typeof ApplicationProgressInfo>;
 

--- a/src/components/ApplicationProgressInfo/ApplicationProgressInfo.tsx
+++ b/src/components/ApplicationProgressInfo/ApplicationProgressInfo.tsx
@@ -14,17 +14,11 @@ import { Details } from "../govukDpr/Details";
 
 export interface ApplicationProgressInfoProps {
   sections: ProgressSectionBase[];
-  withReadMore?: boolean;
-  councilSlug: string;
-  reference: string;
   decisionNoticeUrl?: string;
 }
 
 export const ApplicationProgressInfo = ({
   sections,
-  withReadMore = false,
-  councilSlug,
-  reference,
   decisionNoticeUrl,
 }: ApplicationProgressInfoProps) => {
   const [isClient, setIsClient] = useState(false);
@@ -47,7 +41,7 @@ export const ApplicationProgressInfo = ({
     const anyOpen = accordionStates.find(
       (accordionState) => accordionState.isExpanded === true,
     );
-    anyOpen ? setOpenAll(false) : setOpenAll(true);
+    setOpenAll(!anyOpen);
     setShowControls(true);
   }, [accordionStates]);
 
@@ -62,15 +56,15 @@ export const ApplicationProgressInfo = ({
     setAccordionStates(newStatus);
 
     // update the text that shows open all / close all
-    value ? setOpenAll(false) : setOpenAll(true);
+    setOpenAll(!value);
   };
 
   const toggleAll = () => {
     setOpenAll(!openAll);
-    const newStatus = accordionStates.map((accordionState) => {
-      accordionState.isExpanded = openAll;
-      return accordionState;
-    });
+    const newStatus = accordionStates.map((accordionState) => ({
+      ...accordionState,
+      isExpanded: openAll,
+    }));
     setAccordionStates(newStatus);
   };
 


### PR DESCRIPTION
Fixes `@typescript-eslint/no-unused-vars` and `@typescript-eslint/no-unused-expressions` linting errrors in the ApplicationProgressInfo component