### PR TITLE
DSNPI-1008 BOPS - Add appeals to BOPS API endpoints

### DIFF
--- a/__mocks__/dprApplicationFactory.ts
+++ b/__mocks__/dprApplicationFactory.ts
@@ -148,7 +148,7 @@ export const generateDprApplication = ({
   applicationType?: ApplicationType;
   applicationStatus?: DprPlanningApplication["application"]["status"];
   decision?: string | null;
-  appeal?: DprPlanningApplication["application"]["appeal"] | null;
+  appeal?: DprPlanningApplication["data"]["appeal"];
 } = {}): DprPlanningApplication => {
   const applicationTypes = Object.values(validApplicationTypes).flat();
   applicationType =
@@ -213,7 +213,7 @@ export const generateDprApplication = ({
         faker.helpers.arrayElement([
           "allowed",
           "dismissed",
-          "split_decision",
+          "splitDecision",
           "withdrawn",
         ]);
       appeal.decisionDate =
@@ -230,7 +230,7 @@ export const generateDprApplication = ({
     }
 
     appeal.reason = appeal.reason ?? faker.lorem.paragraph();
-    appeal.documents = appeal.documents ?? [
+    appeal.files = appeal.files ?? [
       ...generateNResults<DprDocument>(2, generateDocument),
     ];
   }
@@ -242,6 +242,7 @@ export const generateDprApplication = ({
         commentsAcceptedUntilDecision:
           primaryApplicationType === "ldc" ? true : false,
       },
+      appeal,
     },
     application: {
       reference: generateReference(),
@@ -259,7 +260,6 @@ export const generateDprApplication = ({
       publishedDate: formatDateToYmd(faker.date.anytime()),
       determinedAt: determinedAt,
       decision: decision,
-      appeal: appeal,
     },
     property: {
       address: {

--- a/__mocks__/dprNewApplicationFactory.ts
+++ b/__mocks__/dprNewApplicationFactory.ts
@@ -15,7 +15,7 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { DprApplication, DprDecisionSummary, DprStatusSummary } from "@/types";
+import { DprApplication } from "@/types";
 import { faker, fakerEN_GB } from "@faker-js/faker";
 import dayjs, { Dayjs } from "dayjs";
 import { generateReference } from "./dprApplicationFactory";
@@ -466,7 +466,7 @@ export const generateDprApplication = ({
         decision: faker.helpers.arrayElement([
           "allowed",
           "dismissed",
-          "split_decision",
+          "splitDecision",
           "withdrawn",
         ]),
       },
@@ -613,10 +613,12 @@ export const generateDprApplication = ({
   if (customStatus === "appealWithdrawn") {
     data.data.appeal = {
       lodgedDate: dates.appeal.lodgedAt.format("YYYY-MM-DD"),
+      validatedDate: dates.appeal.validatedAt.format("YYYY-MM-DD"),
+      startedDate: dates.appeal.startedAt.format("YYYY-MM-DD"),
       reason:
         "We don't believe the council took into consideration the environmental impact alleviation approach during their assessment.",
-      withdrawnAt: dates.appeal.withdrawnAt.toISOString(),
-      withdrawnReason: "Applicant has decided to withdraw the application.",
+      decisionDate: dates.appeal.decidedAt.format("YYYY-MM-DD"),
+      decision: "withdrawn",
     };
   }
 

--- a/__tests__/components/ApplicationCard.test.tsx
+++ b/__tests__/components/ApplicationCard.test.tsx
@@ -53,9 +53,19 @@ describe("Render ApplicationCard", () => {
   // the minimum required data for the application card
   const applicationCardApplication = {
     applicationType: "pp.full",
+    data: {
+      appeal: {
+        reason: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+        decision: "allowed",
+        decisionDate: "2023-11-14",
+        lodgedDate: "2023-11-14",
+        startedDate: "2023-11-14",
+        validatedDate: "2023-11-14",
+      },
+    },
     application: {
       reference: "DPR/1234/2021",
-      status: "in_assessment",
+      status: "Appeal allowed",
       receivedDate: "2023-05-08",
       validDate: "2023-11-14",
       publishedDate: "2023-05-18",
@@ -64,13 +74,6 @@ describe("Render ApplicationCard", () => {
       },
       decision: "granted",
       determinedAt: "2023-11-14T13:40:51.567Z",
-      appeal: {
-        decision: "allowed",
-        decisionDate: "2023-11-14",
-        lodgedDate: "2023-11-14",
-        startedDate: "2023-11-14",
-        validatedDate: "2023-11-14",
-      },
     },
     property: {
       address: {
@@ -112,9 +115,7 @@ describe("Render ApplicationCard", () => {
       screen.queryByText("Application type - Planning permission"),
     ).toBeInTheDocument();
     // application status
-    expect(
-      screen.queryByText("Status - Assessment in progress"),
-    ).toBeInTheDocument();
+    expect(screen.queryByText("Status - Appeal decided")).toBeInTheDocument();
     //Received date
     expect(
       screen.queryByText("Received date - 8 May 2023"),
@@ -147,6 +148,7 @@ describe("Render ApplicationCard", () => {
 
     // Appeal
     expect(screen.queryByText("Appeal decision - Allowed")).toBeInTheDocument();
+    expect(screen.queryByText(/Appeal decision date/)).toBeInTheDocument();
 
     expect(screen.getByTestId("info-icon")).toBeInTheDocument();
   });

--- a/__tests__/lib/planningApplication/status.test.ts
+++ b/__tests__/lib/planningApplication/status.test.ts
@@ -999,9 +999,7 @@ describe("getApplicationDprStatusSummary", () => {
             lodgedDate: formatDateToYmd(dates.appeal.lodgedAt.toDate()),
             validatedDate: formatDateToYmd(dates.appeal.validatedAt.toDate()),
             startedDate: formatDateToYmd(dates.appeal.startedAt.toDate()),
-            withdrawnAt: formatDateToYmd(dates.appeal.withdrawnAt.toDate()),
-            withdrawnReason: "No longer needed",
-            decision: "allowed",
+            decision: "withdrawn",
             reason: "The council's decision was unfair",
           },
           caseOfficer: {

--- a/__tests__/mocks/dprNewApplicationFactory.test.ts
+++ b/__tests__/mocks/dprNewApplicationFactory.test.ts
@@ -16,7 +16,7 @@
  */
 
 import {
-  AssessmentBase,
+  PostSubmissionAssessment,
   PriorApprovalAssessment,
 } from "@/types/odp-types/schemas/postSubmissionApplication/data/Assessment";
 import { generateDprApplication } from "@mocks/dprNewApplicationFactory";
@@ -318,7 +318,7 @@ describe("generateDprApplication", () => {
     expect(
       Object.keys(
         planningPermissionFullHouseholderAssessmentInProgress.data
-          .assessment as AssessmentBase,
+          .assessment as PostSubmissionAssessment,
       ),
     ).toHaveLength(1);
 
@@ -1235,12 +1235,8 @@ describe("generateDprApplication", () => {
       planningPermissionFullHouseholderAppealWithdrawn.data.appeal?.reason,
     ).toBeDefined();
     expect(
-      planningPermissionFullHouseholderAppealWithdrawn.data.appeal?.withdrawnAt,
-    ).toBeDefined();
-    expect(
-      planningPermissionFullHouseholderAppealWithdrawn.data.appeal
-        ?.withdrawnReason,
-    ).toBeDefined();
+      planningPermissionFullHouseholderAppealWithdrawn.data.appeal?.decision,
+    ).toEqual("withdrawn");
   });
 
   it("Certain application types don't have consultation phases", () => {

--- a/src/components/ApplicationAppeals/ApplicationAppeals.stories.tsx
+++ b/src/components/ApplicationAppeals/ApplicationAppeals.stories.tsx
@@ -41,8 +41,8 @@ const meta = {
     layout: "fullscreen",
   },
   args: {
-    appealReason: appWithAppeal.application.appeal?.reason,
-    appealDocuments: appWithAppeal.application.appeal?.documents,
+    appealReason: appWithAppeal.data.appeal?.reason,
+    appealDocuments: appWithAppeal.data.appeal?.documents,
   },
 } satisfies Meta<typeof ApplicationAppeals>;
 

--- a/src/components/ApplicationCard/ApplicationCard.tsx
+++ b/src/components/ApplicationCard/ApplicationCard.tsx
@@ -66,7 +66,7 @@ export const ApplicationCard = ({
 
   const applicationAppealDecisionSummary = findItemByKey<DprContentPage>(
     contentDecisions(),
-    application?.application?.appeal?.decision?.replaceAll("_", "-") ?? "",
+    application?.data?.appeal?.decision?.replaceAll("_", "-") ?? "",
   )?.title;
 
   return (
@@ -208,17 +208,15 @@ export const ApplicationCard = ({
                 />
               </>
             )}
-            {application?.application?.appeal?.decision && (
+            {application?.data?.appeal?.decision && (
               <>
-                {application?.application?.appeal?.decisionDate ? (
+                {application?.data?.appeal?.decisionDate ? (
                   <ApplicationDataField
                     title="Appeal decision date"
                     value={
-                      <time
-                        dateTime={application.application.appeal.decisionDate}
-                      >
+                      <time dateTime={application.data.appeal.decisionDate}>
                         {formatDateToDprDate(
-                          application.application.appeal.decisionDate,
+                          application.data.appeal.decisionDate,
                         )}
                       </time>
                     }

--- a/src/components/ApplicationDetails/ApplicationDetails.tsx
+++ b/src/components/ApplicationDetails/ApplicationDetails.tsx
@@ -54,7 +54,7 @@ export const ApplicationDetails = ({
   const description = application.proposal.description;
   const people = application.officer || application.applicant;
   const applicationProgress = buildApplicationProgress(application);
-  const appeal = application.application.appeal;
+  const appeal = application.data.appeal;
   const { url: decisionNoticeUrl } =
     documents?.find((d) => d.title === "Decision notice") ?? {};
 
@@ -79,7 +79,7 @@ export const ApplicationDetails = ({
     });
   }
 
-  if (appeal?.reason || appeal?.documents) {
+  if (appeal?.reason || appeal?.files) {
     sidebar.push({
       key: slugify("Appeal"),
       title: "Appeal",
@@ -159,10 +159,10 @@ export const ApplicationDetails = ({
             Description
           </h2>
           <p className="govuk-body">{description}</p>
-          {(appeal?.documents || appeal?.reason) && (
+          {(appeal?.files || appeal?.reason) && (
             <ApplicationAppeals
               appealReason={appeal?.reason}
-              appealDocuments={appeal?.documents}
+              appealDocuments={appeal?.files}
             />
           )}
           {/* <ImpactMeasures /> */}

--- a/src/components/ApplicationHero/ApplicationHero.stories.tsx
+++ b/src/components/ApplicationHero/ApplicationHero.stories.tsx
@@ -222,6 +222,9 @@ export const StatusAppealDetermined: Story = {
         ...baseApplication.application,
         status: "Appeal determined",
         decision: "granted",
+      },
+      data: {
+        ...baseApplication.data,
         appeal: {
           decision: "allowed",
           decisionDate: new Date().toISOString(),
@@ -242,6 +245,9 @@ export const StatusAppealAllowed: Story = {
         ...baseApplication.application,
         status: "Appeal allowed",
         decision: "granted",
+      },
+      data: {
+        ...baseApplication.data,
         appeal: {
           decision: "allowed",
           decisionDate: new Date().toISOString(),
@@ -262,6 +268,9 @@ export const StatusAppealDismissed: Story = {
         ...baseApplication.application,
         status: "Appeal dismissed",
         decision: "refused",
+      },
+      data: {
+        ...baseApplication.data,
         appeal: {
           decision: "dismissed",
           decisionDate: new Date().toISOString(),
@@ -282,6 +291,9 @@ export const StatusAppealSplitDecision: Story = {
         ...baseApplication.application,
         status: "Appeal split decision",
         decision: "granted",
+      },
+      data: {
+        ...baseApplication.data,
         appeal: {
           decision: "split_decision",
           decisionDate: new Date().toISOString(),
@@ -302,6 +314,9 @@ export const StatusAppealWithdrawn: Story = {
         ...baseApplication.application,
         status: "Appeal withdrawn",
         decision: "granted",
+      },
+      data: {
+        ...baseApplication.data,
         appeal: {
           decision: "withdrawn",
           decisionDate: new Date().toISOString(),
@@ -389,6 +404,7 @@ export const AppealDecisionAllowed: Story = {
       decision: "refused",
       applicationStatus: "Appeal allowed",
       appeal: {
+        reason: "Morbi leo risus, porta ac consectetur ac, vestibulum at eros.",
         decision: "allowed",
         decisionDate: new Date().toISOString(),
         lodgedDate: new Date().toISOString(),
@@ -405,6 +421,7 @@ export const AppealDecisionDismissed: Story = {
       decision: "refused",
       applicationStatus: "Appeal allowed",
       appeal: {
+        reason: "Morbi leo risus, porta ac consectetur ac, vestibulum at eros.",
         decision: "dismissed",
         decisionDate: new Date().toISOString(),
         lodgedDate: new Date().toISOString(),
@@ -421,7 +438,8 @@ export const AppealDecisionSplitDecision: Story = {
       decision: "refused",
       applicationStatus: "Appeal allowed",
       appeal: {
-        decision: "split_decision",
+        reason: "Morbi leo risus, porta ac consectetur ac, vestibulum at eros.",
+        decision: "splitDecision",
         decisionDate: new Date().toISOString(),
         lodgedDate: new Date().toISOString(),
         startedDate: new Date().toISOString(),
@@ -437,6 +455,7 @@ export const AppealDecisionWithdrawn: Story = {
       decision: "refused",
       applicationStatus: "Appeal allowed",
       appeal: {
+        reason: "Morbi leo risus, porta ac consectetur ac, vestibulum at eros.",
         decision: "withdrawn",
         decisionDate: new Date().toISOString(),
         lodgedDate: new Date().toISOString(),
@@ -453,6 +472,7 @@ export const AppealDecisionNotDecidedYet: Story = {
       decision: "refused",
       applicationStatus: "Appeal lodged",
       appeal: {
+        reason: "Morbi leo risus, porta ac consectetur ac, vestibulum at eros.",
         decision: undefined, // explicitly setting it to null
         lodgedDate: new Date().toISOString(),
         startedDate: new Date().toISOString(),

--- a/src/components/ApplicationHero/ApplicationHero.tsx
+++ b/src/components/ApplicationHero/ApplicationHero.tsx
@@ -73,7 +73,7 @@ export const ApplicationHero = ({
 
   const applicationAppealDecisionSummary = findItemByKey<DprContentPage>(
     contentDecisions(),
-    application?.application?.appeal?.decision?.replaceAll("_", "-") ?? "",
+    application?.data?.appeal?.decision?.replaceAll("_", "-") ?? "",
   )?.title;
 
   return (
@@ -173,15 +173,13 @@ export const ApplicationHero = ({
                       />
                     ) : undefined
                   }
-                  isFull={
-                    application?.application?.appeal?.decision ? false : true
-                  }
+                  isFull={application?.data?.appeal?.decision ? false : true}
                 />
               </>
             )}
 
             {/* Appeal decision */}
-            {application?.application?.appeal?.decision && (
+            {application?.data?.appeal?.decision && (
               <ApplicationDataField
                 title="Appeal decision"
                 value={

--- a/src/handlers/bops/types/definitions/application.d.ts
+++ b/src/handlers/bops/types/definitions/application.d.ts
@@ -25,6 +25,7 @@ import { BopsNonStandardComment } from "./comment";
 import { Applicant } from "@/types/odp-types/schemas/prototypeApplication/data/Applicant";
 import { ApplicationType } from "@/types/odp-types/schemas/prototypeApplication/enums/ApplicationType.ts";
 import { DprDocument } from "@/types";
+import { Appeal } from "@/types/odp-types/schemas/prototypeApplication/data/Appeal";
 
 /**
  * #/components/definitions/ApplicationOverview
@@ -103,6 +104,11 @@ export interface BopsApplicationOverview {
 
 export interface BopsPlanningApplication {
   application: BopsApplicationOverview;
+  data: {
+    appeal?: Appeal & {
+      files?: BopsFile[];
+    };
+  };
   property: {
     address: {
       latitude: number;

--- a/src/lib/planningApplication/decision.tsx
+++ b/src/lib/planningApplication/decision.tsx
@@ -27,7 +27,7 @@ import { Council } from "@/config/types";
 import Link from "next/link";
 import {
   PostSubmissionAssessment,
-  PriorApprovalAssessmentBase,
+  PriorApprovalAssessment,
 } from "@/types/odp-types/schemas/postSubmissionApplication/data/Assessment";
 import { PostSubmissionApplication } from "@/types/odp-types/schemas/postSubmissionApplication";
 
@@ -127,7 +127,7 @@ export const getApplicationDprDecisionSummary = (
   }
   const assessment = application.data.assessment as
     | PostSubmissionAssessment
-    | PriorApprovalAssessmentBase;
+    | PriorApprovalAssessment;
 
   const decision =
     assessment?.planningOfficerDecision || assessment?.committeeDecision;
@@ -136,7 +136,7 @@ export const getApplicationDprDecisionSummary = (
     return undefined;
   }
 
-  const priorApprovalRequired = (assessment as PriorApprovalAssessmentBase)
+  const priorApprovalRequired = (assessment as PriorApprovalAssessment)
     ?.priorApprovalRequired;
 
   if (priorApprovalRequired === undefined) {

--- a/src/lib/planningApplication/progress.tsx
+++ b/src/lib/planningApplication/progress.tsx
@@ -130,10 +130,10 @@ export const buildApplicationProgress = (
 
   // 06 appealLodged
 
-  if (application?.application?.appeal?.lodgedDate) {
+  if (application?.data?.appeal?.lodgedDate) {
     progressData.push({
       title: "Appeal lodged",
-      date: formatDateToDprDate(application.application.appeal.lodgedDate),
+      date: formatDateToDprDate(application.data.appeal.lodgedDate),
       content: findItemByKey<DprContentPage>(
         contentImportantDates(),
         slugify("Appeal lodged date"),
@@ -143,10 +143,10 @@ export const buildApplicationProgress = (
 
   // 07 appealValidFrom
 
-  if (application?.application?.appeal?.validatedDate) {
+  if (application?.data?.appeal?.validatedDate) {
     progressData.push({
       title: "Appeal valid from",
-      date: formatDateToDprDate(application.application.appeal.validatedDate),
+      date: formatDateToDprDate(application.data.appeal.validatedDate),
       content: findItemByKey<DprContentPage>(
         contentImportantDates(),
         slugify("Appeal valid from date"),
@@ -156,10 +156,10 @@ export const buildApplicationProgress = (
 
   // 08 appealStarted
 
-  if (application?.application?.appeal?.startedDate) {
+  if (application?.data?.appeal?.startedDate) {
     progressData.push({
       title: "Appeal started",
-      date: formatDateToDprDate(application.application.appeal.startedDate),
+      date: formatDateToDprDate(application.data.appeal.startedDate),
       content: findItemByKey<DprContentPage>(
         contentImportantDates(),
         slugify("Appeal started date"),
@@ -169,13 +169,13 @@ export const buildApplicationProgress = (
 
   // 09 appealDecided
 
-  if (application?.application?.appeal?.decisionDate) {
+  if (application?.data?.appeal?.decisionDate) {
     progressData.push({
       title: "Appeal decided",
-      date: formatDateToDprDate(application.application.appeal.decisionDate),
+      date: formatDateToDprDate(application.data.appeal.decisionDate),
       content: findItemByKey<DprContentPage>(
         contentImportantDates(),
-        slugify("Appeal decision date"),
+        slugify("Appeal decided date"),
       )?.content ?? <></>,
     });
   }

--- a/src/lib/planningApplication/status.tsx
+++ b/src/lib/planningApplication/status.tsx
@@ -33,7 +33,7 @@ import { Council } from "@/config/types";
 import { PostSubmissionApplication } from "@/types/odp-types/schemas/postSubmissionApplication";
 import {
   PostSubmissionAssessment,
-  PriorApprovalAssessmentBase,
+  PriorApprovalAssessment,
 } from "@/types/odp-types/schemas/postSubmissionApplication/data/Assessment";
 
 dayjs.extend(customParseFormat);
@@ -201,9 +201,9 @@ export const getApplicationDprStatusSummary = (
 
   if (stage === "assessment") {
     const hasAssessmentDecisionData =
-      (assessment as PostSubmissionAssessment | PriorApprovalAssessmentBase)
+      (assessment as PostSubmissionAssessment | PriorApprovalAssessment)
         ?.planningOfficerDecision ||
-      (assessment as PostSubmissionAssessment | PriorApprovalAssessmentBase)
+      (assessment as PostSubmissionAssessment | PriorApprovalAssessment)
         ?.committeeDecision;
 
     if (status === "determined" && hasAssessmentDecisionData) {
@@ -214,12 +214,15 @@ export const getApplicationDprStatusSummary = (
   }
 
   if (stage === "appeal" && appeal) {
-    if (appeal.withdrawnAt) {
-      return "Appeal withdrawn";
-    }
-
     if (appeal.decision) {
-      return "Appeal decided";
+      switch (appeal.decision) {
+        case "allowed":
+        case "dismissed":
+        case "splitDecision":
+          return "Appeal decided";
+        case "withdrawn":
+          return "Appeal withdrawn";
+      }
     }
 
     if (appeal.lodgedDate && appeal.validatedDate && appeal.startedDate) {

--- a/src/types/definitions.d.ts
+++ b/src/types/definitions.d.ts
@@ -26,6 +26,7 @@
  */
 
 import { Applicant } from "@/types/odp-types/schemas/prototypeApplication/data/Applicant";
+import { Appeal } from "@/types/odp-types/schemas/prototypeApplication/data/Appeal";
 import { ApplicationType } from "@/types/odp-types/schemas/prototypeApplication/enums/ApplicationType.ts";
 import { GeoBoundary } from "@/types/odp-types/shared/Boundaries";
 import { PostSubmissionApplication } from "@/types/odp-types/schemas/postSubmissionApplication/index";
@@ -63,6 +64,9 @@ export interface DprPlanningApplication {
   data: {
     localPlanningAuthority: {
       commentsAcceptedUntilDecision: boolean;
+    };
+    appeal?: Appeal & {
+      files?: DprDocument[];
     };
   };
   application: {
@@ -127,31 +131,6 @@ export interface DprPlanningApplication {
      */
     determinedAt?: string | null;
     decision?: string | null;
-    appeal?: {
-      decision?: "allowed" | "dismissed" | "split_decision" | "withdrawn";
-      /**
-       * YYYY-MM-DD
-       * Follows convention of if date in the name it is YYYY-MM-DD
-       */
-      decisionDate?: string;
-      /**
-       * YYYY-MM-DD
-       * Follows convention of if date in the name it is YYYY-MM-DD
-       */
-      lodgedDate?: string;
-      /**
-       * YYYY-MM-DD
-       * Follows convention of if date in the name it is YYYY-MM-DD
-       */
-      startedDate?: string;
-      /**
-       * YYYY-MM-DD
-       * Follows convention of if date in the name it is YYYY-MM-DD
-       */
-      validatedDate?: string;
-      reason?: string;
-      documents?: DprDocument[];
-    } | null;
   };
   property: {
     address: {

--- a/src/types/odp-types/schemas/postSubmissionApplication/README.md
+++ b/src/types/odp-types/schemas/postSubmissionApplication/README.md
@@ -165,7 +165,7 @@ undetermined:::status
 submission --> validation
 validation --> consultation
 consultation --> assessment
-assessment -.-> appeal
+assessment -.-> |After determination made or if assessment expiryDate passed|appeal
 appeal -.-> highCourtAppeal
 
 

--- a/src/types/odp-types/schemas/postSubmissionApplication/data/Appeal.ts
+++ b/src/types/odp-types/schemas/postSubmissionApplication/data/Appeal.ts
@@ -1,8 +1,15 @@
-import { Date, DateTime } from "../../../shared/utils";
+import { Date } from "../../../shared/utils";
 import { PrimaryApplicationType } from "../../prototypeApplication/enums/ApplicationType";
 import { AppealDecision } from "../enums/AppealDecision";
 import { PostSubmissionFile } from "./File";
 
+/**
+ * This schema represents the appeal process for a planning application currently based on the implentation in BOPS and DPR
+ * @todo We need to confirm if withdrawn is a decision or a status
+ * Status: Appeal lapsed https://acp.planninginspectorate.gov.uk/ViewCase.aspx?CaseID=3174076&CoID=0
+ * Status: Appeal withdrawn https://acp.planninginspectorate.gov.uk/ViewCase.aspx?CaseID=3174654&CoID=0
+ * Status: Complete: Notice Withdrawn https://acp.planninginspectorate.gov.uk/ViewCase.aspx?CaseID=3062094&CoID=0
+ */
 type AppealBase = {
   /**
    * Reason for appeal
@@ -43,12 +50,9 @@ type AppealBase = {
 
   /**
    * Date the appeal was withdrawn
+   * @todo removed until we have more information on if withdrawn is a status or not for now use decision
    */
-  withdrawnAt?: DateTime;
-  /**
-   * The reason the appeal was withdrawn
-   */
-  withdrawnReason?: string;
+  // withdrawnAt?: DateTime;
 
   /**
    *

--- a/src/types/odp-types/schemas/postSubmissionApplication/data/Assessment.ts
+++ b/src/types/odp-types/schemas/postSubmissionApplication/data/Assessment.ts
@@ -6,15 +6,38 @@ import { AssessmentDecision } from "../enums/AssessmentDecision";
  * Council decision is planningOfficerDecision || committeeDecision
  * Council decision date is planningOfficerDecisionDate || committeeDecisionDate
  */
-export type AssessmentBase = {
+/**
+ * @description Assessment for a post submission application
+ */
+export type PostSubmissionAssessment = AssessmentBase &
+  AssessmentDecisionSection &
+  AssessmentCommittee;
+
+/**
+ * @description Base type for all assessments
+ */
+type AssessmentBase = {
   /**
    * The decision has to be made before this date if not an appeal can be made on the grounds of non-determination
    * @todo After this the determination can be shown as "Non-Determination: would have granted Non-Determination: would have refused" by some councils do we need to show this or will decisionDate being after expiryDate be enough?
    */
   expiryDate: Date;
+
+  /**
+   * The url to the decision notice
+   * A decision notice is issued when an application is determined or withdrawn
+   *
+   */
+  decisionNotice?: {
+    url: string;
+  };
 };
 
-export type PostSubmissionAssessment = AssessmentBase & {
+/**
+ * @description AssessmentDecisionSection
+ * When a decision is made by a planning officer(s) in a LPA
+ */
+type AssessmentDecisionSection = {
   /**
    * This is the decision made by planning officer(s) in a LPA
    */
@@ -24,7 +47,13 @@ export type PostSubmissionAssessment = AssessmentBase & {
    * This is the date the decision was made by planning officer(s) in a LPA
    */
   planningOfficerDecisionDate?: Date;
+};
 
+/**
+ * @description AssessmentCommittee
+ * When a decision is made by a committee in a LPA
+ */
+type AssessmentCommittee = {
   /**
    * This is the recommendation made by planning officer(s) to the committee
    * This is an alternative to a decision - either planningOfficerDecision or planningOfficerRecommendation can be set not both
@@ -46,27 +75,18 @@ export type PostSubmissionAssessment = AssessmentBase & {
    * The date the committee made their decision
    */
   committeeDecisionDate?: Date;
-  /**
-   * The url to the decision notice
-   * A decision notice is issued when an application is determined or withdrawn
-   *
-   */
-  decisionNotice?: {
-    url: string;
-  };
 };
 
-export type PriorApprovalAssessmentBase = PostSubmissionAssessment & {
+/**
+ * @description Assessment for a post submission application with type prior approval
+ */
+export type PriorApprovalAssessment = PostSubmissionAssessment & {
   /**
    * Only applies for prior approval applications so we can work out
    * 'Prior approval required and approved', 'Prior approval not required', 'Prior approval required and refused'
    */
-  priorApprovalRequired: boolean;
+  priorApprovalRequired?: boolean;
 };
-
-export type PriorApprovalAssessment =
-  | AssessmentBase
-  | PriorApprovalAssessmentBase;
 
 /**
  * TypeMap of PrimaryApplicationTypes to their specific Assessment models

--- a/src/types/odp-types/schemas/postSubmissionApplication/data/File.ts
+++ b/src/types/odp-types/schemas/postSubmissionApplication/data/File.ts
@@ -10,15 +10,16 @@ export interface PostSubmissionFile {
   type?: FileType[];
   description?: string;
   url: string;
-  metadata: FileMetadata;
+  metadata: PostSubmissionFileMetadata;
 }
 
 /**
  * @description Metadata about the file
  */
-interface FileMetadata {
+interface PostSubmissionFileMetadata {
   byteSize: number;
   mimeType: string;
   createdAt: DateTime;
   uploadedAt: DateTime;
+  publishedAt: DateTime;
 }

--- a/src/types/odp-types/schemas/postSubmissionApplication/enums/AppealDecision.ts
+++ b/src/types/odp-types/schemas/postSubmissionApplication/enums/AppealDecision.ts
@@ -9,9 +9,9 @@ type allowed = "allowed";
 type dismissed = "dismissed";
 
 /**
- * @description split_decision
+ * @description splitDecision
  */
-type split_decision = "split_decision";
+type splitDecision = "splitDecision";
 
 /**
  * @description withdrawn
@@ -22,4 +22,4 @@ type withdrawn = "withdrawn";
  * @id #AppealDecision
  * @description Types of comments
  */
-export type AppealDecision = allowed | dismissed | split_decision | withdrawn;
+export type AppealDecision = allowed | dismissed | splitDecision | withdrawn;

--- a/src/types/odp-types/schemas/postSubmissionApplication/lib/realisticDates.ts
+++ b/src/types/odp-types/schemas/postSubmissionApplication/lib/realisticDates.ts
@@ -15,6 +15,7 @@ type RealisticDates = {
     endAt: Date;
   };
   assessment: {
+    expiryAt: Date;
     planningOfficerDecisionAt: Date;
     committeeSentAt: Date;
     committeeDecisionAt: Date;
@@ -66,6 +67,9 @@ export const generateRealisticDates = (
   const consultationStartAt = validatedAt;
   const consultationEndAt = addDays(consultationStartAt, 21);
 
+  // An assessment has an expiry date which is different per application type
+  const expiryAt = addMonths(consultationEndAt, 1);
+
   // the council decision is made sometime after the consultation ends
   const planningOfficerDecisionAt = addDays(consultationEndAt, 10);
 
@@ -111,6 +115,7 @@ export const generateRealisticDates = (
       endAt: consultationEndAt,
     },
     assessment: {
+      expiryAt: expiryAt,
       planningOfficerDecisionAt: planningOfficerDecisionAt,
       committeeSentAt: committeeSentAt,
       committeeDecisionAt: committeeDecisionAt,


### PR DESCRIPTION
[DSNPI-1008 BOPS - Add appeals to BOPS API endpoints - Jira](https://tpximpact.atlassian.net/browse/DSNPI-1008)

This PR:

- makes some tweaks to the original work we did to add appeals into the DPR as we updated/created the Post-submission schema in the meantime
  - Appeals is now at `data.appeal` not `data.application.appeal` to kick start the migration to the new format
- Adds the latest changes from the ODP repo in a separate commit
- Updates some of the new mock logic with the new changes in the ODP repo 

![image](https://github.com/user-attachments/assets/d8b9a4a3-d557-4726-98c7-885e9d6b6ea7)


## Related PRs (not dependant on)

- [PR in BOPS](https://github.com/unboxed/bops/pull/2196)
- https://github.com/theopensystemslab/digital-planning-data-schemas/pull/323 
- https://github.com/theopensystemslab/digital-planning-data-schemas/pull/324



