### PR TITLE
DSNPI-1067 / Create a utility function to convert DprPlanningApplication to DprApplication

### DIFF
--- a/__mocks__/dprApplicationFactory.ts
+++ b/__mocks__/dprApplicationFactory.ts
@@ -31,6 +31,16 @@ import { ApplicationType } from "@/types/odp-types/schemas/prototypeApplication/
 import { formatDateToYmd } from "@/util";
 
 import { faker, fakerEN_GB } from "@faker-js/faker";
+import {
+  generateAgent,
+  generateBaseApplicant,
+  generateCaseOfficer,
+  generateSiteAddress,
+} from "./dprNewApplicationFactory";
+import {
+  Agent,
+  BaseApplicant,
+} from "@/types/odp-types/schemas/prototypeApplication/data/Applicant";
 
 /**
  * Generates a random reference string in the format `XX-XXXXX-XXXX`.
@@ -287,6 +297,7 @@ export const generateDprApplication = ({
         consulteeComments: generateNResults<DprComment>(50, generateComment),
         publishedComments: generateNResults<DprComment>(50, generateComment),
       },
+      expiryDate: formatDateToYmd(faker.date.anytime()),
       receivedAt: faker.date.anytime().toISOString(),
       validAt: faker.date.anytime().toISOString(),
       publishedAt: faker.date.anytime().toISOString(),
@@ -294,43 +305,22 @@ export const generateDprApplication = ({
       decision: decision,
     },
     property: {
-      address: {
-        singleLine: fakerEN_GB.location.streetAddress(true),
-      },
+      address: generateSiteAddress,
       boundary: {
         site: generateBoundaryGeoJson(),
+        area: {
+          squareMetres: faker.number.int({ min: 1000, max: 10000 }),
+        },
       },
     },
     proposal: {
       description: faker.lorem.paragraphs({ min: 1, max: 10 }),
     },
-    applicant: {
-      type: "company",
-      name: {
-        first: faker.person.firstName(),
-        last: faker.person.lastName(),
-      },
-      address: {
-        sameAsSiteAddress: true,
-      },
-      agent: {
-        name: {
-          first: faker.person.firstName(),
-          last: faker.person.lastName(),
-        },
-        address: {
-          line1: fakerEN_GB.location.street(),
-          line2: "",
-          town: fakerEN_GB.location.city(),
-          county: "",
-          postcode: fakerEN_GB.location.zipCode(),
-          country: "",
-        },
-      },
-    },
-    officer: {
-      name: faker.person.fullName(),
-    },
+    applicant: faker.helpers.arrayElement<BaseApplicant | Agent>([
+      generateBaseApplicant,
+      generateAgent,
+    ]),
+    officer: generateCaseOfficer,
   };
 };
 

--- a/__tests__/components/ApplicationPeople.test.tsx
+++ b/__tests__/components/ApplicationPeople.test.tsx
@@ -18,13 +18,16 @@
 import "@testing-library/jest-dom";
 import { ApplicationPeople } from "@/components/ApplicationPeople";
 import { screen, render } from "@testing-library/react";
-import { generateDprApplication } from "@mocks/dprApplicationFactory";
+import {
+  generateAgent,
+  generateCaseOfficer,
+} from "@mocks/dprNewApplicationFactory";
 
 describe("Render ApplicationPeople", () => {
-  const applicant = generateDprApplication().applicant;
-  const caseOfficer = generateDprApplication().officer;
+  const applicant = generateAgent;
+  const caseOfficer = generateCaseOfficer;
 
-  it("should render correct if it has all the data", async () => {
+  it("should render correctly if it has all the data", async () => {
     render(
       <ApplicationPeople applicant={applicant} caseOfficer={caseOfficer} />,
     );
@@ -58,8 +61,8 @@ describe("Render ApplicationPeople", () => {
     ).toBeInTheDocument();
   });
 
-  it("shouldn't show anything if no applicant", async () => {
-    render(<ApplicationPeople applicant={{}} />);
+  it("shouldn't show anything if no data", async () => {
+    render(<ApplicationPeople />);
 
     // it should be showing
     expect(
@@ -69,15 +72,14 @@ describe("Render ApplicationPeople", () => {
 
   it("shouldn't show agent column if the fields we need are empty", async () => {
     // Remove agent.name and agent.address
-    const {
-      agent: { name, address, ...restAgent },
-      ...restApplicant
-    } = applicant;
-    const updatedApplicant = {
+    const { agent, ...restApplicant } = generateAgent;
+    const { name, address, ...restAgent } = agent;
+    const updatedAgent = {
       ...restApplicant,
       agent: restAgent,
     };
-    render(<ApplicationPeople applicant={updatedApplicant} />);
+
+    render(<ApplicationPeople applicant={updatedAgent} />);
 
     // it should be showing
     expect(screen.getByRole("heading", { name: "People" })).toBeInTheDocument();

--- a/__tests__/lib/planningApplication/application.test.tsx
+++ b/__tests__/lib/planningApplication/application.test.tsx
@@ -1,0 +1,203 @@
+import {
+  getCouncilDecisionDate,
+  getCouncilDecision,
+  getDescription,
+  getPropertyAddress,
+  getPropertyAddressLatitudeLongitude,
+} from "@/lib/planningApplication/application";
+import { DprApplication } from "@/types";
+import {
+  GeographyBasedProposal,
+  HedgerowRemovalNoticeProposal,
+  ProposalBase,
+} from "@/types/odp-types/schemas/prototypeApplication/data/Proposal";
+import { OSAddress, ProposedAddress } from "@/types/odp-types/shared/Addresses";
+
+describe("getPropertyAddress", () => {
+  it("should return the description for an application with ProposedAddress address", () => {
+    const address: ProposedAddress = {
+      title: "House McHouseface Housing",
+      x: 502869.8591151078,
+      y: 180333.4537434135,
+      latitude: 51.51257224609594,
+      longitude: -0.5189885919643893,
+      source: "Proposed by applicant",
+    };
+    expect(getPropertyAddress(address)).toEqual("House McHouseface Housing");
+  });
+  it("should return the description for an application with OSAddress address", () => {
+    const address: OSAddress = {
+      latitude: 51.6994957,
+      longitude: -0.708966,
+      x: 489320,
+      y: 200872,
+      title: "GIPSY HOUSE, WHITEFIELD LANE, GREAT MISSENDEN",
+      singleLine: "GIPSY HOUSE, WHITEFIELD LANE, GREAT MISSENDEN, HP16 0BP",
+      source: "Ordnance Survey",
+      uprn: "100081174436",
+      usrn: "07300709",
+      pao: "",
+      street: "WHITEFIELD LANE",
+      town: "GREAT MISSENDEN",
+      postcode: "HP16 0BP",
+    };
+    expect(getPropertyAddress(address)).toEqual(
+      "GIPSY HOUSE, WHITEFIELD LANE, GREAT MISSENDEN, HP16 0BP",
+    );
+  });
+});
+
+describe("getPropertyAddressLatitudeLongitude", () => {
+  it("should return the latitude/longitude for an application with ProposedAddress address", () => {
+    const address: ProposedAddress = {
+      title: "House McHouseface Housing",
+      x: 502869.8591151078,
+      y: 180333.4537434135,
+      latitude: 51.51257224609594,
+      longitude: -0.5189885919643893,
+      source: "Proposed by applicant",
+    };
+    expect(getPropertyAddressLatitudeLongitude(address)).toMatchObject({
+      latitude: 51.51257224609594,
+      longitude: -0.5189885919643893,
+    });
+  });
+  it("should return the latitude/longitude for an application with OSAddress address", () => {
+    const address: OSAddress = {
+      latitude: 51.6994957,
+      longitude: -0.708966,
+      x: 489320,
+      y: 200872,
+      title: "GIPSY HOUSE, WHITEFIELD LANE, GREAT MISSENDEN",
+      singleLine: "GIPSY HOUSE, WHITEFIELD LANE, GREAT MISSENDEN, HP16 0BP",
+      source: "Ordnance Survey",
+      uprn: "100081174436",
+      usrn: "07300709",
+      pao: "",
+      street: "WHITEFIELD LANE",
+      town: "GREAT MISSENDEN",
+      postcode: "HP16 0BP",
+    };
+
+    expect(getPropertyAddressLatitudeLongitude(address)).toMatchObject({
+      latitude: 51.6994957,
+      longitude: -0.708966,
+    });
+  });
+});
+
+describe("description", () => {
+  it("should return the description for an application with ProposalBase proposal", () => {
+    const proposal: ProposalBase = {
+      description: "I am description",
+    };
+    expect(getDescription(proposal)).toEqual("I am description");
+  });
+  it("should return the description for an application with ProposalBase proposal", () => {
+    const proposal: GeographyBasedProposal = {
+      projectType: ["alter.balcony"],
+      description: "I am description",
+    };
+    expect(getDescription(proposal)).toEqual("I am description");
+  });
+  it("should return the description for an application with ProposalBase proposal", () => {
+    const proposal: HedgerowRemovalNoticeProposal = {
+      reason: "I am description",
+      hedgerowLength: { metres: 100 },
+      hedgerowAgeLessThanThirty: true,
+    };
+    expect(getDescription(proposal)).toEqual("I am description");
+  });
+});
+
+describe("getCouncilDecision", () => {
+  it("should return the planning officer decision if it exists", () => {
+    const application = {
+      data: {
+        assessment: {
+          planningOfficerDecision: "refused",
+        },
+      },
+    };
+    expect(
+      getCouncilDecision(application as unknown as DprApplication),
+    ).toEqual("refused");
+  });
+  it("should return the committee decision if it exists", () => {
+    const application = {
+      data: {
+        assessment: {
+          committeeDecision: "refused",
+        },
+      },
+    };
+    expect(
+      getCouncilDecision(application as unknown as DprApplication),
+    ).toEqual("refused");
+  });
+  it("should return the committee decision if both exist", () => {
+    const application = {
+      data: {
+        assessment: {
+          planningOfficerDecision: "granted",
+          committeeDecision: "refused",
+        },
+      },
+    };
+    expect(
+      getCouncilDecision(application as unknown as DprApplication),
+    ).toEqual("refused");
+  });
+  it("should return undefined if neither the planning officer or committee decision exists", () => {
+    const application = {};
+    expect(
+      getCouncilDecision(application as unknown as DprApplication),
+    ).toBeUndefined();
+  });
+});
+
+describe("getCouncilDecisionDate", () => {
+  it("should return the planning officer decision date if it exists", () => {
+    const application = {
+      data: {
+        assessment: {
+          planningOfficerDecisionDate: "2021-01-01",
+        },
+      },
+    };
+    expect(
+      getCouncilDecisionDate(application as unknown as DprApplication),
+    ).toEqual("2021-01-01");
+  });
+  it("should return the committee decision date if it exists", () => {
+    const application = {
+      data: {
+        assessment: {
+          committeeDecisionDate: "2021-01-01",
+        },
+      },
+    };
+    expect(
+      getCouncilDecisionDate(application as unknown as DprApplication),
+    ).toEqual("2021-01-01");
+  });
+  it("should return the committee decision date if both exist", () => {
+    const application = {
+      data: {
+        assessment: {
+          planningOfficerDecisionDate: "2020-01-01",
+          committeeDecisionDate: "2021-01-01",
+        },
+      },
+    };
+    expect(
+      getCouncilDecisionDate(application as unknown as DprApplication),
+    ).toEqual("2021-01-01");
+  });
+  it("should return undefined if neither the planning officer or committee decision date exists", () => {
+    const application = {};
+    expect(
+      getCouncilDecisionDate(application as unknown as DprApplication),
+    ).toBeUndefined();
+  });
+});

--- a/__tests__/lib/planningApplication/convertToDprApplication.test.tsx
+++ b/__tests__/lib/planningApplication/convertToDprApplication.test.tsx
@@ -18,7 +18,7 @@
 import { DprPlanningApplication } from "@/types";
 import { convertToDprApplication } from "@/lib/planningApplication/convertToDprApplication";
 import { generateDprApplication as generateOldDprApplication } from "@mocks/dprApplicationFactory";
-import dayjs from "dayjs";
+// import dayjs from "dayjs";
 
 describe("when input is a DprPlanningApplication", () => {
   it("should convert an old DprPlanningApplication into a new DprApplication", () => {
@@ -28,190 +28,190 @@ describe("when input is a DprPlanningApplication", () => {
     expect(result).toHaveProperty("data.application.reference");
   });
 
-  it("should handle an application with no validDate => stage is 'submission'", () => {
-    const oldApp = generateOldDprApplication();
-    oldApp.application.validDate = null;
+  // it("should handle an application with no validDate => stage is 'submission'", () => {
+  //   const oldApp = generateOldDprApplication();
+  //   oldApp.application.validDate = null;
 
-    const converted = convertToDprApplication(oldApp);
-    expect(converted.data.application.stage).toBe("submission");
+  //   const converted = convertToDprApplication(oldApp);
+  //   expect(converted.data.application.stage).toBe("submission");
 
-    expect(converted.data.submission).toBeDefined();
-    expect(converted.data.validation?.validatedAt).toBeUndefined();
-  });
+  //   expect(converted.data.submission).toBeDefined();
+  //   expect(converted.data.validation?.validatedAt).toBeUndefined();
+  // });
 
-  it("should handle an 'invalid' status => stage is 'validation'", () => {
-    const oldApp = generateOldDprApplication({
-      applicationStatus: "invalid",
-    });
-    const converted = convertToDprApplication(oldApp);
-    expect(converted.data.application.stage).toBe("validation");
-    expect(converted.data.validation).toBeDefined();
-  });
+  // it("should handle an 'invalid' status => stage is 'validation'", () => {
+  //   const oldApp = generateOldDprApplication({
+  //     applicationStatus: "invalid",
+  //   });
+  //   const converted = convertToDprApplication(oldApp);
+  //   expect(converted.data.application.stage).toBe("validation");
+  //   expect(converted.data.validation).toBeDefined();
+  // });
 
-  it("should handle an 'returned' status => stage is 'validation'", () => {
-    const oldApp = generateOldDprApplication({
-      applicationStatus: "returned",
-    });
-    const converted = convertToDprApplication(oldApp);
-    expect(converted.data.application.stage).toBe("validation");
-    expect(converted.data.validation).toBeDefined();
-  });
+  // it("should handle an 'returned' status => stage is 'validation'", () => {
+  //   const oldApp = generateOldDprApplication({
+  //     applicationStatus: "returned",
+  //   });
+  //   const converted = convertToDprApplication(oldApp);
+  //   expect(converted.data.application.stage).toBe("validation");
+  //   expect(converted.data.validation).toBeDefined();
+  // });
 
-  it("should handle a consultation scenario => stage is 'consultation'", () => {
-    const today = dayjs.utc();
-    const startDate = today.subtract(1, "day").format("YYYY-MM-DD");
-    const endDate = today.add(5, "day").format("YYYY-MM-DD");
+  // it("should handle a consultation scenario => stage is 'consultation'", () => {
+  //   const today = dayjs.utc();
+  //   const startDate = today.subtract(1, "day").format("YYYY-MM-DD");
+  //   const endDate = today.add(5, "day").format("YYYY-MM-DD");
 
-    const oldApp = generateOldDprApplication({
-      applicationStatus: "pending",
-    });
+  //   const oldApp = generateOldDprApplication({
+  //     applicationStatus: "pending",
+  //   });
 
-    oldApp.application.consultation = {
-      startDate,
-      endDate,
-      consulteeComments: [],
-      publishedComments: [],
-    };
+  //   oldApp.application.consultation = {
+  //     startDate,
+  //     endDate,
+  //     consulteeComments: [],
+  //     publishedComments: [],
+  //   };
 
-    const converted = convertToDprApplication(oldApp);
-    expect(converted.data.application.stage).toBe("consultation");
-    expect(converted.data.consultation).toBeDefined();
-    expect(converted.data.consultation?.startDate).toBe(startDate);
-    expect(converted.data.consultation?.endDate).toBe(endDate);
-  });
+  //   const converted = convertToDprApplication(oldApp);
+  //   expect(converted.data.application.stage).toBe("consultation");
+  //   expect(converted.data.consultation).toBeDefined();
+  //   expect(converted.data.consultation?.startDate).toBe(startDate);
+  //   expect(converted.data.consultation?.endDate).toBe(endDate);
+  // });
 
-  it("should handle an application with no consultation or not currently in window => stage is 'assessment'", () => {
-    const oldApp = generateOldDprApplication({
-      applicationStatus: "pending",
-    });
+  // it("should handle an application with no consultation or not currently in window => stage is 'assessment'", () => {
+  //   const oldApp = generateOldDprApplication({
+  //     applicationStatus: "pending",
+  //   });
 
-    const startDate = dayjs.utc().subtract(30, "days").format("YYYY-MM-DD");
-    const endDate = dayjs.utc().subtract(20, "days").format("YYYY-MM-DD");
-    oldApp.application.consultation = {
-      startDate,
-      endDate,
-      consulteeComments: [],
-      publishedComments: [],
-    };
+  //   const startDate = dayjs.utc().subtract(30, "days").format("YYYY-MM-DD");
+  //   const endDate = dayjs.utc().subtract(20, "days").format("YYYY-MM-DD");
+  //   oldApp.application.consultation = {
+  //     startDate,
+  //     endDate,
+  //     consulteeComments: [],
+  //     publishedComments: [],
+  //   };
 
-    const converted = convertToDprApplication(oldApp);
-    expect(converted.data.application.stage).toBe("assessment");
+  //   const converted = convertToDprApplication(oldApp);
+  //   expect(converted.data.application.stage).toBe("assessment");
 
-    expect(converted.data.assessment).toBeDefined();
-  });
+  //   expect(converted.data.assessment).toBeDefined();
+  // });
 
-  it("should handle an application with appeal => stage is 'appeal'", () => {
-    const oldApp = generateOldDprApplication({
-      appeal: {
-        reason: "some reason",
-      },
-    });
+  // it("should handle an application with appeal => stage is 'appeal'", () => {
+  //   const oldApp = generateOldDprApplication({
+  //     appeal: {
+  //       reason: "some reason",
+  //     },
+  //   });
 
-    const converted = convertToDprApplication(oldApp);
-    expect(converted.data.application.stage).toBe("appeal");
-    expect(converted.data.appeal).toBeDefined();
-    expect(converted.data.appeal?.reason).toBe("some reason");
-  });
+  //   const converted = convertToDprApplication(oldApp);
+  //   expect(converted.data.application.stage).toBe("appeal");
+  //   expect(converted.data.appeal).toBeDefined();
+  //   expect(converted.data.appeal?.reason).toBe("some reason");
+  // });
 
-  it("should map application status to new system statuses correctly", () => {
-    const oldApp = generateOldDprApplication({
-      applicationStatus: "Appeal allowed",
-    });
-    const converted = convertToDprApplication(oldApp);
-    expect(converted.data.application.status).toBe("determined");
+  // it("should map application status to new system statuses correctly", () => {
+  //   const oldApp = generateOldDprApplication({
+  //     applicationStatus: "Appeal allowed",
+  //   });
+  //   const converted = convertToDprApplication(oldApp);
+  //   expect(converted.data.application.status).toBe("determined");
 
-    // "withdrawn" => "withdrawn"
-    const withdrawnApp = generateOldDprApplication({
-      applicationStatus: "withdrawn",
-    });
-    const convertedWithdrawn = convertToDprApplication(withdrawnApp);
-    expect(convertedWithdrawn.data.application.status).toBe("withdrawn");
+  //   // "withdrawn" => "withdrawn"
+  //   const withdrawnApp = generateOldDprApplication({
+  //     applicationStatus: "withdrawn",
+  //   });
+  //   const convertedWithdrawn = convertToDprApplication(withdrawnApp);
+  //   expect(convertedWithdrawn.data.application.status).toBe("withdrawn");
 
-    // "invalid" => "returned"
-    const invalidApp = generateOldDprApplication({
-      applicationStatus: "invalid",
-    });
-    const convertedInvalid = convertToDprApplication(invalidApp);
-    expect(convertedInvalid.data.application.status).toBe("returned");
+  //   // "invalid" => "returned"
+  //   const invalidApp = generateOldDprApplication({
+  //     applicationStatus: "invalid",
+  //   });
+  //   const convertedInvalid = convertToDprApplication(invalidApp);
+  //   expect(convertedInvalid.data.application.status).toBe("returned");
 
-    // "pending" => "undetermined"
-    const pendingApp = generateOldDprApplication({
-      applicationStatus: "pending",
-    });
-    const convertedPending = convertToDprApplication(pendingApp);
-    expect(convertedPending.data.application.status).toBe("undetermined");
-  });
+  //   // "pending" => "undetermined"
+  //   const pendingApp = generateOldDprApplication({
+  //     applicationStatus: "pending",
+  //   });
+  //   const convertedPending = convertToDprApplication(pendingApp);
+  //   expect(convertedPending.data.application.status).toBe("undetermined");
+  // });
 
-  it("should map localPlanningAuthority section correctly", () => {
-    const oldApp = generateOldDprApplication({});
+  // it("should map localPlanningAuthority section correctly", () => {
+  //   const oldApp = generateOldDprApplication({});
 
-    const converted = convertToDprApplication(oldApp);
-    expect(
-      typeof converted.data.localPlanningAuthority
-        ?.commentsAcceptedUntilDecision,
-    ).toBe("boolean");
-  });
+  //   const converted = convertToDprApplication(oldApp);
+  //   expect(
+  //     typeof converted.data.localPlanningAuthority
+  //       ?.commentsAcceptedUntilDecision,
+  //   ).toBe("boolean");
+  // });
 
-  it("should map submission data correctly", () => {
-    const oldApp = generateOldDprApplication();
-    oldApp.application.receivedDate = "2023-01-15";
+  // it("should map submission data correctly", () => {
+  //   const oldApp = generateOldDprApplication();
+  //   oldApp.application.receivedDate = "2023-01-15";
 
-    const converted = convertToDprApplication(oldApp);
-    expect(converted.data.submission?.submittedAt).toBe("2023-01-15");
-  });
+  //   const converted = convertToDprApplication(oldApp);
+  //   expect(converted.data.submission?.submittedAt).toBe("2023-01-15");
+  // });
 
-  it("should map validation data if validDate exists", () => {
-    const oldApp = generateOldDprApplication();
-    oldApp.application.receivedDate = "2023-01-10";
-    oldApp.application.validDate = "2023-02-01";
+  // it("should map validation data if validDate exists", () => {
+  //   const oldApp = generateOldDprApplication();
+  //   oldApp.application.receivedDate = "2023-01-10";
+  //   oldApp.application.validDate = "2023-02-01";
 
-    const converted = convertToDprApplication(oldApp);
-    expect(converted.data.validation?.receivedAt).toBe("2023-01-10");
-    expect(converted.data.validation?.validatedAt).toBe("2023-02-01");
-    expect(converted.data.validation?.isValid).toBe(true);
-  });
+  //   const converted = convertToDprApplication(oldApp);
+  //   expect(converted.data.validation?.receivedAt).toBe("2023-01-10");
+  //   expect(converted.data.validation?.validatedAt).toBe("2023-02-01");
+  //   expect(converted.data.validation?.isValid).toBe(true);
+  // });
 
-  it("should omit validation data if validDate is null", () => {
-    const oldApp = generateOldDprApplication();
-    oldApp.application.validDate = null;
+  // it("should omit validation data if validDate is null", () => {
+  //   const oldApp = generateOldDprApplication();
+  //   oldApp.application.validDate = null;
 
-    const converted = convertToDprApplication(oldApp);
-    expect(converted.data.validation?.validatedAt).toBeUndefined();
-  });
+  //   const converted = convertToDprApplication(oldApp);
+  //   expect(converted.data.validation?.validatedAt).toBeUndefined();
+  // });
 
-  it("should map assessment data", () => {
-    const oldApp = generateOldDprApplication({
-      decision: "granted",
-    });
-    oldApp.application.determinedAt = "2024-02-28";
-    const converted = convertToDprApplication(oldApp);
+  // it("should map assessment data", () => {
+  //   const oldApp = generateOldDprApplication({
+  //     decision: "granted",
+  //   });
+  //   oldApp.application.determinedAt = "2024-02-28";
+  //   const converted = convertToDprApplication(oldApp);
 
-    expect(converted.data.assessment).toBeDefined();
-    expect(converted.data.assessment?.planningOfficerDecision).toBe("granted");
-    expect(converted.data.assessment?.planningOfficerDecisionDate).toBe(
-      "2024-02-28",
-    );
-    expect(converted.data.assessment?.decisionNotice?.url).toBe(
-      "https://planningregister.org",
-    );
-  });
+  //   expect(converted.data.assessment).toBeDefined();
+  //   expect(converted.data.assessment?.planningOfficerDecision).toBe("granted");
+  //   expect(converted.data.assessment?.planningOfficerDecisionDate).toBe(
+  //     "2024-02-28",
+  //   );
+  //   expect(converted.data.assessment?.decisionNotice?.url).toBe(
+  //     "https://planningregister.org",
+  //   );
+  // });
 
-  it("should map appeal data if present", () => {
-    const oldApp = generateOldDprApplication({
-      applicationStatus: "Appeal determined",
-      appeal: {
-        lodgedDate: "2023-02-02",
-        startedDate: "2023-02-10",
-        decisionDate: "2023-05-01",
-        decision: "allowed",
-        reason: "Lorem ipsum",
-        validatedDate: "2023-02-05",
-      },
-    });
-    const converted = convertToDprApplication(oldApp);
+  // it("should map appeal data if present", () => {
+  //   const oldApp = generateOldDprApplication({
+  //     applicationStatus: "Appeal determined",
+  //     appeal: {
+  //       lodgedDate: "2023-02-02",
+  //       startedDate: "2023-02-10",
+  //       decisionDate: "2023-05-01",
+  //       decision: "allowed",
+  //       reason: "Lorem ipsum",
+  //       validatedDate: "2023-02-05",
+  //     },
+  //   });
+  //   const converted = convertToDprApplication(oldApp);
 
-    expect(converted.data.appeal).toBeDefined();
-    expect(converted.data.appeal?.lodgedDate).toBe("2023-02-02");
-    expect(converted.data.appeal?.decision).toBe("allowed");
-  });
+  //   expect(converted.data.appeal).toBeDefined();
+  //   expect(converted.data.appeal?.lodgedDate).toBe("2023-02-02");
+  //   expect(converted.data.appeal?.decision).toBe("allowed");
+  // });
 });

--- a/__tests__/lib/planningApplication/convertToDprApplication.test.tsx
+++ b/__tests__/lib/planningApplication/convertToDprApplication.test.tsx
@@ -15,19 +15,10 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { DprApplication, DprPlanningApplication } from "@/types";
-import { convertToDprApplication } from "@/util/convertToDprApplication";
-import { generateDprApplication as generateNewDprApplication } from "@mocks/dprNewApplicationFactory";
+import { DprPlanningApplication } from "@/types";
+import { convertToDprApplication } from "@/lib/planningApplication/convertToDprApplication";
 import { generateDprApplication as generateOldDprApplication } from "@mocks/dprApplicationFactory";
 import dayjs from "dayjs";
-
-describe("when input is a DprApplication", () => {
-  it("should return the same DprApplication if already in the correct structure", () => {
-    const newApp: DprApplication = generateNewDprApplication();
-    const result = convertToDprApplication(newApp);
-    expect(result).toBe(newApp);
-  });
-});
 
 describe("when input is a DprPlanningApplication", () => {
   it("should convert an old DprPlanningApplication into a new DprApplication", () => {
@@ -35,13 +26,6 @@ describe("when input is a DprPlanningApplication", () => {
     const result = convertToDprApplication(oldApp);
     expect(result).toHaveProperty("applicationType");
     expect(result).toHaveProperty("data.application.reference");
-  });
-
-  it("should throw an error if it does not match either shape (edge case)", () => {
-    const invalidObj = {} as DprPlanningApplication;
-    expect(() => convertToDprApplication(invalidObj)).toThrow(
-      "Invalid application object",
-    );
   });
 
   it("should handle an application with no validDate => stage is 'submission'", () => {
@@ -173,7 +157,7 @@ describe("when input is a DprPlanningApplication", () => {
     oldApp.application.receivedDate = "2023-01-15";
 
     const converted = convertToDprApplication(oldApp);
-    expect(converted.data.submission?.submittedAt).toBe("2023-01-15T00:00:00Z");
+    expect(converted.data.submission?.submittedAt).toBe("2023-01-15");
   });
 
   it("should map validation data if validDate exists", () => {
@@ -182,8 +166,8 @@ describe("when input is a DprPlanningApplication", () => {
     oldApp.application.validDate = "2023-02-01";
 
     const converted = convertToDprApplication(oldApp);
-    expect(converted.data.validation?.receivedAt).toBe("2023-01-10T00:00:00Z");
-    expect(converted.data.validation?.validatedAt).toBe("2023-02-01T00:00:00Z");
+    expect(converted.data.validation?.receivedAt).toBe("2023-01-10");
+    expect(converted.data.validation?.validatedAt).toBe("2023-02-01");
     expect(converted.data.validation?.isValid).toBe(true);
   });
 

--- a/__tests__/lib/planningApplication/converter.test.tsx
+++ b/__tests__/lib/planningApplication/converter.test.tsx
@@ -1,0 +1,624 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {
+  convertToDprApplication,
+  getIsConsultationPeriod,
+  isDprApplication,
+} from "@/lib/planningApplication/converter";
+import { generateExampleApplications } from "@mocks/dprNewApplicationFactory";
+import { generateDprApplication as generateOldDprApplication } from "@mocks/dprApplicationFactory";
+import { DprApplication, DprPlanningApplication } from "@/types";
+import { PriorApprovalAssessment } from "@/types/odp-types/schemas/postSubmissionApplication/data/Assessment";
+
+// YYYY-MM-DD
+const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+// YYYY-MM-DDTHH:MM:SS.SSSZ
+const utcDateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+describe("isDprApplication", () => {
+  it("should return true if the given object is a DprApplication", () => {
+    const { planningOfficerDetermined } = generateExampleApplications();
+    const app = planningOfficerDetermined;
+    expect(isDprApplication(app)).toBe(true);
+  });
+
+  it("should return false if the given object is a DprPlanningApplication", () => {
+    const app = generateOldDprApplication();
+    expect(isDprApplication(app)).toBe(false);
+  });
+
+  it("should throw an error if the given object is invalid", () => {
+    const app = { invalid: "object" };
+    expect(() => isDprApplication(app as unknown as DprApplication)).toThrow(
+      new Error("Invalid application object"),
+    );
+  });
+});
+
+describe("getIsConsultationPeriod", () => {
+  it("should return true if the current date is within the consultation period", () => {
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - 1); // Yesterday
+    const endDate = new Date();
+    endDate.setDate(endDate.getDate() + 1); // Tomorrow
+
+    const result = getIsConsultationPeriod(startDate, endDate);
+
+    expect(result).toBe(true);
+  });
+
+  it("should return true if the current date is the same as the end date", () => {
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - 1); // Yesterday
+    const endDate = new Date();
+
+    const result = getIsConsultationPeriod(startDate, endDate);
+
+    expect(result).toBe(true);
+  });
+
+  it("should return false if the current date is before the consultation period", () => {
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() + 1); // Tomorrow
+    const endDate = new Date();
+    endDate.setDate(endDate.getDate() + 2); // Day after tomorrow
+
+    const result = getIsConsultationPeriod(startDate, endDate);
+
+    expect(result).toBe(false);
+  });
+
+  it("should return false if the current date is after the consultation period", () => {
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - 2); // Day before yesterday
+    const endDate = new Date();
+    endDate.setDate(endDate.getDate() - 1); // Yesterday
+
+    const result = getIsConsultationPeriod(startDate, endDate);
+
+    expect(result).toBe(false);
+  });
+
+  it("should return false if the start date is after the end date", () => {
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() + 2); // Day after tomorrow
+    const endDate = new Date();
+    endDate.setDate(endDate.getDate() + 1); // Tomorrow
+
+    const result = getIsConsultationPeriod(startDate, endDate);
+
+    expect(result).toBe(false);
+  });
+});
+
+/**
+ * 01-submission
+ * pending
+ * not_started
+ *
+ * 02-validation-01-invalid
+ * invalidated
+ * returned
+ *
+ * 03-consultation
+ * in_assessment
+ * assessment_in_progress
+ *
+ * 04-assessment-00-assessment-in-progress
+ * in_assessment
+ * assessment_in_progress
+ * awaiting_determination
+ * to_be_reviewed
+ *
+ * 04-assessment-01-council-determined
+ * determined
+ *
+ * 04-assessment-02-assessment-in-committee
+ * in_committee
+ *
+ * 04-assessment-03-committee-determined
+ * determined
+ *
+ * 05-appeal-00-appeal-lodged
+ * Appeal lodged
+ *
+ * 05-appeal-01-appeal-validated
+ * Appeal valid
+ *
+ * 05-appeal-02-appeal-started
+ * Appeal started
+ *
+ * 05-appeal-03-appeal-determined
+ * 05-appeal-04-appeal-withdrawn
+ * Appeal determined
+ *
+ * Appeal withdrawn
+ * Appeal allowed
+ * Appeal dismissed
+ * Appeal split decision
+ *
+ * 06-assessment-withdrawn
+ * withdrawn
+ * closed
+ */
+describe("convertToDprApplication", () => {
+  const testCommon = (result: DprApplication, from: DprPlanningApplication) => {
+    // keeps the same application type
+    expect(result.applicationType).toBe(from.applicationType);
+
+    // data object should be the same
+    expect(result.data).toEqual(result.data);
+
+    // keeps the same reference in the right places
+    expect(result.metadata.id).toEqual(from.application.reference);
+    expect(result.data.application.reference).toEqual(
+      from.application.reference,
+    );
+    expect(result.metadata.id).toEqual(result.data.application.reference);
+
+    // metadata
+    expect(result.metadata).toBeDefined();
+    expect(Object.keys(result.metadata)).toEqual([
+      "organisation",
+      "id",
+      "publishedAt",
+      "submittedAt",
+      "schema",
+    ]);
+
+    expect(result.metadata.publishedAt).toMatch(utcDateRegex);
+    expect(result.metadata.submittedAt).toMatch(utcDateRegex);
+  };
+
+  const consultationStartDateInPast = new Date(
+    new Date().getTime() - 100 * 24 * 60 * 60 * 1000,
+  );
+
+  const testConsultationDatesAreInPast = (result: DprApplication) => {
+    expect(result.data.consultation?.startDate).not.toBeNull();
+    expect(result.data.consultation?.endDate).not.toBeNull();
+    const startDate = new Date(result.data.consultation?.startDate as string);
+    const endDate = new Date(result.data.consultation?.endDate as string);
+    expect(startDate).toBeInstanceOf(Date);
+    expect(endDate).toBeInstanceOf(Date);
+    expect(startDate < endDate).toBe(true);
+
+    const now = new Date();
+    expect(now >= startDate && now >= endDate).toBe(true);
+  };
+
+  const testAssessment = (result: DprApplication) => {
+    expect(result.applicationStatusSummary).toBe("Assessment in progress");
+    expect(result.applicationDecisionSummary).not.toBeDefined();
+    expect(result.data.application.stage).toBe("assessment");
+    expect(result.data.application.status).toBe("undetermined");
+    testConsultationDatesAreInPast(result);
+    expect(result.data.assessment?.planningOfficerDecision).toBeUndefined();
+    expect(result.data.assessment?.planningOfficerDecisionDate).toBeUndefined();
+    expect(result.data.appeal).toBeUndefined();
+  };
+
+  const testDetermined = (
+    result: DprApplication,
+    from: DprPlanningApplication,
+  ) => {
+    expect(result.data.application.status).toBe("determined");
+    testConsultationDatesAreInPast(result);
+    expect(result.data.assessment?.planningOfficerDecision).not.toBeNull();
+    expect(result.data.assessment?.planningOfficerDecisionDate).toMatch(
+      utcDateRegex,
+    );
+    expect(result.data.assessment?.planningOfficerDecision).toBe(
+      from.application.decision,
+    );
+  };
+
+  describe("03-consultation", () => {
+    it("in_assessment", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "in_assessment",
+        consultationStartDate: new Date(),
+      });
+      const result = convertToDprApplication(from);
+      testCommon(result, from);
+      expect(result.applicationStatusSummary).toBe("Consultation in progress");
+      expect(result.applicationDecisionSummary).not.toBeDefined();
+      expect(result.data.application.stage).toBe("consultation");
+      expect(result.data.application.status).toBe("undetermined");
+    });
+    it("assessment_in_progress", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "assessment_in_progress",
+        consultationStartDate: new Date(),
+      });
+      const result = convertToDprApplication(from);
+      testCommon(result, from);
+      expect(result.applicationStatusSummary).toBe("Consultation in progress");
+      expect(result.applicationDecisionSummary).not.toBeDefined();
+      expect(result.data.application.stage).toBe("consultation");
+      expect(result.data.application.status).toBe("undetermined");
+    });
+  });
+
+  describe("04-assessment-00-assessment-in-progress", () => {
+    it("in_assessment", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "in_assessment",
+        decision: null,
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const result = convertToDprApplication(from);
+      testAssessment(result);
+    });
+    it("assessment_in_progress", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "assessment_in_progress",
+        decision: null,
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const result = convertToDprApplication(from);
+      testAssessment(result);
+    });
+    it("awaiting_determination", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "awaiting_determination",
+        decision: null,
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const result = convertToDprApplication(from);
+      testAssessment(result);
+    });
+    it("to_be_reviewed", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "to_be_reviewed",
+        decision: null,
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const result = convertToDprApplication(from);
+      testAssessment(result);
+    });
+  });
+
+  describe("04-assessment-01-council-determined", () => {
+    it("determined", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "determined",
+        decision: "granted",
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const result = convertToDprApplication(from);
+      expect(result.data.application.stage).toBe("assessment");
+      expect(result.data.appeal).toBeUndefined();
+      testDetermined(result, from);
+      expect(result.applicationStatusSummary).toBe("Determined");
+      expect(result.applicationDecisionSummary).toBe("Granted");
+
+      // Prior approval applications
+      const priorApprovalFromGranted = generateOldDprApplication({
+        applicationType: "pa.part1.classA",
+        applicationStatus: "determined",
+        decision: "granted",
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const priorApprovalResultGranted = convertToDprApplication(
+        priorApprovalFromGranted,
+      );
+      const priorApprovalResultGrantedAssessment = priorApprovalResultGranted
+        .data.assessment as PriorApprovalAssessment;
+      expect(priorApprovalResultGrantedAssessment.priorApprovalRequired).toBe(
+        true,
+      );
+
+      const priorApprovalFromRefused = generateOldDprApplication({
+        applicationType: "pa.part1.classA",
+        applicationStatus: "determined",
+        decision: "refused",
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const priorApprovalResultRefused = convertToDprApplication(
+        priorApprovalFromRefused,
+      );
+      const priorApprovalResultRefusedAssessment = priorApprovalResultRefused
+        .data.assessment as PriorApprovalAssessment;
+      expect(priorApprovalResultRefusedAssessment.priorApprovalRequired).toBe(
+        true,
+      );
+      expect(priorApprovalResultRefused.applicationDecisionSummary).toBe(
+        "Prior approval required and refused",
+      );
+
+      // @TODO can't test Prior approval not required yet because its not in the types
+    });
+  });
+
+  describe("04-assessment-02-assessment-in-committee", () => {
+    it("in_committee", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "in_committee",
+        decision: null,
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const result = convertToDprApplication(from);
+      testAssessment(result);
+    });
+  });
+
+  describe("04-assessment-03-committee-determined", () => {
+    it("determined", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "determined",
+        decision: "granted",
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const result = convertToDprApplication(from);
+      expect(result.data.application.stage).toBe("assessment");
+      expect(result.data.appeal).toBeUndefined();
+      testDetermined(result, from);
+      expect(result.applicationStatusSummary).toBe("Determined");
+      expect(result.applicationDecisionSummary).toBe("Granted");
+    });
+  });
+
+  describe("05-appeal-00-appeal-lodged", () => {
+    it("Appeal lodged", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "Appeal lodged",
+        decision: "refused",
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const result = convertToDprApplication(from);
+      expect(result.data.application.stage).toBe("appeal");
+      expect(result.applicationStatusSummary).toBe("Appeal lodged");
+      expect(result.applicationDecisionSummary).toBe("Refused");
+      testDetermined(result, from);
+      expect(result.data.appeal).not.toBeUndefined();
+      expect(result.data.appeal?.reason).toBeTruthy();
+      expect(result.data.appeal?.lodgedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.validatedDate).not.toBeDefined();
+      expect(result.data.appeal?.startedDate).not.toBeDefined();
+      expect(result.data.appeal?.decisionDate).not.toBeDefined();
+      expect(result.data.appeal?.decision).not.toBeDefined();
+      expect(result.data.appeal?.files?.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("05-appeal-01-appeal-validated", () => {
+    it("Appeal valid", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "Appeal valid",
+        decision: "refused",
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const result = convertToDprApplication(from);
+      expect(result.data.application.stage).toBe("appeal");
+      expect(result.applicationStatusSummary).toBe("Appeal validated");
+      expect(result.applicationDecisionSummary).toBe("Refused");
+      testDetermined(result, from);
+      expect(result.data.appeal).not.toBeUndefined();
+      expect(result.data.appeal?.reason).toBeTruthy();
+      expect(result.data.appeal?.lodgedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.validatedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.startedDate).not.toBeDefined();
+      expect(result.data.appeal?.decisionDate).not.toBeDefined();
+      expect(result.data.appeal?.decision).not.toBeDefined();
+      expect(result.data.appeal?.files?.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("05-appeal-02-appeal-started", () => {
+    it("Appeal started", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "Appeal started",
+        decision: "refused",
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const result = convertToDprApplication(from);
+      expect(result.data.application.stage).toBe("appeal");
+      expect(result.applicationStatusSummary).toBe("Appeal in progress");
+      expect(result.applicationDecisionSummary).toBe("Refused");
+      testDetermined(result, from);
+      expect(result.data.appeal).not.toBeUndefined();
+      expect(result.data.appeal?.reason).toBeTruthy();
+      expect(result.data.appeal?.lodgedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.validatedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.startedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.decisionDate).not.toBeDefined();
+      expect(result.data.appeal?.decision).not.toBeDefined();
+      expect(result.data.appeal?.files?.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("05-appeal-03-appeal-determined", () => {
+    it("Appeal determined", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "Appeal determined",
+        decision: "refused",
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const result = convertToDprApplication(from);
+      expect(result.data.application.stage).toBe("appeal");
+      expect(result.applicationStatusSummary).toBe("Appeal decided");
+      expect(result.applicationDecisionSummary).toBe("Refused");
+      testDetermined(result, from);
+      expect(result.data.appeal?.decision).toBe("allowed");
+      expect(result.data.appeal).not.toBeUndefined();
+      expect(result.data.appeal?.reason).toBeTruthy();
+      expect(result.data.appeal?.lodgedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.validatedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.startedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.decisionDate).toMatch(dateRegex);
+      expect(result.data.appeal?.files?.length).toBeGreaterThan(0);
+    });
+    it("Appeal withdrawn", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "Appeal withdrawn",
+        decision: "refused",
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const result = convertToDprApplication(from);
+      expect(result.data.application.stage).toBe("appeal");
+      expect(result.applicationStatusSummary).toBe("Appeal decided");
+      expect(result.applicationDecisionSummary).toBe("Refused");
+      testDetermined(result, from);
+      expect(result.data.appeal?.decision).toBe("withdrawn");
+      expect(result.data.appeal).not.toBeUndefined();
+      expect(result.data.appeal?.reason).toBeTruthy();
+      expect(result.data.appeal?.lodgedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.validatedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.startedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.decisionDate).toMatch(dateRegex);
+      expect(result.data.appeal?.files?.length).toBeGreaterThan(0);
+    });
+    it("Appeal allowed", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "Appeal allowed",
+        decision: "refused",
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const result = convertToDprApplication(from);
+      expect(result.data.application.stage).toBe("appeal");
+      expect(result.applicationStatusSummary).toBe("Appeal decided");
+      expect(result.applicationDecisionSummary).toBe("Refused");
+      testDetermined(result, from);
+      expect(result.data.appeal?.decision).toBe("allowed");
+      expect(result.data.appeal).not.toBeUndefined();
+      expect(result.data.appeal?.reason).toBeTruthy();
+      expect(result.data.appeal?.lodgedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.validatedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.startedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.decisionDate).toMatch(dateRegex);
+      expect(result.data.appeal?.files?.length).toBeGreaterThan(0);
+    });
+    it("Appeal dismissed", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "Appeal dismissed",
+        decision: "refused",
+        consultationStartDate: consultationStartDateInPast,
+      });
+
+      const result = convertToDprApplication(from);
+      expect(result.data.application.stage).toBe("appeal");
+      expect(result.applicationStatusSummary).toBe("Appeal decided");
+      expect(result.applicationDecisionSummary).toBe("Refused");
+      testDetermined(result, from);
+      expect(result.data.appeal?.decision).toBe("dismissed");
+      expect(result.data.appeal).not.toBeUndefined();
+      expect(result.data.appeal?.reason).toBeTruthy();
+      expect(result.data.appeal?.lodgedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.validatedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.startedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.decisionDate).toMatch(dateRegex);
+      expect(result.data.appeal?.files?.length).toBeGreaterThan(0);
+    });
+    it("Appeal split decision", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "Appeal split decision",
+        decision: "refused",
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const result = convertToDprApplication(from);
+      expect(result.data.application.stage).toBe("appeal");
+      expect(result.applicationStatusSummary).toBe("Appeal decided");
+      expect(result.applicationDecisionSummary).toBe("Refused");
+      testDetermined(result, from);
+      expect(result.data.appeal?.decision).toBe("splitDecision");
+      expect(result.data.appeal).not.toBeUndefined();
+      expect(result.data.appeal?.reason).toBeTruthy();
+      expect(result.data.appeal?.lodgedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.validatedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.startedDate).toMatch(dateRegex);
+      expect(result.data.appeal?.decisionDate).toMatch(dateRegex);
+      expect(result.data.appeal?.files?.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("06-assessment-withdrawn", () => {
+    it("withdrawn", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "withdrawn",
+        consultationStartDate: consultationStartDateInPast,
+        decision: null,
+      });
+      const result = convertToDprApplication(from);
+      expect(result.data.application.stage).toBe("assessment");
+      expect(result.applicationStatusSummary).toBe("Withdrawn");
+      expect(result.applicationDecisionSummary).not.toBeDefined();
+      expect(result.data.application.withdrawnAt).not.toBeUndefined();
+      expect(result.data.application.withdrawnAt).toMatch(utcDateRegex);
+      testConsultationDatesAreInPast(result);
+      expect(result.data.assessment?.planningOfficerDecision).toBeUndefined();
+      expect(
+        result.data.assessment?.planningOfficerDecisionDate,
+      ).toBeUndefined();
+
+      expect(result.data.appeal).toBeUndefined();
+    });
+    it("closed", () => {
+      const applicationType = "pp.full";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "closed",
+        consultationStartDate: consultationStartDateInPast,
+        decision: null,
+      });
+
+      expect(() => {
+        convertToDprApplication(from);
+      }).toThrow(
+        new Error("Closed application not enough information to convert"),
+      );
+    });
+  });
+});

--- a/__tests__/lib/planningApplication/status.test.ts
+++ b/__tests__/lib/planningApplication/status.test.ts
@@ -530,6 +530,7 @@ describe("getApplicationDprStatusSummary", () => {
             siteNotice: true,
           },
           assessment: {
+            expiryDate: formatDateToYmd(dates.assessment.expiryAt.toDate()),
             planningOfficerRecommendation: "refused",
             committeeSentDate: formatDateToYmd(
               dates.assessment.committeeSentAt.toDate(),
@@ -573,6 +574,7 @@ describe("getApplicationDprStatusSummary", () => {
             siteNotice: true,
           },
           assessment: {
+            expiryDate: formatDateToYmd(dates.assessment.expiryAt.toDate()),
             planningOfficerDecision: "granted",
             planningOfficerDecisionDate: formatDateToYmd(
               dates.assessment.planningOfficerDecisionAt.toDate(),
@@ -619,6 +621,7 @@ describe("getApplicationDprStatusSummary", () => {
             siteNotice: true,
           },
           assessment: {
+            expiryDate: formatDateToYmd(dates.assessment.expiryAt.toDate()),
             planningOfficerRecommendation: "refused",
             committeeSentDate: formatDateToYmd(
               dates.assessment.committeeSentAt.toDate(),
@@ -669,6 +672,7 @@ describe("getApplicationDprStatusSummary", () => {
             siteNotice: true,
           },
           assessment: {
+            expiryDate: formatDateToYmd(dates.assessment.expiryAt.toDate()),
             planningOfficerDecisionDate: formatDateToYmd(
               dates.assessment.planningOfficerDecisionAt.toDate(),
             ),
@@ -714,6 +718,7 @@ describe("getApplicationDprStatusSummary", () => {
             siteNotice: true,
           },
           assessment: {
+            expiryDate: formatDateToYmd(dates.assessment.expiryAt.toDate()),
             planningOfficerRecommendation: "refused",
             committeeSentDate: formatDateToYmd(
               dates.assessment.committeeSentAt.toDate(),
@@ -765,6 +770,7 @@ describe("getApplicationDprStatusSummary", () => {
             siteNotice: true,
           },
           assessment: {
+            expiryDate: formatDateToYmd(dates.assessment.expiryAt.toDate()),
             planningOfficerRecommendation: "refused",
             committeeSentDate: formatDateToYmd(
               dates.assessment.committeeSentAt.toDate(),
@@ -818,6 +824,7 @@ describe("getApplicationDprStatusSummary", () => {
             siteNotice: true,
           },
           assessment: {
+            expiryDate: formatDateToYmd(dates.assessment.expiryAt.toDate()),
             planningOfficerRecommendation: "refused",
             committeeSentDate: formatDateToYmd(
               dates.assessment.committeeSentAt.toDate(),
@@ -872,6 +879,7 @@ describe("getApplicationDprStatusSummary", () => {
             siteNotice: true,
           },
           assessment: {
+            expiryDate: formatDateToYmd(dates.assessment.expiryAt.toDate()),
             planningOfficerRecommendation: "refused",
             committeeSentDate: formatDateToYmd(
               dates.assessment.committeeSentAt.toDate(),
@@ -927,6 +935,7 @@ describe("getApplicationDprStatusSummary", () => {
             siteNotice: true,
           },
           assessment: {
+            expiryDate: formatDateToYmd(dates.assessment.expiryAt.toDate()),
             planningOfficerRecommendation: "refused",
             committeeSentDate: formatDateToYmd(
               dates.assessment.committeeSentAt.toDate(),
@@ -984,6 +993,7 @@ describe("getApplicationDprStatusSummary", () => {
             siteNotice: true,
           },
           assessment: {
+            expiryDate: formatDateToYmd(dates.assessment.expiryAt.toDate()),
             planningOfficerRecommendation: "refused",
             committeeSentDate: formatDateToYmd(
               dates.assessment.committeeSentAt.toDate(),
@@ -1010,7 +1020,7 @@ describe("getApplicationDprStatusSummary", () => {
         metadata: generateMetadata(dates),
       };
       const statusSummary = getApplicationDprStatusSummary(application);
-      expect(statusSummary).toBe("Appeal withdrawn");
+      expect(statusSummary).toBe("Appeal decided");
     });
   });
 });

--- a/__tests__/mocks/dprNewApplicationFactory.test.ts
+++ b/__tests__/mocks/dprNewApplicationFactory.test.ts
@@ -15,7 +15,6 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { DprApplication } from "@/types";
 import {
   PostSubmissionAssessment,
   PriorApprovalAssessment,
@@ -227,6 +226,19 @@ describe("generateDprApplication", () => {
     expect(
       planningPermissionFullHouseholderConsultation.data.consultation?.endDate,
     ).toBeDefined();
+    const startDate = new Date(
+      planningPermissionFullHouseholderConsultation?.data?.consultation
+        ?.startDate as string,
+    );
+    const endDate = new Date(
+      planningPermissionFullHouseholderConsultation?.data?.consultation
+        ?.endDate as string,
+    );
+    expect(startDate).toBeInstanceOf(Date);
+    expect(endDate).toBeInstanceOf(Date);
+    expect(startDate < endDate).toBe(true);
+    const now = new Date();
+    expect(now >= startDate && now <= endDate).toBe(true);
 
     // assessment data checks
     expect(

--- a/__tests__/util/concatenateFieldsInOrder.test.tsx
+++ b/__tests__/util/concatenateFieldsInOrder.test.tsx
@@ -28,7 +28,7 @@ describe("concatenateFieldsInOrder", () => {
       country: "USA",
     };
     const fields = ["line1", "line2", "town", "county", "postcode", "country"];
-    const result = concatenateFieldsInOrder<string>(obj, fields);
+    const result = concatenateFieldsInOrder(obj, fields);
     expect(result).toBe(
       "123 Main St, Apt 4B, Springfield, Some County, 12345, USA",
     );
@@ -41,7 +41,7 @@ describe("concatenateFieldsInOrder", () => {
       postcode: "12345",
     };
     const fields = ["line1", "line2", "town", "county", "postcode", "country"];
-    const result = concatenateFieldsInOrder<string>(obj, fields);
+    const result = concatenateFieldsInOrder(obj, fields);
     expect(result).toBe("123 Main St, Springfield, 12345");
   });
 
@@ -55,14 +55,14 @@ describe("concatenateFieldsInOrder", () => {
       country: undefined,
     };
     const fields = ["line1", "line2", "town", "county", "postcode", "country"];
-    const result = concatenateFieldsInOrder<string>(obj, fields);
+    const result = concatenateFieldsInOrder(obj, fields);
     expect(result).toBe("123 Main St, Springfield, 12345");
   });
 
   it("should return an empty string if no fields are present in the object", () => {
     const obj = {};
     const fields = ["line1", "line2", "town", "county", "postcode", "country"];
-    const result = concatenateFieldsInOrder<string>(obj, fields);
+    const result = concatenateFieldsInOrder(obj, fields);
     expect(result).toBe("");
   });
 
@@ -73,7 +73,7 @@ describe("concatenateFieldsInOrder", () => {
       postcode: "12345",
     };
     const fields: string[] = [];
-    const result = concatenateFieldsInOrder<string>(obj, fields);
+    const result = concatenateFieldsInOrder(obj, fields);
     expect(result).toBe("");
   });
 
@@ -83,7 +83,7 @@ describe("concatenateFieldsInOrder", () => {
       last: "Smith",
     };
     const fields = ["first", "last"];
-    const result = concatenateFieldsInOrder<string>(obj, fields, "HELLO");
+    const result = concatenateFieldsInOrder(obj, fields, "HELLO");
     expect(result).toBe("JohnHELLOSmith");
   });
 });

--- a/__tests__/util/convertDprPlanningApplicationToPostSubmissionApplication.test.tsx
+++ b/__tests__/util/convertDprPlanningApplicationToPostSubmissionApplication.test.tsx
@@ -1,0 +1,233 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { DprApplication, DprPlanningApplication } from "@/types";
+import { convertToDprApplication } from "@/util/convertToDprApplication";
+import { generateDprApplication as generateNewDprApplication } from "@mocks/dprNewApplicationFactory";
+import { generateDprApplication as generateOldDprApplication } from "@mocks/dprApplicationFactory";
+import dayjs from "dayjs";
+
+describe("when input is a DprApplication", () => {
+  it("should return the same DprApplication if already in the correct structure", () => {
+    const newApp: DprApplication = generateNewDprApplication();
+    const result = convertToDprApplication(newApp);
+    expect(result).toBe(newApp);
+  });
+});
+
+describe("when input is a DprPlanningApplication", () => {
+  it("should convert an old DprPlanningApplication into a new DprApplication", () => {
+    const oldApp: DprPlanningApplication = generateOldDprApplication();
+    const result = convertToDprApplication(oldApp);
+    expect(result).toHaveProperty("applicationType");
+    expect(result).toHaveProperty("data.application.reference");
+  });
+
+  it("should throw an error if it does not match either shape (edge case)", () => {
+    const invalidObj = {} as DprPlanningApplication;
+    expect(() => convertToDprApplication(invalidObj)).toThrow(
+      "Invalid application object",
+    );
+  });
+
+  it("should handle an application with no validDate => stage is 'submission'", () => {
+    const oldApp = generateOldDprApplication();
+    oldApp.application.validDate = null;
+
+    const converted = convertToDprApplication(oldApp);
+    expect(converted.data.application.stage).toBe("submission");
+
+    expect(converted.data.submission).toBeDefined();
+    expect(converted.data.validation?.validatedAt).toBeUndefined();
+  });
+
+  it("should handle an 'invalid' status => stage is 'validation'", () => {
+    const oldApp = generateOldDprApplication({
+      applicationStatus: "invalid",
+    });
+    const converted = convertToDprApplication(oldApp);
+    expect(converted.data.application.stage).toBe("validation");
+    expect(converted.data.validation).toBeDefined();
+  });
+
+  it("should handle an 'returned' status => stage is 'validation'", () => {
+    const oldApp = generateOldDprApplication({
+      applicationStatus: "returned",
+    });
+    const converted = convertToDprApplication(oldApp);
+    expect(converted.data.application.stage).toBe("validation");
+    expect(converted.data.validation).toBeDefined();
+  });
+
+  it("should handle a consultation scenario => stage is 'consultation'", () => {
+    const today = dayjs.utc();
+    const startDate = today.subtract(1, "day").format("YYYY-MM-DD");
+    const endDate = today.add(5, "day").format("YYYY-MM-DD");
+
+    const oldApp = generateOldDprApplication({
+      applicationStatus: "pending",
+    });
+
+    oldApp.application.consultation = {
+      startDate,
+      endDate,
+      consulteeComments: [],
+      publishedComments: [],
+    };
+
+    const converted = convertToDprApplication(oldApp);
+    expect(converted.data.application.stage).toBe("consultation");
+    expect(converted.data.consultation).toBeDefined();
+    expect(converted.data.consultation?.startDate).toBe(startDate);
+    expect(converted.data.consultation?.endDate).toBe(endDate);
+  });
+
+  it("should handle an application with no consultation or not currently in window => stage is 'assessment'", () => {
+    const oldApp = generateOldDprApplication({
+      applicationStatus: "pending",
+    });
+
+    const startDate = dayjs.utc().subtract(30, "days").format("YYYY-MM-DD");
+    const endDate = dayjs.utc().subtract(20, "days").format("YYYY-MM-DD");
+    oldApp.application.consultation = {
+      startDate,
+      endDate,
+      consulteeComments: [],
+      publishedComments: [],
+    };
+
+    const converted = convertToDprApplication(oldApp);
+    expect(converted.data.application.stage).toBe("assessment");
+
+    expect(converted.data.assessment).toBeDefined();
+  });
+
+  it("should handle an application with appeal => stage is 'appeal'", () => {
+    const oldApp = generateOldDprApplication({
+      appeal: {
+        reason: "some reason",
+      },
+    });
+
+    const converted = convertToDprApplication(oldApp);
+    expect(converted.data.application.stage).toBe("appeal");
+    expect(converted.data.appeal).toBeDefined();
+    expect(converted.data.appeal?.reason).toBe("some reason");
+  });
+
+  it("should map application status to new system statuses correctly", () => {
+    const oldApp = generateOldDprApplication({
+      applicationStatus: "Appeal allowed",
+    });
+    const converted = convertToDprApplication(oldApp);
+    expect(converted.data.application.status).toBe("determined");
+
+    // "withdrawn" => "withdrawn"
+    const withdrawnApp = generateOldDprApplication({
+      applicationStatus: "withdrawn",
+    });
+    const convertedWithdrawn = convertToDprApplication(withdrawnApp);
+    expect(convertedWithdrawn.data.application.status).toBe("withdrawn");
+
+    // "invalid" => "returned"
+    const invalidApp = generateOldDprApplication({
+      applicationStatus: "invalid",
+    });
+    const convertedInvalid = convertToDprApplication(invalidApp);
+    expect(convertedInvalid.data.application.status).toBe("returned");
+
+    // "pending" => "undetermined"
+    const pendingApp = generateOldDprApplication({
+      applicationStatus: "pending",
+    });
+    const convertedPending = convertToDprApplication(pendingApp);
+    expect(convertedPending.data.application.status).toBe("undetermined");
+  });
+
+  it("should map localPlanningAuthority section correctly", () => {
+    const oldApp = generateOldDprApplication({});
+
+    const converted = convertToDprApplication(oldApp);
+    expect(
+      typeof converted.data.localPlanningAuthority
+        ?.commentsAcceptedUntilDecision,
+    ).toBe("boolean");
+  });
+
+  it("should map submission data correctly", () => {
+    const oldApp = generateOldDprApplication();
+    oldApp.application.receivedDate = "2023-01-15";
+
+    const converted = convertToDprApplication(oldApp);
+    expect(converted.data.submission?.submittedAt).toBe("2023-01-15T00:00:00Z");
+  });
+
+  it("should map validation data if validDate exists", () => {
+    const oldApp = generateOldDprApplication();
+    oldApp.application.receivedDate = "2023-01-10";
+    oldApp.application.validDate = "2023-02-01";
+
+    const converted = convertToDprApplication(oldApp);
+    expect(converted.data.validation?.receivedAt).toBe("2023-01-10T00:00:00Z");
+    expect(converted.data.validation?.validatedAt).toBe("2023-02-01T00:00:00Z");
+    expect(converted.data.validation?.isValid).toBe(true);
+  });
+
+  it("should omit validation data if validDate is null", () => {
+    const oldApp = generateOldDprApplication();
+    oldApp.application.validDate = null;
+
+    const converted = convertToDprApplication(oldApp);
+    expect(converted.data.validation?.validatedAt).toBeUndefined();
+  });
+
+  it("should map assessment data", () => {
+    const oldApp = generateOldDprApplication({
+      decision: "granted",
+    });
+    oldApp.application.determinedAt = "2024-02-28";
+    const converted = convertToDprApplication(oldApp);
+
+    expect(converted.data.assessment).toBeDefined();
+    expect(converted.data.assessment?.planningOfficerDecision).toBe("granted");
+    expect(converted.data.assessment?.planningOfficerDecisionDate).toBe(
+      "2024-02-28",
+    );
+    expect(converted.data.assessment?.decisionNotice?.url).toBe(
+      "https://planningregister.org",
+    );
+  });
+
+  it("should map appeal data if present", () => {
+    const oldApp = generateOldDprApplication({
+      applicationStatus: "Appeal determined",
+      appeal: {
+        lodgedDate: "2023-02-02",
+        startedDate: "2023-02-10",
+        decisionDate: "2023-05-01",
+        decision: "allowed",
+        reason: "Lorem ipsum",
+        validatedDate: "2023-02-05",
+      },
+    });
+    const converted = convertToDprApplication(oldApp);
+
+    expect(converted.data.appeal).toBeDefined();
+    expect(converted.data.appeal?.lodgedDate).toBe("2023-02-02");
+    expect(converted.data.appeal?.decision).toBe("allowed");
+  });
+});

--- a/src/components/ApplicationDetails/ApplicationDetails.tsx
+++ b/src/components/ApplicationDetails/ApplicationDetails.tsx
@@ -31,6 +31,7 @@ import { buildApplicationProgress } from "@/lib/planningApplication/progress";
 import { ApplicationAppeals } from "../ApplicationAppeals";
 // import { ImpactMeasures } from "../ImpactMeasures";
 import { checkCommentsEnabled } from "@/lib/comments";
+import { getDescription } from "@/lib/planningApplication/application";
 
 export interface ApplicationDetailsProps {
   reference: string;
@@ -51,7 +52,7 @@ export const ApplicationDetails = ({
 
   const commentsEnabled = checkCommentsEnabled(application);
   const councilSlug = appConfig.council.slug;
-  const description = application.proposal.description;
+  const description = getDescription(application.proposal);
   const people = application.officer || application.applicant;
   const applicationProgress = buildApplicationProgress(application);
   const appeal = application.data.appeal;

--- a/src/components/ApplicationPeople/ApplicationPeople.stories.tsx
+++ b/src/components/ApplicationPeople/ApplicationPeople.stories.tsx
@@ -17,7 +17,11 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 import { ApplicationPeople } from "./ApplicationPeople";
-import { generateDprApplication } from "@mocks/dprApplicationFactory";
+import {
+  generateAgent,
+  generateBaseApplicant,
+  generateCaseOfficer,
+} from "@mocks/dprNewApplicationFactory";
 
 const meta = {
   title: "DPR Components/ApplicationPeople",
@@ -33,87 +37,47 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const fullApplication = generateDprApplication();
+// const fullApplication = generateDprApplication();
 
 export const Default: Story = {
   args: {
-    applicant: fullApplication.applicant,
-    caseOfficer: fullApplication.officer,
+    applicant: generateAgent,
+    caseOfficer: generateCaseOfficer,
   },
 };
 
-export const AllApplicationPeople: Story = {
+export const AgentAndCaseOfficer: Story = {
   args: {
-    applicant: fullApplication.applicant,
-    caseOfficer: fullApplication.officer,
+    applicant: generateAgent,
+    caseOfficer: generateCaseOfficer,
   },
 };
 
-export const ApplicantAndAgent: Story = {
+export const BaseApplicantAndCaseOfficer: Story = {
   args: {
-    applicant: {
-      ...fullApplication.applicant,
-      agent: fullApplication.applicant.agent,
-    },
-  },
-};
-
-export const ApplicantAndCaseOfficer: Story = {
-  args: {
-    applicant: {
-      ...fullApplication.applicant,
-      agent: undefined,
-    },
-    caseOfficer: fullApplication.officer,
-  },
-};
-
-export const CaseOfficerAndAgent: Story = {
-  args: {
-    caseOfficer: fullApplication.officer,
-    applicant: {
-      agent: fullApplication.applicant.agent,
-    },
+    applicant: generateBaseApplicant,
+    caseOfficer: generateCaseOfficer,
   },
 };
 
 export const OnlyApplicant: Story = {
   args: {
-    applicant: {
-      ...fullApplication.applicant,
-      agent: undefined,
-    },
-  },
-};
-
-export const OnlyApplicantMinimalData: Story = {
-  args: {
-    applicant: {
-      name: fullApplication.applicant.name,
-    },
+    applicant: generateBaseApplicant,
   },
 };
 
 export const OnlyAgent: Story = {
   args: {
-    applicant: {
-      agent: fullApplication.applicant.agent,
-    },
-  },
-};
-
-export const OnlyAgentMinimalData: Story = {
-  args: {
-    applicant: {
-      agent: {
-        name: fullApplication.applicant.agent?.name,
-      },
-    },
+    applicant: generateAgent,
   },
 };
 
 export const OnlyCaseOfficer: Story = {
   args: {
-    caseOfficer: fullApplication.officer,
+    caseOfficer: generateCaseOfficer,
   },
+};
+
+export const NoPeople: Story = {
+  args: {},
 };

--- a/src/components/ApplicationPeople/ApplicationPeople.tsx
+++ b/src/components/ApplicationPeople/ApplicationPeople.tsx
@@ -18,6 +18,10 @@
 import { DprPlanningApplication } from "@/types";
 import { capitalizeFirstLetter, concatenateFieldsInOrder } from "@/util";
 import "./ApplicationPeople.scss";
+import {
+  Agent,
+  BaseApplicant,
+} from "@/types/odp-types/schemas/prototypeApplication/data/Applicant";
 
 interface ApplicationPeopleProps {
   applicant?: DprPlanningApplication["applicant"];
@@ -28,41 +32,11 @@ export const ApplicationPeople = ({
   applicant,
   caseOfficer,
 }: ApplicationPeopleProps) => {
-  const applicantName = concatenateFieldsInOrder<string>(
-    applicant?.name ?? {},
-    ["first", "last"],
-    " ",
-  );
-  const applicantType = applicant?.type;
-  const applicantAddress = applicant?.address?.sameAsSiteAddress
-    ? "Same as site address"
-    : concatenateFieldsInOrder<string>(applicant?.address ?? {}, [
-        "line1",
-        "line2",
-        "town",
-        "county",
-        "postcode",
-        "country",
-      ]);
-  const agentName = concatenateFieldsInOrder<string>(
-    applicant?.agent?.name ?? {},
-    ["first", "last"],
-    " ",
-  );
-  const agentAddress = concatenateFieldsInOrder<string>(
-    applicant?.agent?.address ?? {},
-    ["line1", "line2", "town", "county", "postcode", "country"],
-  );
+  const agent = applicant?.agent;
 
-  if (
-    !caseOfficer?.name &&
-    !applicantName &&
-    !applicantType &&
-    !applicantAddress &&
-    !agentName &&
-    !agentAddress
-  ) {
-    return <></>;
+  const hasPeople = caseOfficer || agent || applicant;
+  if (!hasPeople) {
+    return null;
   }
 
   return (
@@ -81,97 +55,215 @@ export const ApplicationPeople = ({
       </p>
 
       <div className="dpr-application-people__grid">
-        {caseOfficer?.name && (
-          <div className="dpr-application-people__grid-item">
-            <h3 className="govuk-heading-m">Case Officer</h3>
-            <p className="govuk-hint">
-              This is the individual at the council who is currently responsible
-              for assessing this application.
-            </p>
-            <div>
-              <h4 className="govuk-heading-s">
-                <span className="govuk-visually-hidden">Case Officer </span>
-                Name
-              </h4>
-              <p className="govuk-body">{caseOfficer.name}</p>
-            </div>
-          </div>
+        {caseOfficer && (
+          <ApplicationPeopleCaseOfficer caseOfficer={caseOfficer} />
         )}
 
-        {(agentName || agentAddress) && (
-          <div className="dpr-application-people__grid-item">
-            <h3 className="govuk-heading-m">Applicant&apos;s Agent</h3>
-            <p className="govuk-hint">
-              This is who the applicant has engaged to manage this application
-              for them.
-            </p>
+        {agent && <ApplicationPeopleAgent agent={agent} />}
 
-            {agentName && (
-              <div>
-                <h4 className="govuk-heading-s">
-                  <span className="govuk-visually-hidden">
-                    Applicant&apos;s Agent{" "}
-                  </span>
-                  Name
-                </h4>
-                <p className="govuk-body">{agentName}</p>
-              </div>
-            )}
-            {agentAddress && (
-              <div>
-                <h4 className="govuk-heading-s">
-                  <span className="govuk-visually-hidden">
-                    Applicant&apos;s Agent{" "}
-                  </span>
-                  Address
-                </h4>
-                <p className="govuk-body">{agentAddress}</p>
-              </div>
-            )}
-          </div>
-        )}
-
-        {(applicantName || applicantType || applicantAddress) && (
-          <div className="dpr-application-people__grid-item">
-            <h3 className="govuk-heading-m">Applicant</h3>
-            <p className="govuk-hint">
-              This is who has submitted this application.
-            </p>
-
-            {applicantName && (
-              <div>
-                <h4 className="govuk-heading-s">
-                  <span className="govuk-visually-hidden">Applicant </span>
-                  Name
-                </h4>
-                <p className="govuk-body">{applicantName}</p>
-              </div>
-            )}
-
-            {applicantType && (
-              <div>
-                <h4 className="govuk-heading-s">
-                  <span className="govuk-visually-hidden">Applicant </span>
-                  Type
-                </h4>
-                <p className="govuk-body">
-                  {capitalizeFirstLetter(applicantType)}
-                </p>
-              </div>
-            )}
-
-            {applicantAddress && (
-              <div>
-                <h4 className="govuk-heading-s">
-                  <span className="govuk-visually-hidden">Applicant </span>
-                  Address
-                </h4>
-                <p className="govuk-body">{applicantAddress}</p>
-              </div>
-            )}
-          </div>
-        )}
+        {applicant && <ApplicationPeopleApplicant applicant={applicant} />}
       </div>
     </section>
+  );
+};
+
+/**
+ * Gets the fields needed to show the case officer section
+ * @param caseOfficer
+ * @returns
+ */
+export const getCasedOfficerFields = (
+  caseOfficer: DprPlanningApplication["officer"],
+) => {
+  const caseOfficerName = caseOfficer.name;
+  return { caseOfficerName };
+};
+
+/**
+ * Shows the case officer details
+ * @param param0
+ * @returns
+ */
+export const ApplicationPeopleCaseOfficer = ({
+  caseOfficer,
+}: {
+  caseOfficer: DprPlanningApplication["officer"];
+}) => {
+  const { caseOfficerName } = getCasedOfficerFields(caseOfficer);
+
+  if (!caseOfficerName) {
+    return <></>;
+  }
+  return (
+    <div className="dpr-application-people__grid-item">
+      <h3 className="govuk-heading-m">Case Officer</h3>
+      <p className="govuk-hint">
+        This is the individual at the council who is currently responsible for
+        assessing this application.
+      </p>
+      <div>
+        <h4 className="govuk-heading-s">
+          <span className="govuk-visually-hidden">Case Officer </span>
+          Name
+        </h4>
+        <p className="govuk-body">{caseOfficerName}</p>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Gets the agent fields needed to show the agent section
+ * @param agent
+ * @returns
+ */
+export const getAgentFields = (agent: Agent["agent"]) => {
+  const agentName = concatenateFieldsInOrder(
+    agent?.name,
+    ["first", "last"],
+    " ",
+  );
+
+  // using `as unknown as Record<string, string>` to avoid TS error converting Agent interface to Record<string, string>
+  const agentAddress = concatenateFieldsInOrder(agent.address, [
+    "line1",
+    "line2",
+    "town",
+    "county",
+    "postcode",
+    "country",
+  ]);
+
+  return { agentName, agentAddress };
+};
+
+/**
+ * Shows the agent part of an Applicant data type
+ * @param param0
+ * @returns
+ */
+export const ApplicationPeopleAgent = ({
+  agent,
+}: {
+  agent: Agent["agent"];
+}) => {
+  const { agentName, agentAddress } = getAgentFields(agent);
+
+  if (!agentName && !agentAddress) {
+    return <></>;
+  }
+
+  return (
+    <div className="dpr-application-people__grid-item">
+      <h3 className="govuk-heading-m">Applicant&apos;s Agent</h3>
+      <p className="govuk-hint">
+        This is who the applicant has engaged to manage this application for
+        them.
+      </p>
+      {agentName && (
+        <div>
+          <h4 className="govuk-heading-s">
+            <span className="govuk-visually-hidden">
+              Applicant&apos;s Agent{" "}
+            </span>
+            Name
+          </h4>
+          <p className="govuk-body">{agentName}</p>
+        </div>
+      )}
+      {agentAddress && (
+        <div>
+          <h4 className="govuk-heading-s">
+            <span className="govuk-visually-hidden">
+              Applicant&apos;s Agent{" "}
+            </span>
+            Address
+          </h4>
+          <p className="govuk-body">{agentAddress}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Exports all the fields needed to show the applicant section
+ * @param applicant
+ * @returns
+ */
+export const getApplicantFields = (applicant: Agent | BaseApplicant) => {
+  const applicantName = concatenateFieldsInOrder(
+    applicant.name,
+    ["first", "last"],
+    " ",
+  );
+
+  const applicantType = applicant?.type;
+  const applicantAddress = applicant.address?.sameAsSiteAddress
+    ? "Same as site address"
+    : concatenateFieldsInOrder(applicant.address, [
+        "line1",
+        "line2",
+        "town",
+        "county",
+        "postcode",
+        "country",
+      ]);
+
+  return { applicantName, applicantType, applicantAddress };
+};
+
+/**
+ * Shows the applicant section
+ * @param param0
+ * @returns
+ */
+export const ApplicationPeopleApplicant = ({
+  applicant,
+}: {
+  applicant: Agent | BaseApplicant;
+}) => {
+  const { applicantName, applicantType, applicantAddress } =
+    getApplicantFields(applicant);
+
+  if (!applicantName || !applicantType || !applicantAddress) {
+    return <></>;
+  }
+
+  return (
+    <div className="dpr-application-people__grid-item">
+      <h3 className="govuk-heading-m">Applicant</h3>
+      <p className="govuk-hint">This is who has submitted this application.</p>
+
+      {applicantName && (
+        <div>
+          <h4 className="govuk-heading-s">
+            <span className="govuk-visually-hidden">Applicant </span>
+            Name
+          </h4>
+          <p className="govuk-body">{applicantName}</p>
+        </div>
+      )}
+
+      {applicantType && (
+        <div>
+          <h4 className="govuk-heading-s">
+            <span className="govuk-visually-hidden">Applicant </span>
+            Type
+          </h4>
+          <p className="govuk-body">{capitalizeFirstLetter(applicantType)}</p>
+        </div>
+      )}
+
+      {applicantAddress && (
+        <div>
+          <h4 className="govuk-heading-s">
+            <span className="govuk-visually-hidden">Applicant </span>
+            Address
+          </h4>
+          <p className="govuk-body">{applicantAddress}</p>
+        </div>
+      )}
+    </div>
   );
 };

--- a/src/handlers/bops/converters/planningApplication.ts
+++ b/src/handlers/bops/converters/planningApplication.ts
@@ -22,6 +22,7 @@ import { convertCommentBops } from "./comments";
 import { convertDateTimeToUtc } from "@/util";
 import { getPrimaryApplicationTypeKey } from "@/lib/planningApplication";
 import { convertDocumentBopsFile } from "./documents";
+import { Area } from "@/types/odp-types/shared/utils";
 
 export const convertBopsToDpr = (
   application: BopsPlanningApplication,
@@ -40,7 +41,7 @@ export const convertBopsToDpr = (
 
 export const convertBopsApplicationToDpr = (
   application: BopsApplicationOverview,
-): DprPlanningApplication["applicant"] => {
+): DprPlanningApplication["application"] => {
   const { consulteeComments = [], publishedComments = [] } =
     application.consultation || {};
 
@@ -56,9 +57,6 @@ export const convertBopsApplicationToDpr = (
 
   return {
     reference: application.reference,
-    type: {
-      description: application.type.description,
-    },
     status: application.status,
     consultation: {
       startDate: application.consultation?.startDate,
@@ -68,7 +66,7 @@ export const convertBopsApplicationToDpr = (
     },
     receivedAt: application.receivedAt
       ? convertDateTimeToUtc(application.receivedAt)
-      : null,
+      : "",
     validAt: application.validAt
       ? convertDateTimeToUtc(application.validAt)
       : null,
@@ -126,17 +124,35 @@ export const createProperty = (
   application: BopsPlanningApplication,
 ): DprPlanningApplication["property"] => {
   // glitch in bops where boundary_geojson is coming through as {} not null seems to only affect the search endpoint
+  let boundary = undefined;
+  if (
+    application.property.boundary.site &&
+    Object.keys(application.property.boundary.site).length > 0
+  ) {
+    boundary = {
+      site: application.property.boundary.site,
+      // we don't use this so its ok for now to do this
+      area: "" as unknown as Area,
+    };
+  }
   return {
+    // making up the missing required fields for now
     address: {
       singleLine: application.property.address.singleLine,
+      title: application.property.address.singleLine,
+      x: 0,
+      y: 0,
+      latitude: application.property.address.latitude,
+      longitude: application.property.address.longitude,
+      uprn: application.property.address.uprn,
+      usrn: "",
+      pao: "",
+      street: "",
+      town: "",
+      postcode: "",
+      source: "Ordnance Survey",
     },
-    boundary: {
-      site:
-        application.property.boundary.site &&
-        Object.keys(application.property.boundary.site).length > 0
-          ? application.property.boundary.site
-          : undefined,
-    },
+    boundary,
   };
 };
 
@@ -154,15 +170,41 @@ export const createApplicant = (
   if (application?.applicant) {
     return application.applicant;
   } else {
-    return null;
+    /**
+     * This should never occur in the code but we still need to return a valid BaseApplicant object to prevent errors
+     * BOPS usually returns with which even though not valid we account for in the frontend so nothing wonky shows
+     *
+     * {
+     *   type: null,
+     *   address: null,
+     *   ownership: null,
+     *   agent: { address: null }
+     * }
+     */
+    return {
+      name: {
+        first: null,
+        last: null,
+      },
+      email: "REDACTED",
+      phone: {
+        primary: "REDACTED",
+      },
+      address: {
+        line1: null,
+        town: null,
+        postcode: null,
+        sameAsSiteAddress: false,
+      },
+      siteContact: {
+        role: "proxy",
+      },
+    };
   }
 };
 
 export const createOfficer = (
   application: BopsPlanningApplication,
 ): DprPlanningApplication["officer"] => {
-  if (!application.officer) {
-    return null;
-  }
-  return { name: application.officer.name };
+  return { name: application.officer ? application.officer.name : "" };
 };

--- a/src/lib/planningApplication/application.tsx
+++ b/src/lib/planningApplication/application.tsx
@@ -1,0 +1,72 @@
+import { DprApplication } from "@/types";
+import { OSAddress, ProposedAddress } from "@/types/odp-types/shared/Addresses";
+
+/**
+ * Helper method to get the address for an application
+ * @param address
+ * @returns
+ */
+export const getPropertyAddress = (
+  address: DprApplication["submission"]["data"]["property"]["address"],
+) => {
+  if ("singleLine" in address && address.singleLine) {
+    return address.singleLine;
+  }
+  if ("title" in address && address.title) {
+    return address.title;
+  }
+};
+
+/**
+ * Helper method to get lat and long for an application as an alternative to address
+ * @param address
+ * @returns
+ */
+export const getPropertyAddressLatitudeLongitude = (
+  address: OSAddress | ProposedAddress,
+) => {
+  if (
+    "latitude" in address &&
+    "longitude" in address &&
+    address.latitude &&
+    address.longitude
+  ) {
+    return { latitude: address.latitude, longitude: address.longitude };
+  }
+};
+
+export const getDescription = (
+  proposal: DprApplication["submission"]["data"]["proposal"],
+) => {
+  if ("description" in proposal && proposal.description) {
+    return proposal.description;
+  }
+  if ("reason" in proposal && proposal.reason) {
+    return proposal.reason;
+  }
+  return "No description";
+};
+
+/**
+ * Helper method to get the council decision date for an application
+ * @param application
+ * @returns
+ */
+export const getCouncilDecision = (application: DprApplication) => {
+  return (
+    application?.data?.assessment?.committeeDecision ||
+    application?.data?.assessment?.planningOfficerDecision
+  );
+};
+
+/**
+ * Helper method to get the council decision date for an application
+ * @param application
+ * @returns
+ */
+export const getCouncilDecisionDate = (application: DprApplication) => {
+  return (
+    application?.data?.assessment?.committeeDecisionDate ||
+    application?.data?.assessment?.planningOfficerDecisionDate
+  );
+};

--- a/src/lib/planningApplication/convertToDprApplication.ts
+++ b/src/lib/planningApplication/convertToDprApplication.ts
@@ -56,7 +56,7 @@ function determineStage(app: DprPlanningApplication): ProcessStage {
   if (app.data.appeal) {
     return "appeal";
   }
-  if (!app.application.validDate) {
+  if (!app.application.validAt) {
     return "submission";
   }
   if (
@@ -148,7 +148,7 @@ function mapLocalPlanningAuthoritySection(app: DprPlanningApplication) {
  */
 function mapSubmissionSection(app: DprPlanningApplication) {
   return {
-    submittedAt: app.application.receivedDate,
+    submittedAt: app.application.receivedAt,
   };
 }
 
@@ -157,8 +157,8 @@ function mapSubmissionSection(app: DprPlanningApplication) {
  */
 function mapValidationSection(app: DprPlanningApplication) {
   return {
-    receivedAt: app.application.receivedDate,
-    validatedAt: app.application.validDate ?? undefined,
+    receivedAt: app.application.receivedAt,
+    validatedAt: app.application.validAt ?? undefined,
     isValid: true,
   };
 }
@@ -287,8 +287,8 @@ export function convertToDprApplication(
     metadata: {
       organisation: "BOPS",
       id: planningApp.application.reference,
-      publishedAt: planningApp?.application?.publishedDate,
-      submittedAt: planningApp.application.receivedDate,
+      publishedAt: planningApp?.application?.publishedAt,
+      submittedAt: planningApp.application.receivedAt,
       schema:
         "https://theopensystemslab.github.io/digital-planning-data-schemas/@next/schemas/postSubmissionApplication.json",
     },

--- a/src/lib/planningApplication/convertToDprApplication.ts
+++ b/src/lib/planningApplication/convertToDprApplication.ts
@@ -24,7 +24,6 @@ dayjs.extend(isSameOrAfter);
 
 import { DprApplication, DprPlanningApplication } from "@/types";
 import { ProcessStage } from "@/types/odp-types/schemas/postSubmissionApplication/enums/ProcessStage";
-import { convertDateTimeToUtc } from "./formatDates";
 import { ApplicationStatus } from "@/types/odp-types/schemas/postSubmissionApplication/enums/ApplicationStatus";
 import {
   getApplicationDprDecisionSummary,
@@ -35,7 +34,7 @@ import { AssessmentDecision } from "@/types/odp-types/schemas/postSubmissionAppl
 /**
  * Checks if the given object is a DprApplication.
  */
-function isDprApplication(
+export function isDprApplication(
   app: DprApplication | DprPlanningApplication,
 ): boolean {
   if (
@@ -149,7 +148,7 @@ function mapLocalPlanningAuthoritySection(app: DprPlanningApplication) {
  */
 function mapSubmissionSection(app: DprPlanningApplication) {
   return {
-    submittedAt: convertDateTimeToUtc(app.application.receivedDate),
+    submittedAt: app.application.receivedDate,
   };
 }
 
@@ -158,10 +157,8 @@ function mapSubmissionSection(app: DprPlanningApplication) {
  */
 function mapValidationSection(app: DprPlanningApplication) {
   return {
-    receivedAt: convertDateTimeToUtc(app.application.receivedDate),
-    validatedAt: app.application.validDate
-      ? convertDateTimeToUtc(app.application.validDate)
-      : undefined,
+    receivedAt: app.application.receivedDate,
+    validatedAt: app.application.validDate ?? undefined,
     isValid: true,
   };
 }
@@ -234,12 +231,8 @@ function mapAppealSection(app: DprPlanningApplication) {
  * Main conversion function.
  */
 export function convertToDprApplication(
-  app: DprPlanningApplication | DprApplication,
+  app: DprPlanningApplication,
 ): DprApplication {
-  if (isDprApplication(app)) {
-    return app as DprApplication;
-  }
-
   const planningApp = app as DprPlanningApplication;
   const stage = determineStage(planningApp);
 
@@ -294,12 +287,10 @@ export function convertToDprApplication(
     metadata: {
       organisation: "BOPS",
       id: planningApp.application.reference,
-      publishedAt: planningApp.application.publishedDate
-        ? convertDateTimeToUtc(planningApp.application.publishedDate)
-        : "",
-      submittedAt: convertDateTimeToUtc(planningApp.application.receivedDate),
+      publishedAt: planningApp?.application?.publishedDate,
+      submittedAt: planningApp.application.receivedDate,
       schema:
-        "https://https://theopensystemslab.github.io/digital-planning-data-schemas/@next/schemas/postSubmissionApplication.json",
+        "https://theopensystemslab.github.io/digital-planning-data-schemas/@next/schemas/postSubmissionApplication.json",
     },
   };
 

--- a/src/lib/planningApplication/convertToDprApplication.ts
+++ b/src/lib/planningApplication/convertToDprApplication.ts
@@ -25,10 +25,10 @@ dayjs.extend(isSameOrAfter);
 import { DprApplication, DprPlanningApplication } from "@/types";
 import { ProcessStage } from "@/types/odp-types/schemas/postSubmissionApplication/enums/ProcessStage";
 import { ApplicationStatus } from "@/types/odp-types/schemas/postSubmissionApplication/enums/ApplicationStatus";
-import {
-  getApplicationDprDecisionSummary,
-  getApplicationDprStatusSummary,
-} from "@/lib/planningApplication";
+// import {
+//   getApplicationDprDecisionSummary,
+//   getApplicationDprStatusSummary,
+// } from "@/lib/planningApplication";
 import { AssessmentDecision } from "@/types/odp-types/schemas/postSubmissionApplication/enums/AssessmentDecision";
 
 /**
@@ -294,13 +294,15 @@ export function convertToDprApplication(
     },
   };
 
-  const statusSummary = getApplicationDprStatusSummary(baseApplication);
-  const decisionSummary = getApplicationDprDecisionSummary(baseApplication);
+  // const statusSummary = getApplicationDprStatusSummary(baseApplication);
+  // const decisionSummary = getApplicationDprDecisionSummary(baseApplication);
 
-  const converted: DprApplication = {
+  // disabled to enable build to pass for the other changes
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const converted: any = {
     ...baseApplication,
-    applicationStatusSummary: statusSummary,
-    applicationDecisionSummary: decisionSummary,
+    // applicationStatusSummary: statusSummary,
+    // applicationDecisionSummary: decisionSummary,
   };
 
   return converted;

--- a/src/lib/planningApplication/converter.ts
+++ b/src/lib/planningApplication/converter.ts
@@ -1,0 +1,316 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { DprApplication, DprPlanningApplication } from "@/types";
+import { PostSubmissionMetadata } from "@/types/odp-types/schemas/postSubmissionApplication/Metadata";
+import { getApplicationDprDecisionSummary } from "./decision";
+import { getApplicationDprStatusSummary } from "./status";
+import { ProcessStage } from "@/types/odp-types/schemas/postSubmissionApplication/enums/ProcessStage";
+import { ApplicationStatus } from "@/types/odp-types/schemas/postSubmissionApplication/enums/ApplicationStatus";
+import { AssessmentDecision } from "@/types/odp-types/schemas/postSubmissionApplication/enums/AssessmentDecision";
+import { getPrimaryApplicationTypeKey } from "./type";
+import {
+  PostSubmissionAssessment,
+  PriorApprovalAssessment,
+} from "@/types/odp-types/schemas/postSubmissionApplication/data/Assessment";
+import { getDescription } from "./application";
+
+/**
+ * Checks if the given object is a DprApplication.
+ * Run this before convertToDprApplication()
+ */
+export const isDprApplication = (
+  app: DprApplication | DprPlanningApplication,
+): boolean => {
+  if (
+    "data" in app &&
+    "application" in app.data &&
+    "reference" in app.data.application
+  ) {
+    return true;
+  } else if ("application" in app && "reference" in app.application) {
+    return false;
+  }
+
+  throw new Error("Invalid application object");
+};
+
+/**
+ * Checks to see if we're in the consultation period
+ * @param startDate string
+ * @param endDate string
+ * @returns boolean
+ */
+export const getIsConsultationPeriod = (
+  startDate: Date,
+  endDate: Date,
+): boolean => {
+  const now = new Date();
+
+  return now >= startDate && now <= endDate;
+};
+
+export const convertToDprApplication = (
+  app: DprPlanningApplication,
+): DprApplication => {
+  let stage = undefined;
+  let status = undefined;
+  let withdrawnAt = undefined;
+  const withdrawnReason = undefined;
+  let consultation = undefined;
+
+  const isConsultationPeriod =
+    app.application.consultation.startDate &&
+    app.application.consultation.endDate
+      ? getIsConsultationPeriod(
+          new Date(app.application.consultation.startDate),
+          new Date(app.application.consultation.endDate),
+        )
+      : false;
+
+  switch (app.application.status) {
+    /**
+     * 01-submission
+     * pending
+     * not_started
+     * 02-validation-01-invalid
+     * invalidated
+     * returned
+     */
+    case "pending":
+    case "not_started":
+    case "invalid":
+    case "returned":
+      throw new Error("Application should not be published");
+
+    /**
+     * 03-consultation
+     * in_assessment
+     * assessment_in_progress
+     *
+     * 04-assessment-00-assessment-in-progress
+     * in_assessment
+     * assessment_in_progress
+     * awaiting_determination
+     * to_be_reviewed
+     *
+     * 04-assessment-01-council-determined
+     * determined
+     *
+     * 04-assessment-02-assessment-in-committee
+     * in_committee
+     *
+     * 04-assessment-03-committee-determined
+     * determined - can't determine this currently
+     *
+     */
+
+    case "in_assessment":
+    case "assessment_in_progress":
+      if (isConsultationPeriod) {
+        stage = "consultation";
+        status = "undetermined";
+      } else {
+        stage = "assessment";
+        status = "undetermined";
+      }
+      break;
+    case "awaiting_determination":
+    case "to_be_reviewed":
+    case "in_committee":
+      stage = "assessment";
+      status = "undetermined";
+      break;
+    case "determined":
+      stage = "assessment";
+      status = "determined";
+      break;
+
+    /**
+     * 05-appeal-00-appeal-lodged
+     * Appeal lodged
+     */
+
+    case "Appeal lodged":
+      stage = "appeal";
+      status = "determined";
+      break;
+
+    /**
+     * 05-appeal-01-appeal-validated
+     * Appeal valid
+     */
+
+    case "Appeal valid":
+      stage = "appeal";
+      status = "determined";
+      break;
+
+    /**
+     * 05-appeal-02-appeal-started
+     * Appeal started
+     */
+
+    case "Appeal started":
+      stage = "appeal";
+      status = "determined";
+      break;
+    /**
+     * 05-appeal-03-appeal-determined
+     * Appeal determined
+     *
+     * Appeal withdrawn
+     * Appeal allowed
+     * Appeal dismissed
+     * Appeal split decision
+     */
+
+    case "Appeal determined":
+    case "Appeal allowed":
+    case "Appeal dismissed":
+    case "Appeal split decision":
+    case "Appeal withdrawn":
+      stage = "appeal";
+      status = "determined";
+      break;
+
+    /**
+     * 06-assessment-withdrawn
+     * withdrawn
+     * closed
+     */
+    case "withdrawn":
+      stage = "assessment";
+      status = "withdrawn";
+      withdrawnAt =
+        app.application.determinedAt ||
+        app.application.publishedAt ||
+        undefined;
+      // withdrawnReason = "Applicant withdrew the application";
+      break;
+    /**
+     * @todo closed is
+     *  scope :closed, lambda {
+     *   where(status: %w[determined withdrawn returned closed])
+     *  }
+     */
+    case "closed":
+      throw new Error("Closed application not enough information to convert");
+  }
+
+  // if theres consultation details add those
+  if (
+    app.application.consultation.startDate !== null &&
+    app.application.consultation.endDate !== null
+  ) {
+    consultation = {
+      startDate: app.application.consultation.startDate,
+      endDate: app.application.consultation.endDate,
+      siteNotice: true,
+    };
+  }
+
+  const dprApplication = {
+    applicationType: app.applicationType,
+    data: {
+      application: {
+        reference: app.application.reference,
+        stage: stage as ProcessStage,
+        status: status as ApplicationStatus,
+        withdrawnAt,
+        withdrawnReason,
+      },
+      localPlanningAuthority: app.data.localPlanningAuthority,
+      submission: {
+        submittedAt: app.application.receivedAt,
+      },
+      validation: {
+        receivedAt: app.application.receivedAt,
+        validatedAt: app.application.validAt ?? undefined,
+        isValid: true,
+      },
+      consultation,
+      assessment: {
+        expiryDate: app.application.expiryDate ?? new Date().toISOString(),
+      },
+      appeal: app.data.appeal,
+      caseOfficer: {
+        name: app.officer?.name ?? "",
+      },
+    },
+    submission: {
+      data: {
+        applicant: app.applicant,
+        property: {
+          address: app.property.address,
+          boundary: app.property.boundary,
+        },
+        proposal: {
+          description: getDescription(app.proposal),
+        },
+      },
+    },
+    metadata: {
+      organisation: "BOPS",
+      id: app.application.reference,
+      publishedAt: app.application.publishedAt,
+      submittedAt: app.application.receivedAt,
+      schema:
+        "https://theopensystemslab.github.io/digital-planning-data-schemas/@next/schemas/postSubmissionApplication.json",
+    } as PostSubmissionMetadata,
+  };
+
+  // Sort out the assessment section
+
+  if (app.application.decision && app.application.determinedAt) {
+    dprApplication.data.assessment = {
+      planningOfficerDecision: app.application.decision as AssessmentDecision,
+      planningOfficerDecisionDate: app.application.determinedAt,
+      decisionNotice: app.application.decision
+        ? {
+            url: "https://planningregister.org",
+          }
+        : undefined,
+    } as PostSubmissionAssessment;
+
+    if (getPrimaryApplicationTypeKey(app.applicationType) === "pa") {
+      let priorApprovalRequired = false;
+      if (
+        app.application.decision === "granted" ||
+        app.application.decision === "refused"
+      ) {
+        priorApprovalRequired = true;
+      }
+      dprApplication.data.assessment = {
+        ...dprApplication.data.assessment,
+        priorApprovalRequired,
+      } as PriorApprovalAssessment;
+    }
+  }
+
+  const applicationDecisionSummary =
+    getApplicationDprDecisionSummary(dprApplication);
+  const applicationStatusSummary =
+    getApplicationDprStatusSummary(dprApplication);
+  const application = {
+    applicationStatusSummary,
+    applicationDecisionSummary,
+    ...dprApplication,
+  };
+
+  return application;
+};

--- a/src/lib/planningApplication/status.tsx
+++ b/src/lib/planningApplication/status.tsx
@@ -151,7 +151,6 @@ export const getApplicationStatusSummary = (
  * "Appeal validated"
  * "Appeal in progress"
  * "Appeal decided"
- * "Appeal withdrawn"
  * "Unknown"
  * @param application
  * @returns
@@ -219,9 +218,8 @@ export const getApplicationDprStatusSummary = (
         case "allowed":
         case "dismissed":
         case "splitDecision":
-          return "Appeal decided";
         case "withdrawn":
-          return "Appeal withdrawn";
+          return "Appeal decided";
       }
     }
 

--- a/src/types/definitions.d.ts
+++ b/src/types/definitions.d.ts
@@ -30,7 +30,7 @@ import { Appeal } from "@/types/odp-types/schemas/prototypeApplication/data/Appe
 import { ApplicationType } from "@/types/odp-types/schemas/prototypeApplication/enums/ApplicationType.ts";
 import { GeoBoundary } from "@/types/odp-types/shared/Boundaries";
 import { PostSubmissionApplication } from "@/types/odp-types/schemas/postSubmissionApplication/index";
-import { DprStatusSummary, DprDecisionSummary } from "@/types";
+// import { DprStatusSummary, DprDecisionSummary } from "@/types";
 
 /**
  *
@@ -44,7 +44,10 @@ import { DprStatusSummary, DprDecisionSummary } from "@/types";
  *
  *
  */
-export type DprApplication = PostSubmissionApplication & {
+export type DprApplication = Omit<
+  PostSubmissionApplication,
+  "submission" | "comments"
+> & {
   applicationStatusSummary: DprStatusSummary;
   applicationDecisionSummary?: DprDecisionSummary;
 };

--- a/src/types/definitions.d.ts
+++ b/src/types/definitions.d.ts
@@ -25,12 +25,12 @@
  * DprBoundaryGeojson - the messy data bit that describes the boundary of a planning application
  */
 
-import { Applicant } from "@/types/odp-types/schemas/prototypeApplication/data/Applicant";
 import { Appeal } from "@/types/odp-types/schemas/prototypeApplication/data/Appeal";
 import { ApplicationType } from "@/types/odp-types/schemas/prototypeApplication/enums/ApplicationType.ts";
 import { GeoBoundary } from "@/types/odp-types/shared/Boundaries";
 import { PostSubmissionApplication } from "@/types/odp-types/schemas/postSubmissionApplication/index";
-// import { DprStatusSummary, DprDecisionSummary } from "@/types";
+import { DprStatusSummary, DprDecisionSummary } from "@/types";
+import { PrototypeApplication } from "./odp-types/schemas/prototypeApplication";
 
 /**
  *
@@ -40,7 +40,8 @@ import { PostSubmissionApplication } from "@/types/odp-types/schemas/postSubmiss
  * the most important object, contains all the information about a planning application
  *
  * NB this will need to be changes to PublishedApplication when the redacted version is made
- * NB this doesn't exclude email address etc yet that will be done through the redacted application submission schema
+ * NB this currently excludes a lot of the submission data as DPR isn't using it and BOPS isn't
+ * currently providing it all in a valid format
  *
  *
  */
@@ -48,6 +49,16 @@ export type DprApplication = Omit<
   PostSubmissionApplication,
   "submission" | "comments"
 > & {
+  submission: {
+    data: {
+      applicant: PrototypeApplication["data"]["applicant"];
+      property: Pick<
+        PrototypeApplication["data"]["property"],
+        "address" | "boundary"
+      >;
+      proposal: PrototypeApplication["data"]["proposal"];
+    };
+  };
   applicationStatusSummary: DprStatusSummary;
   applicationDecisionSummary?: DprDecisionSummary;
 };
@@ -114,6 +125,10 @@ export interface DprPlanningApplication {
       consulteeComments: DprComment[] | null;
     };
     /**
+     * YYYY-MM-DD
+     */
+    expiryDate?: string | null;
+    /**
      * 2024-05-30T14:23:21.936Z
      * NB coverting to UTC in the converters
      */
@@ -135,23 +150,13 @@ export interface DprPlanningApplication {
     determinedAt?: string | null;
     decision?: string | null;
   };
-  property: {
-    address: {
-      singleLine: string;
-    };
-    boundary: {
-      site?: DprBoundaryGeojson;
-    };
-  };
-  proposal: {
-    description: string;
-  };
-  // allowing any here because this type will be replaced soon
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  applicant: Applicant<any>;
-  officer: {
-    name: string;
-  } | null;
+  property: Pick<
+    PostSubmissionApplication["data"]["property"],
+    "address" | "boundary"
+  >;
+  proposal: PostSubmissionApplication["data"]["proposal"];
+  applicant: PostSubmissionApplication["data"]["applicant"];
+  officer: PostSubmissionApplication["data"]["caseOfficer"];
 }
 
 /**

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -141,7 +141,6 @@ export type DprStatusSummary =
   | "Appeal validated"
   | "Appeal in progress"
   | "Appeal decided"
-  | "Appeal withdrawn"
   | "Unknown";
 
 /**

--- a/src/util/concatenateFieldsInOrder.ts
+++ b/src/util/concatenateFieldsInOrder.ts
@@ -21,13 +21,18 @@
  * @param fields - The array of field names in the order to concatenate.
  * @returns A concatenated string of field values.
  */
-export const concatenateFieldsInOrder = <T>(
-  obj: Record<string, T>,
+export const concatenateFieldsInOrder = (
+  obj: object,
   fields: string[],
   separator: string = ", ",
 ): string => {
-  return fields
-    .filter((field) => obj[field]) // Filter out fields that are not present or have falsy values
-    .map((field) => obj[field]) // Map the remaining fields to their values
-    .join(separator); // Join the values with a comma
+  const data = fields
+    .map((key) => {
+      if (obj && obj.hasOwnProperty(key)) {
+        const value = obj[key as keyof object];
+        return value ?? "";
+      }
+    })
+    .filter(Boolean);
+  return data.join(separator).trim();
 };

--- a/src/util/convertToDprApplication.ts
+++ b/src/util/convertToDprApplication.ts
@@ -1,0 +1,316 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { Dayjs } from "dayjs";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
+dayjs.extend(utc);
+dayjs.extend(isSameOrAfter);
+
+import { DprApplication, DprPlanningApplication } from "@/types";
+import { ProcessStage } from "@/types/odp-types/schemas/postSubmissionApplication/enums/ProcessStage";
+import { convertDateTimeToUtc } from "./formatDates";
+import { ApplicationStatus } from "@/types/odp-types/schemas/postSubmissionApplication/enums/ApplicationStatus";
+import {
+  getApplicationDprDecisionSummary,
+  getApplicationDprStatusSummary,
+} from "@/lib/planningApplication";
+import { AssessmentDecision } from "@/types/odp-types/schemas/postSubmissionApplication/enums/AssessmentDecision";
+
+/**
+ * Checks if the given object is a DprApplication.
+ */
+function isDprApplication(
+  app: DprApplication | DprPlanningApplication,
+): boolean {
+  if (
+    "data" in app &&
+    "application" in app.data &&
+    "reference" in app.data.application
+  ) {
+    return true;
+  } else if ("application" in app && "reference" in app.application) {
+    return false;
+  }
+
+  throw new Error("Invalid application object");
+}
+/**
+ * Determines the stage
+ */
+function determineStage(app: DprPlanningApplication): ProcessStage {
+  if (app.data.appeal) {
+    return "appeal";
+  }
+  if (!app.application.validDate) {
+    return "submission";
+  }
+  if (
+    app.application.status === "invalid" ||
+    app.application.status === "returned"
+  ) {
+    return "validation";
+  }
+  if (app.application.consultation && app.application.consultation.endDate) {
+    if (
+      app.application.consultation.startDate &&
+      dayjs(app.application.consultation.startDate).isValid() &&
+      dayjs(app.application.consultation.endDate).isValid()
+    ) {
+      const consultationStartDate: Dayjs = dayjs.utc(
+        app.application.consultation.startDate,
+      );
+      const consultationEndDate: Dayjs = dayjs.utc(
+        app.application.consultation.endDate,
+      );
+      const now: Dayjs = dayjs.utc();
+      if (
+        now.isSameOrAfter(consultationStartDate, "day") &&
+        now.isBefore(consultationEndDate, "day")
+      ) {
+        return "consultation";
+      }
+    }
+  }
+  return "assessment";
+}
+
+/**
+ * Maps the "application" section.
+ * might be best to move this further down I think as the logic for stage/status will be useful in other sections
+ */
+/**
+ * Maps the "application" section.
+ * Converts legacy status strings into one of the allowed ApplicationStatus values.
+ */
+function mapApplicationSection(
+  app: DprPlanningApplication,
+  stage: ProcessStage,
+) {
+  const legacyStatus = app.application.status;
+  let status: ApplicationStatus;
+  if (legacyStatus === "returned" || legacyStatus === "invalid") {
+    status = "returned";
+  } else if (
+    legacyStatus === "withdrawn" ||
+    legacyStatus === "Appeal withdrawn"
+  ) {
+    status = "withdrawn";
+  } else if (
+    legacyStatus === "Appeal allowed" ||
+    legacyStatus === "Appeal dismissed" ||
+    legacyStatus === "Appeal split decision" ||
+    legacyStatus === "Appeal valid" ||
+    legacyStatus === "Appeal started" ||
+    legacyStatus === "Appeal determined" ||
+    legacyStatus === "closed"
+  ) {
+    status = "determined";
+  } else if (legacyStatus === "pending") {
+    status = "undetermined";
+  } else {
+    status = "undetermined";
+  }
+
+  return {
+    reference: app.application.reference,
+    stage: stage,
+    status,
+  };
+}
+
+/**
+ * Maps the "localPlanningAuthority" section.
+ */
+function mapLocalPlanningAuthoritySection(app: DprPlanningApplication) {
+  return {
+    commentsAcceptedUntilDecision:
+      app.data.localPlanningAuthority.commentsAcceptedUntilDecision || false,
+  };
+}
+
+/**
+ * Maps the common "submission" section.
+ */
+function mapSubmissionSection(app: DprPlanningApplication) {
+  return {
+    submittedAt: convertDateTimeToUtc(app.application.receivedDate),
+  };
+}
+
+/**
+ * Maps the "validation" section if a validDate exists.
+ */
+function mapValidationSection(app: DprPlanningApplication) {
+  return {
+    receivedAt: convertDateTimeToUtc(app.application.receivedDate),
+    validatedAt: app.application.validDate
+      ? convertDateTimeToUtc(app.application.validDate)
+      : undefined,
+    isValid: true,
+  };
+}
+
+/**
+ * Maps the "consultation" section if it exists.
+ */
+function mapConsultationSection(app: DprPlanningApplication) {
+  const consultation = app.application.consultation;
+  if (!consultation) return undefined;
+
+  // Only return the consultation object if both dates are non-null.
+  if (consultation.startDate == null || consultation.endDate == null) {
+    return undefined;
+  }
+
+  return {
+    startDate: consultation.startDate, // now guaranteed non-null
+    endDate: consultation.endDate, // now guaranteed non-null
+    // we can't map this yet, default to false for now
+    siteNotice: false,
+  };
+}
+
+/**
+ * Maps the "assessment" section if the stage is assessment or appeal.
+ */
+function mapAssessmentSection(app: DprPlanningApplication) {
+  const rawDecision = app.application.decision;
+  let planningOfficerDecision: AssessmentDecision | undefined;
+  if (rawDecision === "granted" || rawDecision === "refused") {
+    planningOfficerDecision = rawDecision;
+  } else {
+    planningOfficerDecision = undefined;
+  }
+  const planningOfficerDecisionDate = app.application.determinedAt ?? undefined;
+  return {
+    planningOfficerDecision,
+    planningOfficerDecisionDate,
+    decisionNotice: {
+      url: "https://planningregister.org",
+    },
+    expiryDate: "",
+    // committeeSentDate: app.application.committeeSentDate,
+    // committeeDecision: app.applicationcommitteeDecision,
+    // committeeDecisionDate: app.applicationcommitteeDecisionDate,
+  };
+}
+
+/**
+ * Maps the "appeal" section if the stage is appeal.
+ */
+function mapAppealSection(app: DprPlanningApplication) {
+  if (!app.data.appeal) {
+    return undefined;
+  }
+  return {
+    lodgedDate: app.data.appeal.lodgedDate,
+    reason: app.data.appeal.reason,
+    validatedDate: app.data.appeal.validatedDate,
+    startedDate: app.data.appeal.startedDate,
+    decisionDate: app.data.appeal.decisionDate,
+    decision: app.data.appeal.decision,
+    // withdrawnAt: app.data.appeal.withdrawnAt || null,
+    // withdrawnReason: app.data.appeal.withdrawnReason || "",
+  };
+}
+
+/**
+ * Main conversion function.
+ */
+export function convertToDprApplication(
+  app: DprPlanningApplication | DprApplication,
+): DprApplication {
+  if (isDprApplication(app)) {
+    return app as DprApplication;
+  }
+
+  const planningApp = app as DprPlanningApplication;
+  const stage = determineStage(planningApp);
+
+  const mappedApplication = mapApplicationSection(planningApp, stage);
+  const mappedLocalPlanningAuthority =
+    mapLocalPlanningAuthoritySection(planningApp);
+  const mappedSubmission = mapSubmissionSection(planningApp);
+  const mappedValidation = mapValidationSection(planningApp);
+  const mappedConsultation = mapConsultationSection(planningApp);
+  const mappedAssessment = mapAssessmentSection(planningApp);
+  const mappedAppeal = mapAppealSection(planningApp);
+
+  const baseData = {
+    application: mappedApplication,
+    localPlanningAuthority: mappedLocalPlanningAuthority,
+    submission: mappedSubmission,
+    validation: mappedValidation,
+    consultation: mappedConsultation,
+    assessment: mappedAssessment,
+    appeal: mappedAppeal,
+    caseOfficer: { name: planningApp.officer?.name || "" },
+  };
+
+  const finalData = {
+    ...baseData,
+
+    ...(stage !== "consultation" && stage !== "assessment" && stage !== "appeal"
+      ? { consultation: undefined }
+      : {}),
+
+    ...(stage !== "assessment" && stage !== "appeal"
+      ? { assessment: undefined }
+      : {}),
+
+    ...(stage !== "appeal" ? { appeal: undefined } : {}),
+  };
+
+  const baseApplication = {
+    applicationType: planningApp.applicationType,
+    data: finalData,
+    // submission,
+    // comments! soon they will come from their own endpoint so add them as is here
+    // may give an error because of the format so we can just Omit<PostSubmissionApplication,"submission" | "comments"> for now
+    // comments: {
+    //   public: {
+    //     comments: planningApp.consultation.publishedComments,
+    //   },
+    //   specialist: {
+    //     comments: planningApp.consultation.consulteeComments,
+    //   },
+    // },
+    metadata: {
+      organisation: "BOPS",
+      id: planningApp.application.reference,
+      publishedAt: planningApp.application.publishedDate
+        ? convertDateTimeToUtc(planningApp.application.publishedDate)
+        : "",
+      submittedAt: convertDateTimeToUtc(planningApp.application.receivedDate),
+      schema:
+        "https://https://theopensystemslab.github.io/digital-planning-data-schemas/@next/schemas/postSubmissionApplication.json",
+    },
+  };
+
+  const statusSummary = getApplicationDprStatusSummary(baseApplication);
+  const decisionSummary = getApplicationDprDecisionSummary(baseApplication);
+
+  const converted: DprApplication = {
+    ...baseApplication,
+    applicationStatusSummary: statusSummary,
+    applicationDecisionSummary: decisionSummary,
+  };
+
+  return converted;
+}


### PR DESCRIPTION
[Ticket 1067](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-1067)

This PR adds a conversion function that converts the old DprPlanningApplication structure to the new DprApplication.
 The conversion function extracts the relevant sections from the legacy data—such as application details, local planning authority data, and stage sections like submission, validation, consultation, assessment, and appeal—while determining the current application stage. Based on the stage, it selectively includes or omits sections, ensuring that only the relevant parts are present in the final output.

