### PR TITLE
Update DPR Mocks for the conversion function

### DIFF
--- a/__tests__/lib/planningApplication/progress.test.ts
+++ b/__tests__/lib/planningApplication/progress.test.ts
@@ -16,7 +16,23 @@
  */
 
 import { buildApplicationProgress } from "@/lib/planningApplication/progress";
-import { generateDprApplication } from "@mocks/dprApplicationFactory";
+import {
+  generateDprApplication,
+  generateExampleApplications,
+} from "@mocks/dprApplicationFactory";
+
+const {
+  consultation,
+  assessmentInProgress,
+  planningOfficerDetermined,
+  assessmentInCommittee,
+  committeeDetermined,
+  appealLodged,
+  appealValid,
+  appealStarted,
+  appealDetermined,
+  withdrawn,
+} = generateExampleApplications();
 
 describe("buildApplicationProgress", () => {
   it('should show "Consultation ended" when consultation end date is in the past', () => {
@@ -34,5 +50,125 @@ describe("buildApplicationProgress", () => {
     ).toISOString();
     const progressData = buildApplicationProgress(application);
     expect(progressData[3].title).toBe("Consultation ends");
+  });
+
+  // 01-submission
+  // 02-validation-01-invalid
+
+  // 03-consultation
+  it("03-consultation", () => {
+    const application = consultation;
+    const progressData = buildApplicationProgress(application);
+    expect(progressData[0].title).toBe("Received");
+    expect(progressData[1].title).toBe("Valid from");
+    expect(progressData[2].title).toBe("Published");
+    expect(progressData[3].title).toBe("Consultation ends");
+  });
+
+  // 04-assessment-00-assessment-in-progress
+  it("04-assessment-00-assessment-in-progress", () => {
+    const application = assessmentInProgress;
+    const progressData = buildApplicationProgress(application);
+    expect(progressData[0].title).toBe("Received");
+    expect(progressData[1].title).toBe("Valid from");
+    expect(progressData[2].title).toBe("Published");
+    expect(progressData[3].title).toBe("Consultation ended");
+  });
+
+  // 04-assessment-01-council-determined
+  it("04-assessment-01-council-determined", () => {
+    const application = planningOfficerDetermined;
+    const progressData = buildApplicationProgress(application);
+    expect(progressData[0].title).toBe("Received");
+    expect(progressData[1].title).toBe("Valid from");
+    expect(progressData[2].title).toBe("Published");
+    expect(progressData[3].title).toBe("Consultation ended");
+    expect(progressData[4].title).toBe("Council decision made");
+  });
+
+  // 04-assessment-02-assessment-in-committee
+  it("04-assessment-02-assessment-in-committee", () => {
+    const application = assessmentInCommittee;
+    const progressData = buildApplicationProgress(application);
+    expect(progressData[0].title).toBe("Received");
+    expect(progressData[1].title).toBe("Valid from");
+    expect(progressData[2].title).toBe("Published");
+    expect(progressData[3].title).toBe("Consultation ended");
+  });
+
+  // 04-assessment-03-committee-determined
+  it("04-assessment-01-council-determined", () => {
+    const application = committeeDetermined;
+    const progressData = buildApplicationProgress(application);
+    expect(progressData[0].title).toBe("Received");
+    expect(progressData[1].title).toBe("Valid from");
+    expect(progressData[2].title).toBe("Published");
+    expect(progressData[3].title).toBe("Consultation ended");
+    expect(progressData[4].title).toBe("Council decision made");
+  });
+
+  // 05-appeal-00-appeal-lodged
+  it("05-appeal-00-appeal-lodged", () => {
+    const application = appealLodged;
+    const progressData = buildApplicationProgress(application);
+    expect(progressData[0].title).toBe("Received");
+    expect(progressData[1].title).toBe("Valid from");
+    expect(progressData[2].title).toBe("Published");
+    expect(progressData[3].title).toBe("Consultation ended");
+    expect(progressData[4].title).toBe("Council decision made");
+    expect(progressData[5].title).toBe("Appeal lodged");
+  });
+
+  // 05-appeal-01-appeal-validated
+  it("05-appeal-01-appeal-validated", () => {
+    const application = appealValid;
+    const progressData = buildApplicationProgress(application);
+    expect(progressData[0].title).toBe("Received");
+    expect(progressData[1].title).toBe("Valid from");
+    expect(progressData[2].title).toBe("Published");
+    expect(progressData[3].title).toBe("Consultation ended");
+    expect(progressData[4].title).toBe("Council decision made");
+    expect(progressData[5].title).toBe("Appeal lodged");
+    expect(progressData[6].title).toBe("Appeal valid from");
+  });
+
+  // 05-appeal-02-appeal-started
+  it("05-appeal-02-appeal-started", () => {
+    const application = appealStarted;
+    const progressData = buildApplicationProgress(application);
+    expect(progressData[0].title).toBe("Received");
+    expect(progressData[1].title).toBe("Valid from");
+    expect(progressData[2].title).toBe("Published");
+    expect(progressData[3].title).toBe("Consultation ended");
+    expect(progressData[4].title).toBe("Council decision made");
+    expect(progressData[5].title).toBe("Appeal lodged");
+    expect(progressData[6].title).toBe("Appeal valid from");
+    expect(progressData[7].title).toBe("Appeal started");
+  });
+
+  // 05-appeal-03-appeal-determined
+  it("05-appeal-03-appeal-determined", () => {
+    const application = appealDetermined;
+    const progressData = buildApplicationProgress(application);
+    expect(progressData[0].title).toBe("Received");
+    expect(progressData[1].title).toBe("Valid from");
+    expect(progressData[2].title).toBe("Published");
+    expect(progressData[3].title).toBe("Consultation ended");
+    expect(progressData[4].title).toBe("Council decision made");
+    expect(progressData[5].title).toBe("Appeal lodged");
+    expect(progressData[6].title).toBe("Appeal valid from");
+    expect(progressData[7].title).toBe("Appeal started");
+    expect(progressData[8].title).toBe("Appeal decided");
+  });
+
+  // 06-assessment-withdrawn
+  // @TODO need to add withdrawn date to the application
+  it("06-assessment-withdrawn", () => {
+    const application = withdrawn;
+    const progressData = buildApplicationProgress(application);
+    expect(progressData[0].title).toBe("Received");
+    expect(progressData[1].title).toBe("Valid from");
+    expect(progressData[2].title).toBe("Published");
+    expect(progressData[3].title).toBe("Consultation ended");
   });
 });

--- a/src/components/ApplicationCard/ApplicationCard.stories.ts
+++ b/src/components/ApplicationCard/ApplicationCard.stories.ts
@@ -17,10 +17,34 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 import { ApplicationCard } from "./ApplicationCard";
-import { generateDprApplication } from "@mocks/dprApplicationFactory";
-import { faker } from "@faker-js/faker";
+import { generateExampleApplications } from "@mocks/dprApplicationFactory";
 
-const application = generateDprApplication();
+const {
+  consultation,
+  assessmentInProgress,
+  planningOfficerDetermined,
+  assessmentInCommittee,
+  committeeDetermined,
+  appealLodged,
+  appealValid,
+  appealStarted,
+  appealDetermined,
+  appealDeterminedWithdrawn,
+  appealDeterminedAllowed,
+  appealDeterminedDismissed,
+  appealDeterminedSplitDecision,
+  withdrawn,
+} = generateExampleApplications();
+
+const application = committeeDetermined;
+
+const shortDescription = `Maecenas faucibus mollis interdum. Vestibulum id ligula porta felis euismod semper. Etiam porta sem malesuada magna mollis euismod. Cras justo odio, dapibus ac facilisis in, egestas eget quam.`;
+const longDescription = `Maecenas faucibus mollis interdum. Vestibulum id ligula porta felis euismod semper. Etiam porta sem malesuada magna mollis euismod. Cras justo odio, dapibus ac facilisis in, egestas eget quam.
+
+Sed posuere consectetur est at lobortis. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nulla vitae elit libero, a pharetra augue. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Donec id elit non mi porta gravida at eget metus. Maecenas faucibus mollis interdum.
+
+Donec ullamcorper nulla non metus auctor fringilla. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Cras mattis consectetur purus sit amet fermentum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.`;
+
 const meta = {
   title: "DPR Components/ApplicationCard",
   component: ApplicationCard,
@@ -47,7 +71,7 @@ export const LongDescriptionWithMap: Story = {
       ...application,
       proposal: {
         ...application.proposal,
-        description: faker.lorem.paragraphs(20),
+        description: longDescription,
       },
     },
   },
@@ -59,7 +83,7 @@ export const LongDescriptionWithoutMap: Story = {
       ...application,
       proposal: {
         ...application.proposal,
-        description: faker.lorem.paragraphs(20),
+        description: longDescription,
       },
       property: {
         ...application.property,
@@ -77,7 +101,7 @@ export const ShortDescriptionWithMap: Story = {
       ...application,
       proposal: {
         ...application.proposal,
-        description: faker.lorem.paragraphs(1),
+        description: shortDescription,
       },
     },
   },
@@ -88,7 +112,7 @@ export const ShortDescriptionWithoutMap: Story = {
       ...application,
       proposal: {
         ...application.proposal,
-        description: faker.lorem.paragraphs(1),
+        description: shortDescription,
       },
       property: {
         ...application.property,
@@ -98,5 +122,110 @@ export const ShortDescriptionWithoutMap: Story = {
         },
       },
     },
+  },
+};
+
+// 01-submission
+// 02-validation-01-invalid
+// 03-consultation
+export const Consultation: Story = {
+  name: "03-consultation",
+  args: {
+    application: consultation,
+  },
+};
+
+// 04-assessment-00-assessment-in-progress
+export const AssessmentInProgress: Story = {
+  name: "04-assessment-00-assessment-in-progress",
+  args: {
+    application: assessmentInProgress,
+  },
+};
+
+// 04-assessment-01-council-determined
+export const PlanningOfficerDetermined: Story = {
+  name: "04-assessment-01-council-determined",
+  args: {
+    application: planningOfficerDetermined,
+  },
+};
+
+// 04-assessment-02-assessment-in-committee
+export const AssessmentInCommittee: Story = {
+  name: "04-assessment-02-assessment-in-committee",
+  args: {
+    application: assessmentInCommittee,
+  },
+};
+
+// 04-assessment-03-committee-determined
+export const CommitteeDetermined: Story = {
+  name: "04-assessment-03-committee-determined",
+  args: {
+    application: committeeDetermined,
+  },
+};
+
+// 05-appeal-00-appeal-lodged
+export const AppealLodged: Story = {
+  name: "05-appeal-00-appeal-lodged",
+  args: {
+    application: appealLodged,
+  },
+};
+
+// 05-appeal-01-appeal-validated
+export const AppealValid: Story = {
+  name: "05-appeal-01-appeal-validated",
+  args: {
+    application: appealValid,
+  },
+};
+
+// 05-appeal-02-appeal-started
+export const AppealStarted: Story = {
+  name: "05-appeal-02-appeal-started",
+  args: {
+    application: appealStarted,
+  },
+};
+
+// 05-appeal-03-appeal-determined
+export const AppealDetermined: Story = {
+  name: "05-appeal-03-appeal-determined",
+  args: {
+    application: appealDetermined,
+  },
+};
+export const AppealDeterminedWithdrawn: Story = {
+  name: "05-appeal-03-appeal-determined--withdrawn",
+  args: {
+    application: appealDeterminedWithdrawn,
+  },
+};
+export const AppealDeterminedAllowed: Story = {
+  name: "05-appeal-03-appeal-determined--allowed",
+  args: {
+    application: appealDeterminedAllowed,
+  },
+};
+export const AppealDeterminedDismissed: Story = {
+  name: "05-appeal-03-appeal-determined--dismissed",
+  args: {
+    application: appealDeterminedDismissed,
+  },
+};
+export const AppealDeterminedSplitDecision: Story = {
+  name: "05-appeal-03-appeal-determined--split-decision",
+  args: {
+    application: appealDeterminedSplitDecision,
+  },
+};
+// 06-assessment-withdrawn
+export const Withdrawn: Story = {
+  name: "06-assessment-withdrawn",
+  args: {
+    application: withdrawn,
   },
 };

--- a/src/components/ApplicationDetails/ApplicationDetails.stories.tsx
+++ b/src/components/ApplicationDetails/ApplicationDetails.stories.tsx
@@ -20,19 +20,13 @@ import { ApplicationDetails } from "./ApplicationDetails";
 import { createAppConfig } from "@mocks/appConfigFactory";
 import {
   generateDocument,
-  generateDprApplication,
+  generateExampleApplications,
   generateNResults,
 } from "@mocks/dprApplicationFactory";
 import { DprDocument } from "@/types";
-import { formatDateToYmd } from "@/util";
 
-const baseApplication = generateDprApplication();
 const baseAppConfig = createAppConfig("public-council-1");
-if (baseAppConfig?.council) {
-  baseAppConfig.council.pageContent.email_alerts = {
-    sign_up_for_alerts_link: "/signup",
-  };
-}
+const { committeeDetermined } = generateExampleApplications();
 
 const meta = {
   title: "DPR Components/ApplicationDetails",
@@ -46,7 +40,7 @@ const meta = {
   args: {
     reference: "12345",
     appConfig: baseAppConfig,
-    application: baseApplication,
+    application: committeeDetermined,
     documents: generateNResults<DprDocument>(3, generateDocument),
   },
 } satisfies Meta<typeof ApplicationDetails>;
@@ -55,56 +49,3 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
-export const NoDocuments: Story = {
-  args: {
-    documents: undefined,
-  },
-};
-export const FewDocuments: Story = {
-  args: {
-    documents: generateNResults<DprDocument>(3, generateDocument),
-  },
-};
-export const ManyDocuments: Story = {
-  args: {
-    documents: generateNResults<DprDocument>(30, generateDocument),
-  },
-};
-
-const today = new Date();
-const startDate = formatDateToYmd(new Date(today.getTime() - 86400000));
-const endDate = formatDateToYmd(new Date(today));
-const applicationInAssessment = generateDprApplication({
-  applicationType: "pp.full",
-  applicationStatus: "assessment_in_progress",
-});
-const applicationInConsultation = {
-  ...applicationInAssessment,
-  application: {
-    ...applicationInAssessment.application,
-    consultation: {
-      ...applicationInAssessment.application.consultation,
-      startDate,
-      endDate,
-    },
-  },
-};
-
-export const CommentsEnabled: Story = {
-  args: {
-    application: applicationInConsultation,
-  },
-};
-
-export const CommentsEnabledBecauseFlag: Story = {
-  args: {
-    application: {
-      ...applicationInAssessment,
-      data: {
-        localPlanningAuthority: {
-          commentsAcceptedUntilDecision: true,
-        },
-      },
-    },
-  },
-};

--- a/src/components/ApplicationHero/ApplicationHero.stories.tsx
+++ b/src/components/ApplicationHero/ApplicationHero.stories.tsx
@@ -17,10 +17,24 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 import { ApplicationHero } from "./ApplicationHero";
-import { generateDprApplication } from "@mocks/dprApplicationFactory";
-import { formatDateToYmd } from "@/util";
+import { generateExampleApplications } from "@mocks/dprApplicationFactory";
 
-const baseApplication = generateDprApplication();
+const {
+  consultation,
+  assessmentInProgress,
+  planningOfficerDetermined,
+  assessmentInCommittee,
+  committeeDetermined,
+  appealLodged,
+  appealValid,
+  appealStarted,
+  appealDetermined,
+  appealDeterminedWithdrawn,
+  appealDeterminedAllowed,
+  appealDeterminedDismissed,
+  appealDeterminedSplitDecision,
+  withdrawn,
+} = generateExampleApplications();
 
 const meta = {
   title: "DPR Components/ApplicationHero",
@@ -33,7 +47,7 @@ const meta = {
   },
   args: {
     councilSlug: "public-council-1",
-    application: baseApplication,
+    application: committeeDetermined,
   },
 } satisfies Meta<typeof ApplicationHero>;
 
@@ -41,443 +55,108 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
-export const StatusConsultationInProgress: Story = {
+
+// 01-submission
+// 02-validation-01-invalid
+// 03-consultation
+export const Consultation: Story = {
+  name: "03-consultation",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "assessment_in_progress",
-        decision: null,
-        consultation: {
-          startDate: formatDateToYmd(new Date(Date.now() - 5 * 86400000)),
-          endDate: formatDateToYmd(new Date(Date.now() + 86400000)),
-          publishedComments: null,
-          consulteeComments: null,
-        },
-      },
-    },
+    application: consultation,
   },
 };
 
-export const StatusAssessmentInProgress: Story = {
+// 04-assessment-00-assessment-in-progress
+export const AssessmentInProgress: Story = {
+  name: "04-assessment-00-assessment-in-progress",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "in_assessment",
-        decision: null,
-        consultation: {
-          startDate: formatDateToYmd(new Date(Date.now() - 5 * 86400000)),
-          endDate: formatDateToYmd(new Date(Date.now() - 86400000)),
-          publishedComments: null,
-          consulteeComments: null,
-        },
-      },
-    },
+    application: assessmentInProgress,
   },
 };
 
-export const StatusDetermined: Story = {
+// 04-assessment-01-council-determined
+export const PlanningOfficerDetermined: Story = {
+  name: "04-assessment-01-council-determined",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "determined",
-        decision: null,
-        consultation: {
-          startDate: new Date(Date.now() - 5 * 86400000).toISOString(),
-          endDate: new Date(Date.now() - 86400000).toISOString(),
-          publishedComments: null,
-          consulteeComments: null,
-        },
-      },
-    },
+    application: planningOfficerDetermined,
   },
 };
 
-export const StatusWithdrawn: Story = {
+// 04-assessment-02-assessment-in-committee
+export const AssessmentInCommittee: Story = {
+  name: "04-assessment-02-assessment-in-committee",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "withdrawn",
-        decision: null,
-      },
-    },
+    application: assessmentInCommittee,
   },
 };
 
-export const StatusClosed: Story = {
+// 04-assessment-03-committee-determined
+export const CommitteeDetermined: Story = {
+  name: "04-assessment-03-committee-determined",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "closed",
-        decision: null,
-      },
-    },
-  },
-};
-export const StatusReturned: Story = {
-  args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "returned",
-        decision: null,
-      },
-    },
+    application: committeeDetermined,
   },
 };
 
-export const StatusNotStarted: Story = {
+// 05-appeal-00-appeal-lodged
+export const AppealLodged: Story = {
+  name: "05-appeal-00-appeal-lodged",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "not_started",
-        decision: null,
-      },
-    },
+    application: appealLodged,
   },
 };
 
-export const StatusPending: Story = {
+// 05-appeal-01-appeal-validated
+export const AppealValid: Story = {
+  name: "05-appeal-01-appeal-validated",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "pending",
-        decision: null,
-      },
-    },
+    application: appealValid,
   },
 };
 
-export const StatusInvalid: Story = {
+// 05-appeal-02-appeal-started
+export const AppealStarted: Story = {
+  name: "05-appeal-02-appeal-started",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "invalid",
-        decision: null,
-      },
-    },
+    application: appealStarted,
   },
 };
 
-export const StatusAppealLodged: Story = {
+// 05-appeal-03-appeal-determined
+export const AppealDetermined: Story = {
+  name: "05-appeal-03-appeal-determined",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "Appeal lodged",
-        decision: "refused",
-      },
-    },
+    application: appealDetermined,
   },
 };
-
-export const StatusAppealValid: Story = {
+export const AppealDeterminedWithdrawn: Story = {
+  name: "05-appeal-03-appeal-determined--withdrawn",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "Appeal valid",
-        decision: "granted",
-      },
-    },
+    application: appealDeterminedWithdrawn,
   },
 };
-
-export const StatusAppealStarted: Story = {
+export const AppealDeterminedAllowed: Story = {
+  name: "05-appeal-03-appeal-determined--allowed",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "Appeal started",
-        decision: "granted",
-      },
-    },
+    application: appealDeterminedAllowed,
   },
 };
-
-export const StatusAppealDetermined: Story = {
+export const AppealDeterminedDismissed: Story = {
+  name: "05-appeal-03-appeal-determined--dismissed",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "Appeal determined",
-        decision: "granted",
-      },
-      data: {
-        ...baseApplication.data,
-        appeal: {
-          decision: "allowed",
-          decisionDate: new Date().toISOString(),
-          lodgedDate: new Date().toISOString(),
-          startedDate: new Date().toISOString(),
-          validatedDate: new Date().toISOString(),
-        },
-      },
-    },
+    application: appealDeterminedDismissed,
   },
 };
-
-export const StatusAppealAllowed: Story = {
+export const AppealDeterminedSplitDecision: Story = {
+  name: "05-appeal-03-appeal-determined--split-decision",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "Appeal allowed",
-        decision: "granted",
-      },
-      data: {
-        ...baseApplication.data,
-        appeal: {
-          decision: "allowed",
-          decisionDate: new Date().toISOString(),
-          lodgedDate: new Date().toISOString(),
-          startedDate: new Date().toISOString(),
-          validatedDate: new Date().toISOString(),
-        },
-      },
-    },
+    application: appealDeterminedSplitDecision,
   },
 };
-
-export const StatusAppealDismissed: Story = {
+// 06-assessment-withdrawn
+export const Withdrawn: Story = {
+  name: "06-assessment-withdrawn",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "Appeal dismissed",
-        decision: "refused",
-      },
-      data: {
-        ...baseApplication.data,
-        appeal: {
-          decision: "dismissed",
-          decisionDate: new Date().toISOString(),
-          lodgedDate: new Date().toISOString(),
-          startedDate: new Date().toISOString(),
-          validatedDate: new Date().toISOString(),
-        },
-      },
-    },
-  },
-};
-
-export const StatusAppealSplitDecision: Story = {
-  args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "Appeal split decision",
-        decision: "granted",
-      },
-      data: {
-        ...baseApplication.data,
-        appeal: {
-          decision: "split_decision",
-          decisionDate: new Date().toISOString(),
-          lodgedDate: new Date().toISOString(),
-          startedDate: new Date().toISOString(),
-          validatedDate: new Date().toISOString(),
-        },
-      },
-    },
-  },
-};
-
-export const StatusAppealWithdrawn: Story = {
-  args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "Appeal withdrawn",
-        decision: "granted",
-      },
-      data: {
-        ...baseApplication.data,
-        appeal: {
-          decision: "withdrawn",
-          decisionDate: new Date().toISOString(),
-          lodgedDate: new Date().toISOString(),
-          startedDate: new Date().toISOString(),
-          validatedDate: new Date().toISOString(),
-        },
-      },
-    },
-  },
-};
-
-export const DecisionGranted: Story = {
-  args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "determined",
-        decision: "granted",
-      },
-    },
-  },
-};
-
-export const DecisionRefused: Story = {
-  args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "determined",
-        decision: "refused",
-      },
-    },
-  },
-};
-
-export const DecisionPriorApprovalRequiredAndApproved: Story = {
-  args: {
-    application: {
-      ...baseApplication,
-      applicationType: "pa",
-      application: {
-        ...baseApplication.application,
-        status: "determined",
-        decision: "granted",
-      },
-    },
-  },
-};
-
-export const DecisionPriorApprovalNotRequired: Story = {
-  args: {
-    application: {
-      ...baseApplication,
-      applicationType: "pa",
-      application: {
-        ...baseApplication.application,
-
-        status: "determined",
-        decision: "not_required",
-      },
-    },
-  },
-};
-
-export const DecisionPriorApprovalRequiredAndRefused: Story = {
-  args: {
-    application: {
-      ...baseApplication,
-      applicationType: "pa",
-      application: {
-        ...baseApplication.application,
-        status: "determined",
-        decision: "refused",
-      },
-    },
-  },
-};
-
-export const AppealDecisionAllowed: Story = {
-  args: {
-    application: generateDprApplication({
-      decision: "refused",
-      applicationStatus: "Appeal allowed",
-      appeal: {
-        reason: "Morbi leo risus, porta ac consectetur ac, vestibulum at eros.",
-        decision: "allowed",
-        decisionDate: new Date().toISOString(),
-        lodgedDate: new Date().toISOString(),
-        startedDate: new Date().toISOString(),
-        validatedDate: new Date().toISOString(),
-      },
-    }),
-  },
-};
-
-export const AppealDecisionDismissed: Story = {
-  args: {
-    application: generateDprApplication({
-      decision: "refused",
-      applicationStatus: "Appeal allowed",
-      appeal: {
-        reason: "Morbi leo risus, porta ac consectetur ac, vestibulum at eros.",
-        decision: "dismissed",
-        decisionDate: new Date().toISOString(),
-        lodgedDate: new Date().toISOString(),
-        startedDate: new Date().toISOString(),
-        validatedDate: new Date().toISOString(),
-      },
-    }),
-  },
-};
-
-export const AppealDecisionSplitDecision: Story = {
-  args: {
-    application: generateDprApplication({
-      decision: "refused",
-      applicationStatus: "Appeal allowed",
-      appeal: {
-        reason: "Morbi leo risus, porta ac consectetur ac, vestibulum at eros.",
-        decision: "splitDecision",
-        decisionDate: new Date().toISOString(),
-        lodgedDate: new Date().toISOString(),
-        startedDate: new Date().toISOString(),
-        validatedDate: new Date().toISOString(),
-      },
-    }),
-  },
-};
-
-export const AppealDecisionWithdrawn: Story = {
-  args: {
-    application: generateDprApplication({
-      decision: "refused",
-      applicationStatus: "Appeal allowed",
-      appeal: {
-        reason: "Morbi leo risus, porta ac consectetur ac, vestibulum at eros.",
-        decision: "withdrawn",
-        decisionDate: new Date().toISOString(),
-        lodgedDate: new Date().toISOString(),
-        startedDate: new Date().toISOString(),
-        validatedDate: new Date().toISOString(),
-      },
-    }),
-  },
-};
-
-export const AppealDecisionNotDecidedYet: Story = {
-  args: {
-    application: generateDprApplication({
-      decision: "refused",
-      applicationStatus: "Appeal lodged",
-      appeal: {
-        reason: "Morbi leo risus, porta ac consectetur ac, vestibulum at eros.",
-        decision: undefined, // explicitly setting it to null
-        lodgedDate: new Date().toISOString(),
-        startedDate: new Date().toISOString(),
-        validatedDate: new Date().toISOString(),
-      },
-    }),
+    application: withdrawn,
   },
 };

--- a/src/components/ApplicationProgressInfo/ApplicationProgressInfo.stories.tsx
+++ b/src/components/ApplicationProgressInfo/ApplicationProgressInfo.stories.tsx
@@ -17,7 +17,25 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 import { ApplicationProgressInfo } from "./ApplicationProgressInfo";
-import { formatDateTimeToDprDate } from "@/util";
+import { generateExampleApplications } from "@mocks/dprApplicationFactory";
+import { buildApplicationProgress } from "@/lib/planningApplication/progress";
+
+const {
+  consultation,
+  assessmentInProgress,
+  planningOfficerDetermined,
+  assessmentInCommittee,
+  committeeDetermined,
+  appealLodged,
+  appealValid,
+  // appealStarted,
+  // appealDetermined,
+  // appealDeterminedWithdrawn,
+  // appealDeterminedAllowed,
+  // appealDeterminedDismissed,
+  // appealDeterminedSplitDecision,
+  withdrawn,
+} = generateExampleApplications();
 
 const meta = {
   title: "DPR Components/ApplicationProgressInfo",
@@ -27,113 +45,12 @@ const meta = {
   parameters: {
     // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
     layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+    },
   },
   args: {
-    sections: [
-      {
-        title: "Received",
-        date: "2 Jan 2021",
-        content: (
-          <p>
-            Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque
-            ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus
-            mollis interdum. Nulla vitae elit libero, a pharetra augue.
-          </p>
-        ),
-      },
-      {
-        title: "Valid from",
-        date: "3 Jan 2021",
-        content: (
-          <p>
-            Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque
-            ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus
-            mollis interdum. Nulla vitae elit libero, a pharetra augue.
-          </p>
-        ),
-      },
-      {
-        title: "Published",
-        date: "4 Jan 2021",
-        content: (
-          <p>
-            Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque
-            ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus
-            mollis interdum. Nulla vitae elit libero, a pharetra augue.
-          </p>
-        ),
-      },
-      {
-        title: "Consultation ended",
-        date: "5 Jan 2021",
-        content: (
-          <p>
-            Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque
-            ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus
-            mollis interdum. Nulla vitae elit libero, a pharetra augue.
-          </p>
-        ),
-      },
-      {
-        title: "Council decision made",
-        date: (
-          <time dateTime={"2025-07-05T06:37:03.217Z"}>
-            {formatDateTimeToDprDate("2025-07-05T06:37:03.217Z")}
-          </time>
-        ),
-        content: (
-          <p>
-            Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque
-            ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus
-            mollis interdum. Nulla vitae elit libero, a pharetra augue.
-          </p>
-        ),
-      },
-      {
-        title: "Appeal lodged",
-        date: "6 Jan 2021",
-        content: (
-          <p>
-            Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque
-            ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus
-            mollis interdum. Nulla vitae elit libero, a pharetra augue.
-          </p>
-        ),
-      },
-      {
-        title: "Appeal valid from",
-        date: "7 Jan 2021",
-        content: (
-          <p>
-            Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque
-            ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus
-            mollis interdum. Nulla vitae elit libero, a pharetra augue.
-          </p>
-        ),
-      },
-      {
-        title: "Appeal started",
-        date: "8 Jan 2021",
-        content: (
-          <p>
-            Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque
-            ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus
-            mollis interdum. Nulla vitae elit libero, a pharetra augue.
-          </p>
-        ),
-      },
-      {
-        title: "Appeal decided",
-        date: "9 Jan 2021",
-        content: (
-          <p>
-            Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque
-            ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus
-            mollis interdum. Nulla vitae elit libero, a pharetra augue.
-          </p>
-        ),
-      },
-    ],
+    sections: buildApplicationProgress(committeeDetermined),
   },
 } satisfies Meta<typeof ApplicationProgressInfo>;
 
@@ -141,20 +58,110 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
-export const One: Story = {
+
+// 01-submission
+// 02-validation-01-invalid
+// 03-consultation
+export const Consultation: Story = {
+  name: "03-consultation",
   args: {
-    sections: [
-      {
-        title: "Received",
-        date: "2025-01-02",
-        content: (
-          <p>
-            Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque
-            ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus
-            mollis interdum. Nulla vitae elit libero, a pharetra augue.
-          </p>
-        ),
-      },
-    ],
+    sections: buildApplicationProgress(consultation),
+  },
+};
+
+// 04-assessment-00-assessment-in-progress
+export const AssessmentInProgress: Story = {
+  name: "04-assessment-00-assessment-in-progress",
+  args: {
+    sections: buildApplicationProgress(assessmentInProgress),
+  },
+};
+
+// 04-assessment-01-council-determined
+export const PlanningOfficerDetermined: Story = {
+  name: "04-assessment-01-council-determined",
+  args: {
+    sections: buildApplicationProgress(planningOfficerDetermined),
+  },
+};
+
+// 04-assessment-02-assessment-in-committee
+export const AssessmentInCommittee: Story = {
+  name: "04-assessment-02-assessment-in-committee",
+  args: {
+    sections: buildApplicationProgress(assessmentInCommittee),
+  },
+};
+
+// 04-assessment-03-committee-determined
+export const CommitteeDetermined: Story = {
+  name: "04-assessment-03-committee-determined",
+  args: {
+    sections: buildApplicationProgress(committeeDetermined),
+  },
+};
+
+// 05-appeal-00-appeal-lodged
+export const AppealLodged: Story = {
+  name: "05-appeal-00-appeal-lodged",
+  args: {
+    sections: buildApplicationProgress(appealLodged),
+  },
+};
+
+// 05-appeal-01-appeal-validated
+export const AppealValid: Story = {
+  name: "05-appeal-01-appeal-validated",
+  args: {
+    sections: buildApplicationProgress(appealValid),
+  },
+};
+
+// @TODO error in storybook with circular json here - which is fixed if we remove the <Link> from the started content
+// // 05-appeal-02-appeal-started
+// export const AppealStarted: Story = {
+//   name: "05-appeal-02-appeal-started",
+//   args: {
+//     sections: buildApplicationProgress(appealStarted),
+//   },
+// };
+
+// // 05-appeal-03-appeal-determined
+// export const AppealDetermined: Story = {
+//   name: "05-appeal-03-appeal-determined",
+//   args: {
+//     sections: buildApplicationProgress(appealDetermined),
+//   },
+// };
+// export const AppealDeterminedWithdrawn: Story = {
+//   name: "05-appeal-03-appeal-determined--withdrawn",
+//   args: {
+//     sections: buildApplicationProgress(appealDeterminedWithdrawn),
+//   },
+// };
+// export const AppealDeterminedAllowed: Story = {
+//   name: "05-appeal-03-appeal-determined--allowed",
+//   args: {
+//     sections: buildApplicationProgress(appealDeterminedAllowed),
+//   },
+// };
+// export const AppealDeterminedDismissed: Story = {
+//   name: "05-appeal-03-appeal-determined--dismissed",
+//   args: {
+//     sections: buildApplicationProgress(appealDeterminedDismissed),
+//   },
+// };
+// export const AppealDeterminedSplitDecision: Story = {
+//   name: "05-appeal-03-appeal-determined--split-decision",
+//   args: {
+//     sections: buildApplicationProgress(appealDeterminedSplitDecision),
+//   },
+// };
+
+// 06-assessment-withdrawn
+export const Withdrawn: Story = {
+  name: "06-assessment-withdrawn",
+  args: {
+    sections: buildApplicationProgress(withdrawn),
   },
 };

--- a/src/components/PageSearch/PageSearch.stories.tsx
+++ b/src/components/PageSearch/PageSearch.stories.tsx
@@ -18,13 +18,25 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { PageSearch } from "./PageSearch";
 import {
-  generateDprApplication,
-  generateNResults,
+  generateExampleApplications,
   generatePagination,
 } from "@mocks/dprApplicationFactory";
 import { createAppConfig } from "@mocks/appConfigFactory";
 
 const defaultAppConfig = createAppConfig("public-council-1");
+
+const {
+  consultation,
+  assessmentInProgress,
+  planningOfficerDetermined,
+  assessmentInCommittee,
+  committeeDetermined,
+  appealLodged,
+  appealValid,
+  appealStarted,
+  appealDetermined,
+  withdrawn,
+} = generateExampleApplications();
 
 const meta = {
   title: "Council pages/Search",
@@ -50,8 +62,19 @@ const meta = {
   },
   args: {
     appConfig: defaultAppConfig,
-    applications: generateNResults(10, generateDprApplication),
-    pagination: generatePagination(),
+    applications: [
+      consultation,
+      assessmentInProgress,
+      planningOfficerDetermined,
+      assessmentInCommittee,
+      committeeDetermined,
+      appealLodged,
+      appealValid,
+      appealStarted,
+      appealDetermined,
+      withdrawn,
+    ],
+    pagination: generatePagination(1, 100),
   },
 } satisfies Meta<typeof PageSearch>;
 

--- a/src/components/PageShow/PageShow.stories.tsx
+++ b/src/components/PageShow/PageShow.stories.tsx
@@ -18,15 +18,28 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { PageShow } from "./PageShow";
 import {
-  generateComment,
   generateDocument,
-  generateDprApplication,
+  generateExampleApplications,
   generateNResults,
 } from "@mocks/dprApplicationFactory";
 import { createAppConfig } from "@mocks/appConfigFactory";
-import { formatDateToYmd } from "@/util";
 
-const baseApplication = generateDprApplication();
+const {
+  consultation,
+  assessmentInProgress,
+  planningOfficerDetermined,
+  assessmentInCommittee,
+  committeeDetermined,
+  appealLodged,
+  appealValid,
+  appealStarted,
+  appealDetermined,
+  appealDeterminedWithdrawn,
+  appealDeterminedAllowed,
+  appealDeterminedDismissed,
+  appealDeterminedSplitDecision,
+  withdrawn,
+} = generateExampleApplications();
 
 const meta = {
   title: "Council pages/Show",
@@ -52,7 +65,7 @@ const meta = {
   },
   args: {
     appConfig: createAppConfig("public-council-1"),
-    application: generateDprApplication(),
+    application: committeeDetermined,
     documents: generateNResults(10, generateDocument),
     params: {
       council: "public-council-1",
@@ -71,387 +84,107 @@ export const NoResult: Story = {
   },
 };
 
-export const CommentingEnabled: Story = {
+// 01-submission
+// 02-validation-01-invalid
+// 03-consultation
+export const Consultation: Story = {
+  name: "03-consultation",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "in_assessment",
-        decision: null,
-        consultation: {
-          startDate: new Date(Date.now() - 86400000).toISOString(),
-          endDate: new Date(Date.now() + 86400000).toISOString(),
-          publishedComments: null,
-          consulteeComments: null,
-        },
-      },
-    },
+    application: consultation,
   },
 };
 
-export const CommentingDisabled: Story = {
+// 04-assessment-00-assessment-in-progress
+export const AssessmentInProgress: Story = {
+  name: "04-assessment-00-assessment-in-progress",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "determined",
-        decision: "granted",
-        consultation: {
-          startDate: new Date(Date.now() - 172800000).toISOString(),
-          endDate: new Date(Date.now() - 86400000).toISOString(),
-          publishedComments: null,
-          consulteeComments: null,
-        },
-      },
-    },
+    application: assessmentInProgress,
   },
 };
 
-export const StatusConsultationInProgress: Story = {
+// 04-assessment-01-council-determined
+export const PlanningOfficerDetermined: Story = {
+  name: "04-assessment-01-council-determined",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "assessment_in_progress",
-        decision: null,
-        consultation: {
-          startDate: formatDateToYmd(new Date(Date.now() - 86400000)),
-          endDate: formatDateToYmd(new Date(Date.now() + 86400000)),
-          publishedComments: null,
-          consulteeComments: null,
-        },
-      },
-    },
+    application: planningOfficerDetermined,
   },
 };
 
-export const StatusAssessmentInProgress: Story = {
+// 04-assessment-02-assessment-in-committee
+export const AssessmentInCommittee: Story = {
+  name: "04-assessment-02-assessment-in-committee",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "in_assessment",
-        decision: null,
-        consultation: {
-          startDate: new Date(Date.now() - 172800000).toISOString(),
-          endDate: new Date(Date.now() - 86400000).toISOString(),
-          publishedComments: null,
-          consulteeComments: null,
-        },
-      },
-    },
+    application: assessmentInCommittee,
   },
 };
 
-export const StatusDetermined: Story = {
+// 04-assessment-03-committee-determined
+export const CommitteeDetermined: Story = {
+  name: "04-assessment-03-committee-determined",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "determined",
-        decision: null,
-        consultation: {
-          startDate: new Date(Date.now() - 172800000).toISOString(),
-          endDate: new Date(Date.now() - 86400000).toISOString(),
-          publishedComments: null,
-          consulteeComments: null,
-        },
-      },
-    },
+    application: committeeDetermined,
   },
 };
 
-export const StatusAwaitingDetermination: Story = {
+// 05-appeal-00-appeal-lodged
+export const AppealLodged: Story = {
+  name: "05-appeal-00-appeal-lodged",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "awaiting_determination",
-        decision: null,
-        consultation: {
-          startDate: new Date(Date.now() - 172800000).toISOString(),
-          endDate: new Date(Date.now() - 86400000).toISOString(),
-          publishedComments: null,
-          consulteeComments: null,
-        },
-      },
-    },
+    application: appealLodged,
   },
 };
 
-export const StatusWithdrawn: Story = {
+// 05-appeal-01-appeal-validated
+export const AppealValid: Story = {
+  name: "05-appeal-01-appeal-validated",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "withdrawn",
-        decision: null,
-      },
-    },
+    application: appealValid,
   },
 };
 
-export const StatusNotStarted: Story = {
+// 05-appeal-02-appeal-started
+export const AppealStarted: Story = {
+  name: "05-appeal-02-appeal-started",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "not_started",
-        decision: null,
-      },
-    },
+    application: appealStarted,
   },
 };
 
-export const DecisionGranted: Story = {
+// 05-appeal-03-appeal-determined
+export const AppealDetermined: Story = {
+  name: "05-appeal-03-appeal-determined",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "determined",
-        decision: "granted",
-      },
-    },
+    application: appealDetermined,
   },
 };
-
-export const DecisionRefused: Story = {
+export const AppealDeterminedWithdrawn: Story = {
+  name: "05-appeal-03-appeal-determined--withdrawn",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "determined",
-        decision: "refused",
-      },
-    },
+    application: appealDeterminedWithdrawn,
   },
 };
-
-export const DecisionPriorApprovalRequiredAndApproved: Story = {
+export const AppealDeterminedAllowed: Story = {
+  name: "05-appeal-03-appeal-determined--allowed",
   args: {
-    application: {
-      ...baseApplication,
-      applicationType: "pa",
-      application: {
-        ...baseApplication.application,
-
-        status: "determined",
-        decision: "granted",
-      },
-    },
+    application: appealDeterminedAllowed,
   },
 };
-
-export const DecisionPriorApprovalNotRequired: Story = {
+export const AppealDeterminedDismissed: Story = {
+  name: "05-appeal-03-appeal-determined--dismissed",
   args: {
-    application: {
-      ...baseApplication,
-      applicationType: "pa",
-      application: {
-        ...baseApplication.application,
-        status: "determined",
-        decision: "not_required",
-      },
-    },
+    application: appealDeterminedDismissed,
   },
 };
-
-export const DecisionPriorApprovalRequiredAndRefused: Story = {
+export const AppealDeterminedSplitDecision: Story = {
+  name: "05-appeal-03-appeal-determined--split-decision",
   args: {
-    application: {
-      ...baseApplication,
-      applicationType: "pa",
-      application: {
-        ...baseApplication.application,
-        status: "determined",
-        decision: "refused",
-      },
-    },
+    application: appealDeterminedSplitDecision,
   },
 };
-
-export const NoMapData: Story = {
+// 06-assessment-withdrawn
+export const Withdrawn: Story = {
+  name: "06-assessment-withdrawn",
   args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-      },
-      property: {
-        address: {
-          singleLine: baseApplication.property.address.singleLine,
-        },
-        boundary: {
-          site: undefined,
-        },
-      },
-    },
-  },
-};
-
-export const FewerDocumentsWithoutViewAllButton: Story = {
-  args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-      },
-    },
-    documents: generateNResults(3, generateDocument),
-  },
-};
-
-export const NoDocuments: Story = {
-  args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-      },
-    },
-    documents: [],
-  },
-};
-
-// base council config for the following stories that require it
-const baseCouncilConfig = {
-  name: "Public Council 2",
-  slug: "public-council-2",
-  logo: "public-council-2-logo.svg",
-  visibility: "public" as const,
-  dataSource: "local",
-  pageContent: {
-    privacy_policy: {
-      privacy_policy_link: "public-council-2-privacy-policy-link",
-    },
-  },
-};
-
-export const AllCommentsDisabled: Story = {
-  args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "in_assessment",
-        decision: null,
-        consultation: {
-          startDate: new Date(Date.now() - 86400000).toISOString(),
-          endDate: new Date(Date.now() + 86400000).toISOString(),
-          publishedComments: null,
-          consulteeComments: null,
-        },
-      },
-    },
-    appConfig: {
-      ...createAppConfig("Public Council 2"),
-      council: {
-        ...baseCouncilConfig,
-        publicComments: false,
-        specialistComments: false,
-      },
-    },
-  },
-};
-
-export const OnlyPublicCommentsDisabled: Story = {
-  args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "in_assessment",
-        decision: null,
-        consultation: {
-          startDate: new Date(Date.now() - 86400000).toISOString(),
-          endDate: new Date(Date.now() + 86400000).toISOString(),
-          publishedComments: null,
-          consulteeComments: null,
-        },
-      },
-    },
-    appConfig: {
-      ...createAppConfig("Public Council 2"),
-      council: {
-        ...baseCouncilConfig,
-        publicComments: false,
-        specialistComments: true,
-      },
-    },
-  },
-};
-
-export const OnlySpecialistCommentsDisabled: Story = {
-  args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "in_assessment",
-        decision: null,
-        consultation: {
-          startDate: new Date(Date.now() - 86400000).toISOString(),
-          endDate: new Date(Date.now() + 86400000).toISOString(),
-          publishedComments: null,
-          consulteeComments: null,
-        },
-      },
-    },
-    appConfig: {
-      ...createAppConfig("Public Council 2"),
-      council: {
-        ...baseCouncilConfig,
-        publicComments: true,
-        specialistComments: false,
-      },
-    },
-  },
-};
-
-export const NoViewAllPublicCommentsButton: Story = {
-  args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "in_assessment",
-        decision: null,
-        consultation: {
-          startDate: new Date(Date.now() - 86400000).toISOString(),
-          endDate: new Date(Date.now() + 86400000).toISOString(),
-          publishedComments: generateNResults(1, generateComment),
-          consulteeComments: null,
-        },
-      },
-    },
-  },
-};
-
-export const NoViewAllSpecialistCommentsButton: Story = {
-  args: {
-    application: {
-      ...baseApplication,
-      application: {
-        ...baseApplication.application,
-        status: "in_assessment",
-        decision: null,
-        consultation: {
-          startDate: new Date(Date.now() - 86400000).toISOString(),
-          endDate: new Date(Date.now() + 86400000).toISOString(),
-          publishedComments: null,
-          consulteeComments: generateNResults(1, generateComment),
-        },
-      },
-    },
+    application: withdrawn,
   },
 };

--- a/src/handlers/local/v1/search.ts
+++ b/src/handlers/local/v1/search.ts
@@ -18,15 +18,9 @@
 "use server";
 
 import { getAppConfig } from "@/config";
+import { ApiResponse, DprSearchApiResponse, SearchParams } from "@/types";
 import {
-  ApiResponse,
-  DprPlanningApplication,
-  DprSearchApiResponse,
-  SearchParams,
-} from "@/types";
-import {
-  generateDprApplication,
-  generateNResults,
+  generateExampleApplications,
   generatePagination,
 } from "@mocks/dprApplicationFactory";
 
@@ -36,15 +30,38 @@ const responseQuery = (
   const appConfig = getAppConfig();
   const resultsPerPage = appConfig.defaults.resultsPerPage;
 
-  const applications = generateNResults<DprPlanningApplication>(
-    resultsPerPage,
-    generateDprApplication,
-  );
-  const pagination = generatePagination(searchParams?.page);
+  const {
+    consultation,
+    assessmentInProgress,
+    planningOfficerDetermined,
+    assessmentInCommittee,
+    committeeDetermined,
+    appealLodged,
+    appealValid,
+    appealStarted,
+    appealDetermined,
+    withdrawn,
+  } = generateExampleApplications();
+
+  let applications = [
+    consultation,
+    assessmentInProgress,
+    planningOfficerDetermined,
+    assessmentInCommittee,
+    committeeDetermined,
+    appealLodged,
+    appealValid,
+    appealStarted,
+    appealDetermined,
+    withdrawn,
+  ];
+  let pagination = generatePagination(searchParams?.page, resultsPerPage * 5);
 
   // if we've done a search just rename the first result to match the query
   if (searchParams?.query) {
+    applications = [consultation];
     applications[0].application.reference = searchParams.query;
+    pagination = generatePagination(searchParams?.page, 1);
   }
 
   let data: DprSearchApiResponse | null = applications;

--- a/src/handlers/local/v1/show.ts
+++ b/src/handlers/local/v1/show.ts
@@ -18,35 +18,22 @@
 "use server";
 
 import { ApiResponse, DprShowApiResponse } from "@/types";
-import { formatDateToYmd } from "@/util";
-import { generateDprApplication } from "@mocks/dprApplicationFactory";
+
+import { generateExampleApplications } from "@mocks/dprApplicationFactory";
 
 const response = (reference: string): ApiResponse<DprShowApiResponse> => {
   let application = null;
 
+  const exampleApplications = generateExampleApplications();
+
   // it can never be ldc or determined because comments are disabled there!
   if (reference === "TEST-C0MNT-F10W") {
-    const today = new Date();
-    const startDate = formatDateToYmd(new Date(today.getTime() - 86400000));
-    const endDate = formatDateToYmd(new Date(today));
-    const applicationInAssessment = generateDprApplication({
-      applicationType: "pp.full",
-      applicationStatus: "assessment_in_progress",
-    });
-    const applicationInConsultation = {
-      ...applicationInAssessment,
-      application: {
-        ...applicationInAssessment.application,
-        consultation: {
-          ...applicationInAssessment.application.consultation,
-          startDate,
-          endDate,
-        },
-      },
-    };
-    application = applicationInConsultation;
+    application = exampleApplications.consultation;
   } else {
-    application = generateDprApplication();
+    const keys = Object.keys(exampleApplications);
+    const randomIndex = Math.floor(Math.random() * keys.length);
+    const randomKey = keys[randomIndex];
+    application = exampleApplications[randomKey];
   }
 
   application.application.reference = reference;

--- a/src/lib/planningApplication/progress.tsx
+++ b/src/lib/planningApplication/progress.tsx
@@ -48,9 +48,14 @@ export const buildApplicationProgress = (
   application: DprPlanningApplication,
 ): ProgressSectionBase[] => {
   const progressData: ProgressSectionBase[] = [];
+  const importantDates = contentImportantDates();
 
   // 01 received
   if (application.application?.receivedAt) {
+    const receivedAtContent = findItemByKey<DprContentPage>(
+      importantDates,
+      slugify("Received date"),
+    )?.content;
     progressData.push({
       title: "Received",
       date: (
@@ -58,16 +63,17 @@ export const buildApplicationProgress = (
           {formatDateTimeToDprDate(application.application.receivedAt)}
         </time>
       ),
-      content: findItemByKey<DprContentPage>(
-        contentImportantDates(),
-        slugify("Received date"),
-      )?.content ?? <></>,
+      content: receivedAtContent ?? <></>,
     });
   }
 
   // 02 validFrom
 
   if (application.application?.validAt) {
+    const validAtContent = findItemByKey<DprContentPage>(
+      importantDates,
+      slugify("Valid from date"),
+    )?.content;
     progressData.push({
       title: "Valid from",
       date: (
@@ -75,16 +81,17 @@ export const buildApplicationProgress = (
           {formatDateTimeToDprDate(application.application.validAt)}
         </time>
       ),
-      content: findItemByKey<DprContentPage>(
-        contentImportantDates(),
-        slugify("Valid from date"),
-      )?.content ?? <></>,
+      content: validAtContent ?? <></>,
     });
   }
 
   // 03 published
 
   if (application.application?.publishedAt) {
+    const publishedAtContent = findItemByKey<DprContentPage>(
+      importantDates,
+      slugify("Published date"),
+    )?.content;
     progressData.push({
       title: "Published",
       date: (
@@ -92,10 +99,7 @@ export const buildApplicationProgress = (
           {formatDateTimeToDprDate(application.application.publishedAt)}
         </time>
       ),
-      content: findItemByKey<DprContentPage>(
-        contentImportantDates(),
-        slugify("Published date"),
-      )?.content ?? <></>,
+      content: publishedAtContent ?? <></>,
     });
   }
 
@@ -110,13 +114,14 @@ export const buildApplicationProgress = (
       ? "Consultation ended"
       : "Consultation ends";
 
+    const consultationEndDateContent = findItemByKey<DprContentPage>(
+      importantDates,
+      slugify("Consultation end date"),
+    )?.content;
     progressData.push({
       title,
       date: formatDateToDprDate(application.application.consultation.endDate),
-      content: findItemByKey<DprContentPage>(
-        contentImportantDates(),
-        slugify("Consultation end date"),
-      )?.content ?? <></>,
+      content: consultationEndDateContent ?? <></>,
     });
   }
 
@@ -126,6 +131,10 @@ export const buildApplicationProgress = (
     application.application?.decision &&
     application.application.determinedAt
   ) {
+    const councilDecisionMadeContent = findItemByKey<DprContentPage>(
+      importantDates,
+      slugify("Decision date"),
+    )?.content;
     progressData.push({
       title: "Council decision made",
       date: (
@@ -133,62 +142,65 @@ export const buildApplicationProgress = (
           {formatDateTimeToDprDate(application.application.determinedAt)}
         </time>
       ),
-      content: findItemByKey<DprContentPage>(
-        contentImportantDates(),
-        slugify("Decision date"),
-      )?.content ?? <></>,
+      content: councilDecisionMadeContent ?? <></>,
     });
   }
 
   // 06 appealLodged
 
   if (application?.data?.appeal?.lodgedDate) {
+    const appealLodgedDateContent = findItemByKey<DprContentPage>(
+      importantDates,
+      slugify("Appeal lodged date"),
+    )?.content;
     progressData.push({
       title: "Appeal lodged",
       date: formatDateToDprDate(application.data.appeal.lodgedDate),
-      content: findItemByKey<DprContentPage>(
-        contentImportantDates(),
-        slugify("Appeal lodged date"),
-      )?.content ?? <></>,
+      content: appealLodgedDateContent ?? <></>,
     });
   }
 
   // 07 appealValidFrom
 
   if (application?.data?.appeal?.validatedDate) {
+    const appealValidatedDateContent = findItemByKey<DprContentPage>(
+      importantDates,
+      slugify("Appeal valid from date"),
+    )?.content;
     progressData.push({
       title: "Appeal valid from",
       date: formatDateToDprDate(application.data.appeal.validatedDate),
-      content: findItemByKey<DprContentPage>(
-        contentImportantDates(),
-        slugify("Appeal valid from date"),
-      )?.content ?? <></>,
+      content: appealValidatedDateContent ?? <></>,
     });
   }
 
   // 08 appealStarted
 
   if (application?.data?.appeal?.startedDate) {
+    const appealStartedDateContent = findItemByKey<DprContentPage>(
+      importantDates,
+      slugify("Appeal started date"),
+    )?.content;
+
+    // const appealStartedDateContent = <>hello</>;
     progressData.push({
       title: "Appeal started",
       date: formatDateToDprDate(application.data.appeal.startedDate),
-      content: findItemByKey<DprContentPage>(
-        contentImportantDates(),
-        slugify("Appeal started date"),
-      )?.content ?? <></>,
+      content: appealStartedDateContent ?? <></>,
     });
   }
 
   // 09 appealDecided
 
   if (application?.data?.appeal?.decisionDate) {
+    const decisionDateContent = findItemByKey<DprContentPage>(
+      importantDates,
+      slugify("Appeal decided date"),
+    )?.content;
     progressData.push({
       title: "Appeal decided",
       date: formatDateToDprDate(application.data.appeal.decisionDate),
-      content: findItemByKey<DprContentPage>(
-        contentImportantDates(),
-        slugify("Appeal decided date"),
-      )?.content ?? <></>,
+      content: decisionDateContent ?? <></>,
     });
   }
 


### PR DESCRIPTION
For @madz-lw 's conversion function!

This PR:

- Updates the old `generateDprApplication` method to return 'valid' data, more in line with data we would see from BOPS anyway to make the conversion function have to do less checks
- Updates the tests to map each BOPS status to our future 'states' and check its output is valid and correct
- Adds a new method `generateExampleApplications` which will generate a standard set of examples to be used in places
- Update stories for several components to use `generateExampleApplications` 
- I've updated the new `generateDprApplication` and tests to also include `generateExampleApplications` so they can be swapped out easily in the future work


(By states I mean the numbered examples in the ODP repo)

```js
const {
  consultation,
  assessmentInProgress,
  planningOfficerDetermined,
  assessmentInCommittee,
  committeeDetermined,
  appealLodged,
  appealValid,
  appealStarted,
  appealDetermined,
  appealDeterminedWithdrawn,
  appealDeterminedAllowed,
  appealDeterminedDismissed,
  appealDeterminedSplitDecision,
  withdrawn,
} = generateExampleApplications();
```

PS I did find a very odd bug in the `src/components/ApplicationProgressInfo/ApplicationProgressInfo.stories.tsx` its not hugely important at the moment because it only affect storybook but we should look into it at some point in the future.