### PR TITLE
Lint fix: Don't allow 'any' type in application files

### DIFF
--- a/__tests__/util/concatenateFieldsInOrder.test.tsx
+++ b/__tests__/util/concatenateFieldsInOrder.test.tsx
@@ -11,7 +11,7 @@ describe("concatenateFieldsInOrder", () => {
       country: "USA",
     };
     const fields = ["line1", "line2", "town", "county", "postcode", "country"];
-    const result = concatenateFieldsInOrder(obj, fields);
+    const result = concatenateFieldsInOrder<string>(obj, fields);
     expect(result).toBe(
       "123 Main St, Apt 4B, Springfield, Some County, 12345, USA",
     );
@@ -24,7 +24,7 @@ describe("concatenateFieldsInOrder", () => {
       postcode: "12345",
     };
     const fields = ["line1", "line2", "town", "county", "postcode", "country"];
-    const result = concatenateFieldsInOrder(obj, fields);
+    const result = concatenateFieldsInOrder<string>(obj, fields);
     expect(result).toBe("123 Main St, Springfield, 12345");
   });
 
@@ -38,14 +38,14 @@ describe("concatenateFieldsInOrder", () => {
       country: undefined,
     };
     const fields = ["line1", "line2", "town", "county", "postcode", "country"];
-    const result = concatenateFieldsInOrder(obj, fields);
+    const result = concatenateFieldsInOrder<string>(obj, fields);
     expect(result).toBe("123 Main St, Springfield, 12345");
   });
 
   it("should return an empty string if no fields are present in the object", () => {
     const obj = {};
     const fields = ["line1", "line2", "town", "county", "postcode", "country"];
-    const result = concatenateFieldsInOrder(obj, fields);
+    const result = concatenateFieldsInOrder<string>(obj, fields);
     expect(result).toBe("");
   });
 
@@ -56,7 +56,7 @@ describe("concatenateFieldsInOrder", () => {
       postcode: "12345",
     };
     const fields: string[] = [];
-    const result = concatenateFieldsInOrder(obj, fields);
+    const result = concatenateFieldsInOrder<string>(obj, fields);
     expect(result).toBe("");
   });
 
@@ -66,7 +66,7 @@ describe("concatenateFieldsInOrder", () => {
       last: "Smith",
     };
     const fields = ["first", "last"];
-    const result = concatenateFieldsInOrder(obj, fields, "HELLO");
+    const result = concatenateFieldsInOrder<string>(obj, fields, "HELLO");
     expect(result).toBe("JohnHELLOSmith");
   });
 });

--- a/src/components/ApplicationPeople/ApplicationPeople.tsx
+++ b/src/components/ApplicationPeople/ApplicationPeople.tsx
@@ -11,7 +11,7 @@ export const ApplicationPeople = ({
   applicant,
   caseOfficer,
 }: ApplicationPeopleProps) => {
-  const applicantName = concatenateFieldsInOrder(
+  const applicantName = concatenateFieldsInOrder<string>(
     applicant?.name ?? {},
     ["first", "last"],
     " ",
@@ -19,7 +19,7 @@ export const ApplicationPeople = ({
   const applicantType = applicant?.type;
   const applicantAddress = applicant?.address?.sameAsSiteAddress
     ? "Same as site address"
-    : concatenateFieldsInOrder(applicant?.address ?? {}, [
+    : concatenateFieldsInOrder<string>(applicant?.address ?? {}, [
         "line1",
         "line2",
         "town",
@@ -27,12 +27,12 @@ export const ApplicationPeople = ({
         "postcode",
         "country",
       ]);
-  const agentName = concatenateFieldsInOrder(
+  const agentName = concatenateFieldsInOrder<string>(
     applicant?.agent?.name ?? {},
     ["first", "last"],
     " ",
   );
-  const agentAddress = concatenateFieldsInOrder(
+  const agentAddress = concatenateFieldsInOrder<string>(
     applicant?.agent?.address ?? {},
     ["line1", "line2", "town", "county", "postcode", "country"],
   );

--- a/src/lib/planningApplication/type.tsx
+++ b/src/lib/planningApplication/type.tsx
@@ -35,12 +35,12 @@ const primaryApplicationTypeTitles: Record<PrimaryApplicationType, string> = {
 };
 
 /**
- * Utility class that returns the first part of pp.part1.classA
+ * Utility class that checks if a value is a valid PrimaryApplicationType
  * @param value
  * @returns
  */
 export const isValidPrimaryApplicationType = (
-  value: any,
+  value: string,
 ): value is PrimaryApplicationType => {
   return Object.keys(primaryApplicationTypeTitles).includes(value);
 };
@@ -58,10 +58,9 @@ export const getPrimaryApplicationTypeKey = (
     return undefined;
   }
   const type = applicationType.split(".")[0];
-  if (isValidPrimaryApplicationType(type)) {
+  if (type && isValidPrimaryApplicationType(type)) {
     return type || undefined;
   }
-  return undefined;
 };
 
 /**
@@ -75,7 +74,7 @@ export const getPrimaryApplicationType = (
   applicationType: DprPlanningApplication["applicationType"],
 ): string | undefined => {
   const type = getPrimaryApplicationTypeKey(applicationType);
-  if (isValidPrimaryApplicationType(type)) {
+  if (type && isValidPrimaryApplicationType(type)) {
     return primaryApplicationTypeTitles[type] || undefined;
   }
   return undefined;
@@ -128,7 +127,7 @@ export const getDocumentedApplicationType = (
     }
   }
 
-  if (isValidPrimaryApplicationType(type)) {
+  if (type && isValidPrimaryApplicationType(type)) {
     const primaryApplicationTypeToContentApplicationType: Record<
       PrimaryApplicationType,
       string | undefined

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -90,7 +90,7 @@ export interface Documentation {
   file: string;
   description: string | JSX.Element;
   arguments?: string[];
-  run: any;
+  run: Awaited<(...args) => void>;
   validate?: {
     url: string;
     type: "application" | "prototypeApplication";

--- a/src/util/concatenateFieldsInOrder.ts
+++ b/src/util/concatenateFieldsInOrder.ts
@@ -4,8 +4,8 @@
  * @param fields - The array of field names in the order to concatenate.
  * @returns A concatenated string of field values.
  */
-export const concatenateFieldsInOrder = (
-  obj: Record<string, any>,
+export const concatenateFieldsInOrder = <T>(
+  obj: Record<string, T>,
   fields: string[],
   separator: string = ", ",
 ): string => {


### PR DESCRIPTION
Removes `any` option from some components to pass linting