### PR TITLE
DSNPI - 1128 / BUG - consultation end date displaying on progress component when it's in the future

### DIFF
--- a/__tests__/lib/planningApplication/progress.test.ts
+++ b/__tests__/lib/planningApplication/progress.test.ts
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { buildApplicationProgress } from "@/lib/planningApplication/progress";
+import { generateDprApplication } from "@mocks/dprApplicationFactory";
+
+describe("buildApplicationProgress", () => {
+  it('should show "Consultation ended" when consultation end date is in the past', () => {
+    const application = generateDprApplication();
+    application.application.consultation.endDate = new Date(
+      Date.now() - 86400000,
+    ).toISOString();
+    const progressData = buildApplicationProgress(application);
+    expect(progressData[3].title).toBe("Consultation ended");
+  });
+  it('should show "Consultation ends" when consultation end date is in the future', () => {
+    const application = generateDprApplication();
+    application.application.consultation.endDate = new Date(
+      Date.now() + 86400000,
+    ).toISOString();
+    const progressData = buildApplicationProgress(application);
+    expect(progressData[3].title).toBe("Consultation ends");
+  });
+});

--- a/src/lib/planningApplication/progress.tsx
+++ b/src/lib/planningApplication/progress.tsx
@@ -40,6 +40,9 @@ import {
   slugify,
 } from "@/util";
 import { contentImportantDates } from "./date";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+dayjs.extend(utc);
 
 export const buildApplicationProgress = (
   application: DprPlanningApplication,
@@ -87,8 +90,16 @@ export const buildApplicationProgress = (
   // 04 consultationEnded
 
   if (application.application?.consultation?.endDate) {
+    const consultationEndDate = dayjs.utc(
+      application.application.consultation.endDate,
+    );
+    const now = dayjs.utc();
+    const title = consultationEndDate.isBefore(now, "day")
+      ? "Consultation ended"
+      : "Consultation ends";
+
     progressData.push({
-      title: "Consultation ended",
+      title,
       date: formatDateToDprDate(application.application.consultation.endDate),
       content: findItemByKey<DprContentPage>(
         contentImportantDates(),


### PR DESCRIPTION
[Ticket 1128](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-1128)

~~The progress component was showing the “consultation ended” item even when the date is in the future. 
Our code was only checking for the presence of the end date, but now we also check that the date is in the past before showing it.~~

Instead of the above, we always show the consultation end date on the progress bar. The only difference is that if it is in the past, we say 'Consultation ended', otherwise it's 'Consultation ends'