### PR TITLE
BUG: Fix console error in tests

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -167,7 +167,7 @@ const config = {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,23 @@
+const CONSOLE_FAIL_TYPES = ["error", "warn"];
+
+/**
+ * Throws an error whenever  `console.error` or `console.warn` happens
+ * If we're expecting `console.error` or `console.warn` then you should mock it out using `jest.spyOn`
+ * and test that the warning occurs.
+ *
+ * test('should log a warning', () => {
+ *   jest.spyOn(console, 'warn').mockImplementation()
+ *
+ *   // assert the expected warning
+ *   expect(console.warn).toHaveBeenCalledWith(
+ *     expect.stringContaining('Empty titles are deprecated.'),
+ *   )
+ * })
+ */
+CONSOLE_FAIL_TYPES.forEach((type) => {
+  console[type] = (message) => {
+    throw new Error(
+      `Expected test not to call console.${type}().\n\nIf the warning is expected, test for it explicitly by mocking it out using jest.spyOn(console, '${type}') and test that the warning occurs.\n\n${message}`,
+    );
+  };
+});

--- a/src/components/govukDpr/Attachment/Attachment.tsx
+++ b/src/components/govukDpr/Attachment/Attachment.tsx
@@ -112,31 +112,31 @@ export const Attachment = ({
           <p className="dpr-attachment__metadata">{metadataLine}</p>
         )}
         <p className="dpr-attachment__metadata">
-          This file may not be suitable for users of assistive technology.{" "}
-          {alternativeFormatContactEmail && (
-            <Details
-              summaryText="Request an accessible format."
-              text={
-                <>
-                  <p className="govuk-body">
-                    If you use assistive technology (such as a screen reader)
-                    and need a version of this document in a more accessible
-                    format, please email{" "}
-                    <a
-                      href={`mailto:${alternativeFormatContactEmail}`}
-                      className="govuk-link"
-                      aria-label={`Request an accessible format for ${title || fileName || "this file"}`}
-                    >
-                      {alternativeFormatContactEmail}
-                    </a>
-                    . Please tell us what format you need. It will help us if
-                    you say what assistive technology you use.
-                  </p>
-                </>
-              }
-            />
-          )}
+          This file may not be suitable for users of assistive technology.
         </p>
+        {alternativeFormatContactEmail && (
+          <Details
+            summaryText="Request an accessible format."
+            text={
+              <>
+                <p className="govuk-body">
+                  If you use assistive technology (such as a screen reader) and
+                  need a version of this document in a more accessible format,
+                  please email{" "}
+                  <a
+                    href={`mailto:${alternativeFormatContactEmail}`}
+                    className="govuk-link"
+                    aria-label={`Request an accessible format for ${title || fileName || "this file"}`}
+                  >
+                    {alternativeFormatContactEmail}
+                  </a>
+                  . Please tell us what format you need. It will help us if you
+                  say what assistive technology you use.
+                </p>
+              </>
+            }
+          />
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
Some tests were throwing uncaught errors and warns, also fixed the error from the test.

<img width="916" alt="image" src="https://github.com/user-attachments/assets/f44af3a8-ea79-48da-b8e1-ef954cb264b2" />

We now catch these as part of the test so no errors get through:

<img width="1325" alt="image" src="https://github.com/user-attachments/assets/272d8e9d-ab59-4466-a52c-62a351da8a93" />

