### PR TITLE
Lint fix: replace type `String` with `string`

### DIFF
--- a/src/handlers/bops/converters/applicationSubmission.tsx
+++ b/src/handlers/bops/converters/applicationSubmission.tsx
@@ -106,7 +106,7 @@ const convertApplicationSubmissionDataBops = (
  */
 export const flattenObjectIntoRow = (
   field: Record<string, any>,
-  prefix: String = "",
+  prefix: string = "",
   exclude: string[] = [],
   include: string[] = [],
 ): DprApplicationSubmissionSubtopicValue[] => {

--- a/src/handlers/bops/formatters/application-submission--property.tsx
+++ b/src/handlers/bops/formatters/application-submission--property.tsx
@@ -231,7 +231,7 @@ export const formatParking = (
  */
 export const parseParking = (
   parking: Record<string, any>,
-  prefix: String = "",
+  prefix: string = "",
   valuePrefix: string = "",
   field: string = "count",
 ): DprApplicationSubmissionSubtopicValue[] => {


### PR DESCRIPTION
Fix linting error `Error: Prefer using the primitive `string` as a type name, rather than the upper-cased `String`.  @typescript-eslint/no-wrapper-object-types`