### PR TITLE
Advanced search pre-tidy and bug fixes

### DIFF
--- a/src/actions/api/v1/documents.ts
+++ b/src/actions/api/v1/documents.ts
@@ -18,7 +18,11 @@
 "use server";
 
 // Types
-import { ApiResponse, DprDocumentsApiResponse, SearchParams } from "@/types";
+import {
+  ApiResponse,
+  DprDocumentsApiResponse,
+  SearchParamsDocuments,
+} from "@/types";
 
 // handlers
 import { BopsV2 } from "@/handlers/bops";
@@ -32,7 +36,7 @@ export async function documents(
   source: string,
   council: string,
   reference: string,
-  searchParams?: SearchParams,
+  searchParams?: SearchParamsDocuments,
 ): Promise<ApiResponse<DprDocumentsApiResponse | null>> {
   if (!council || !reference) {
     return apiReturnError("Council and reference are required");
@@ -40,7 +44,7 @@ export async function documents(
 
   switch (source) {
     case "bops":
-      return await BopsV2.documents(council, reference);
+      return await BopsV2.documents(council, reference, searchParams);
     case "local":
       return await LocalV1.documents(council, reference, searchParams);
     default:

--- a/src/actions/api/v1/postComment.documentation.tsx
+++ b/src/actions/api/v1/postComment.documentation.tsx
@@ -15,7 +15,7 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Documentation } from "@/types";
+import { Documentation, DprCommentSubmission } from "@/types";
 import { postComment } from "./postComment";
 
 export const documentation: Documentation = {
@@ -23,7 +23,7 @@ export const documentation: Documentation = {
   file: `src/actions/api/v1/postComment.ts`,
   description: "Post a comment to BOPS",
   arguments: ["source", "council", "applicationId"],
-  run: async (args: [string, string, string, object]) => {
+  run: async (args: [string, string, string, DprCommentSubmission]) => {
     return await postComment(...args);
   },
   examples: [

--- a/src/actions/api/v1/postComment.ts
+++ b/src/actions/api/v1/postComment.ts
@@ -18,7 +18,7 @@
 "use server";
 
 // Types
-import { ApiResponse } from "@/types";
+import { ApiResponse, DprCommentSubmission } from "@/types";
 import { BopsV1PlanningApplicationsNeighbourResponse } from "@/handlers/bops/types";
 
 // handlers
@@ -33,7 +33,7 @@ export async function postComment(
   source: string,
   council: string,
   reference: string,
-  apiData: object,
+  apiData: DprCommentSubmission,
 ): Promise<ApiResponse<BopsV1PlanningApplicationsNeighbourResponse | null>> {
   if (!council || !reference || !apiData) {
     return apiReturnError("Council and reference are required");

--- a/src/actions/api/v1/postComment.ts
+++ b/src/actions/api/v1/postComment.ts
@@ -18,8 +18,11 @@
 "use server";
 
 // Types
-import { ApiResponse, DprCommentSubmission } from "@/types";
-import { BopsV1PlanningApplicationsNeighbourResponse } from "@/handlers/bops/types";
+import {
+  ApiResponse,
+  DprApplicationPostCommentApiResponse,
+  DprCommentSubmission,
+} from "@/types";
 
 // handlers
 import { BopsV2 } from "@/handlers/bops";
@@ -34,7 +37,7 @@ export async function postComment(
   council: string,
   reference: string,
   apiData: DprCommentSubmission,
-): Promise<ApiResponse<BopsV1PlanningApplicationsNeighbourResponse | null>> {
+): Promise<ApiResponse<DprApplicationPostCommentApiResponse | null>> {
   if (!council || !reference || !apiData) {
     return apiReturnError("Council and reference are required");
   }

--- a/src/actions/api/v1/search.documentation.tsx
+++ b/src/actions/api/v1/search.documentation.tsx
@@ -27,7 +27,6 @@ export const documentation: Documentation = {
       page: args[2],
       resultsPerPage: args[3],
       query: args[4],
-      type: "dsn",
     };
     return await search(args[0], args[1], searchObj);
   },

--- a/src/app/[council]/[reference]/comments/page.tsx
+++ b/src/app/[council]/[reference]/comments/page.tsx
@@ -16,7 +16,7 @@
  */
 
 import { Metadata } from "next";
-import { ApiResponse, DprShowApiResponse, SearchParams } from "@/types";
+import { ApiResponse, DprShowApiResponse, SearchParamsComments } from "@/types";
 import { ApiV1 } from "@/actions/api";
 import { getAppConfig } from "@/config";
 import { PageMain } from "@/components/PageMain";
@@ -30,7 +30,7 @@ interface PlanningApplicationDetailsCommentsProps {
     council: string;
     reference: string;
   };
-  searchParams?: SearchParams;
+  searchParams?: SearchParamsComments;
 }
 
 async function fetchData({

--- a/src/app/[council]/[reference]/documents/page.tsx
+++ b/src/app/[council]/[reference]/documents/page.tsx
@@ -20,7 +20,7 @@ import {
   ApiResponse,
   DprShowApiResponse,
   DprDocumentsApiResponse,
-  SearchParams,
+  SearchParamsDocuments,
 } from "@/types";
 import { ApiV1 } from "@/actions/api";
 import { getAppConfig } from "@/config";
@@ -35,11 +35,12 @@ interface PlanningApplicationDetailsDocumentsProps {
     council: string;
     reference: string;
   };
-  searchParams?: SearchParams;
+  searchParams?: SearchParamsDocuments;
 }
 
 async function fetchData({
   params,
+  searchParams,
 }: PlanningApplicationDetailsDocumentsProps): Promise<{
   applicationResponse: ApiResponse<DprShowApiResponse | null>;
   documentResponse: ApiResponse<DprDocumentsApiResponse | null>;
@@ -52,6 +53,13 @@ async function fetchData({
       appConfig.council?.dataSource ?? "none",
       council,
       reference,
+      {
+        ...searchParams,
+        page: searchParams?.page ? Number(searchParams.page) : 1,
+        resultsPerPage: searchParams?.resultsPerPage
+          ? Number(searchParams.resultsPerPage)
+          : appConfig.defaults.resultsPerPage,
+      },
     ),
   ]);
   return { applicationResponse, documentResponse };
@@ -59,8 +67,9 @@ async function fetchData({
 
 export async function generateMetadata({
   params,
+  searchParams,
 }: PlanningApplicationDetailsDocumentsProps): Promise<Metadata | undefined> {
-  const { applicationResponse } = await fetchData({ params });
+  const { applicationResponse } = await fetchData({ params, searchParams });
   const { reference, council } = params;
   const councilName = getAppConfig(council)?.council?.name ?? "";
 

--- a/src/components/PageApplicationComments/PageApplicationComments.tsx
+++ b/src/components/PageApplicationComments/PageApplicationComments.tsx
@@ -20,7 +20,7 @@ import {
   DprCommentTypes,
   DprPagination,
   DprPlanningApplication,
-  SearchParams,
+  SearchParamsComments,
 } from "@/types";
 import { BackButton } from "@/components/BackButton";
 import ApplicationHeader from "../application_header";
@@ -42,7 +42,7 @@ export interface PageApplicationCommentsProps {
   };
   type: DprCommentTypes;
   pagination?: DprPagination;
-  searchParams?: SearchParams;
+  searchParams?: SearchParamsComments;
 }
 
 export const PageApplicationComments = ({

--- a/src/components/comment_check_answer/index.tsx
+++ b/src/components/comment_check_answer/index.tsx
@@ -26,6 +26,9 @@ import { Details } from "../govukDpr/Details";
 import { TextButton } from "../TextButton";
 import { sentiment_options } from "@/lib/comments";
 import { PersonalDetails } from "../comment_personal_details";
+import { DprCommentSubmission } from "@/types";
+import { CommentSentiment } from "@/types/odp-types/schemas/postSubmissionApplication/enums/CommentSentiment";
+import { CommentTopic } from "@/types/odp-types/schemas/postSubmissionApplication/enums/CommentTopic";
 
 const topics_selection = [
   {
@@ -151,7 +154,7 @@ const CommentCheckAnswer = ({
       return false;
     }
 
-    const apiData = {
+    const apiData: DprCommentSubmission = {
       name: personalDetails.name,
       email: personalDetails.emailAddress,
       address: `${personalDetails.address}, ${personalDetails.postcode}`,
@@ -163,8 +166,8 @@ const CommentCheckAnswer = ({
           return `* ${topicLabel}: ${comment} `;
         })
         .join(" "),
-      summary_tag: sentiment,
-      tags: selectedTopics,
+      summary_tag: sentiment as CommentSentiment,
+      tags: selectedTopics as CommentTopic[],
     };
 
     try {

--- a/src/handlers/bops/v2/postComment.documentation.tsx
+++ b/src/handlers/bops/v2/postComment.documentation.tsx
@@ -15,7 +15,7 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Documentation } from "@/types";
+import { Documentation, DprCommentSubmission } from "@/types";
 import { postComment } from "./postComment";
 
 export const documentation: Documentation = {
@@ -23,7 +23,7 @@ export const documentation: Documentation = {
   file: `src/handlers/bops/v2/postComment.ts`,
   description: "Post a comment to BOPS",
   arguments: ["council", "applicationId"],
-  run: async (args: [string, string, object]) => {
+  run: async (args: [string, string, DprCommentSubmission]) => {
     return await postComment(...args);
   },
   examples: [

--- a/src/handlers/bops/v2/postComment.ts
+++ b/src/handlers/bops/v2/postComment.ts
@@ -17,7 +17,11 @@
 
 "use server";
 
-import { ApiResponse, DprCommentSubmission } from "@/types";
+import {
+  ApiResponse,
+  DprApplicationPostCommentApiResponse,
+  DprCommentSubmission,
+} from "@/types";
 import {
   BopsV1PlanningApplicationsNeighbourResponse,
   BopsV2PlanningApplicationDetail,
@@ -38,7 +42,7 @@ export async function postComment(
   council: string,
   reference: string,
   apiData: DprCommentSubmission,
-): Promise<ApiResponse<BopsV1PlanningApplicationsNeighbourResponse | null>> {
+): Promise<ApiResponse<DprApplicationPostCommentApiResponse | null>> {
   const appConfig = getAppConfig(council);
   let applicationId = undefined;
 
@@ -65,6 +69,12 @@ export async function postComment(
   const postRequest = await handleBopsPostRequest<
     ApiResponse<BopsV1PlanningApplicationsNeighbourResponse | null>
   >(council, url, apiData, true);
+
+  if (postRequest.status.code !== 200) {
+    return apiReturnError(
+      postRequest.status.detail || "Failed to post comment",
+    );
+  }
 
   return postRequest;
 }

--- a/src/handlers/bops/v2/postComment.ts
+++ b/src/handlers/bops/v2/postComment.ts
@@ -17,7 +17,7 @@
 
 "use server";
 
-import { ApiResponse } from "@/types";
+import { ApiResponse, DprCommentSubmission } from "@/types";
 import {
   BopsV1PlanningApplicationsNeighbourResponse,
   BopsV2PlanningApplicationDetail,
@@ -37,7 +37,7 @@ import { getAppConfig } from "@/config";
 export async function postComment(
   council: string,
   reference: string,
-  apiData: object,
+  apiData: DprCommentSubmission,
 ): Promise<ApiResponse<BopsV1PlanningApplicationsNeighbourResponse | null>> {
   const appConfig = getAppConfig(council);
   let applicationId = undefined;

--- a/src/handlers/bops/v2/search.documentation.tsx
+++ b/src/handlers/bops/v2/search.documentation.tsx
@@ -28,7 +28,6 @@ export const documentation: Documentation = {
       page: args[1],
       resultsPerPage: args[2],
       query: args[3],
-      type: "dsn",
     };
     return await search(args[0], searchObj);
   },

--- a/src/handlers/local/v1/postComment.documentation.tsx
+++ b/src/handlers/local/v1/postComment.documentation.tsx
@@ -15,7 +15,7 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Documentation, DprCommentSubmission } from "@/types";
+import { Documentation } from "@/types";
 import { postComment } from "./postComment";
 
 export const documentation: Documentation = {
@@ -23,7 +23,7 @@ export const documentation: Documentation = {
   file: `src/handlers/local/v1/postComment.ts`,
   description: "postComment",
   arguments: ["council", "applicationId"],
-  run: async (args: [string, number, DprCommentSubmission]) => {
+  run: async (args: [string, number]) => {
     return await postComment(...args);
   },
 };

--- a/src/handlers/local/v1/postComment.documentation.tsx
+++ b/src/handlers/local/v1/postComment.documentation.tsx
@@ -15,7 +15,7 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Documentation } from "@/types";
+import { Documentation, DprCommentSubmission } from "@/types";
 import { postComment } from "./postComment";
 
 export const documentation: Documentation = {
@@ -23,7 +23,7 @@ export const documentation: Documentation = {
   file: `src/handlers/local/v1/postComment.ts`,
   description: "postComment",
   arguments: ["council", "applicationId"],
-  run: async (args: [string, number]) => {
+  run: async (args: [string, number, DprCommentSubmission]) => {
     return await postComment(...args);
   },
 };

--- a/src/handlers/local/v1/postComment.ts
+++ b/src/handlers/local/v1/postComment.ts
@@ -17,8 +17,11 @@
 
 "use server";
 
-import { ApiResponse, DprCommentSubmission } from "@/types";
-import { BopsV1PlanningApplicationsNeighbourResponse } from "@/handlers/bops/types";
+import {
+  ApiResponse,
+  DprApplicationPostCommentApiResponse,
+  // DprCommentSubmission,
+} from "@/types";
 
 /**
  * @todo this needs to be made more Dpr specific
@@ -30,7 +33,7 @@ const responseQuery = (
   council: string,
   applicationId: number,
   error: boolean,
-): ApiResponse<BopsV1PlanningApplicationsNeighbourResponse> => {
+): ApiResponse<DprApplicationPostCommentApiResponse> => {
   if (error) {
     return {
       data: null,
@@ -58,9 +61,9 @@ const responseQuery = (
 export const postComment = (
   council: string,
   applicationId: number,
-  apiData: DprCommentSubmission,
-): Promise<ApiResponse<BopsV1PlanningApplicationsNeighbourResponse | null>> => {
-  console.log("apiData", apiData);
+  // apiData: DprCommentSubmission,
+): Promise<ApiResponse<DprApplicationPostCommentApiResponse | null>> => {
+  // console.log("apiData", apiData);
   const error = false;
   // uncomment for testing
   // error = true;

--- a/src/handlers/local/v1/postComment.ts
+++ b/src/handlers/local/v1/postComment.ts
@@ -17,7 +17,7 @@
 
 "use server";
 
-import { ApiResponse } from "@/types";
+import { ApiResponse, DprCommentSubmission } from "@/types";
 import { BopsV1PlanningApplicationsNeighbourResponse } from "@/handlers/bops/types";
 
 /**
@@ -58,9 +58,9 @@ const responseQuery = (
 export const postComment = (
   council: string,
   applicationId: number,
-  // apiData: object,
+  apiData: DprCommentSubmission,
 ): Promise<ApiResponse<BopsV1PlanningApplicationsNeighbourResponse | null>> => {
-  // console.log("apiData", apiData);
+  console.log("apiData", apiData);
   const error = false;
   // uncomment for testing
   // error = true;

--- a/src/handlers/local/v1/search.documentation.tsx
+++ b/src/handlers/local/v1/search.documentation.tsx
@@ -28,7 +28,6 @@ export const documentation: Documentation = {
       page: args[0],
       resultsPerPage: args[1],
       query: args[3],
-      type: args[4],
     };
     return await search(searchObj);
   },

--- a/src/lib/comments.ts
+++ b/src/lib/comments.ts
@@ -24,7 +24,7 @@ import {
   DprCommentTypes,
   DprPagination,
   DprPlanningApplication,
-  SearchParams,
+  SearchParamsComments,
 } from "@/types";
 import { AppConfig } from "@/config/types";
 import { createItemPagination } from "./pagination";
@@ -51,7 +51,7 @@ export const sortComments = (comments: DprComment[]) => {
  */
 export const getCommentTypeToShow = (
   council: AppConfig["council"],
-  searchParams?: SearchParams,
+  searchParams?: SearchParamsComments,
 ): DprCommentTypes => {
   let type: DprCommentTypes =
     (searchParams?.type as DprCommentTypes) ??
@@ -72,7 +72,7 @@ export const buildCommentResult = (
   appConfig: AppConfig,
   type: DprCommentTypes,
   application: DprPlanningApplication,
-  searchParams?: SearchParams,
+  searchParams?: SearchParamsComments,
 ) => {
   const comments =
     type === "specialist"

--- a/src/types/definitions.d.ts
+++ b/src/types/definitions.d.ts
@@ -31,6 +31,8 @@ import { ApplicationType } from "@/types/odp-types/schemas/prototypeApplication/
 import { GeoBoundary } from "@/types/odp-types/shared/Boundaries";
 import { PostSubmissionApplication } from "@/types/odp-types/schemas/postSubmissionApplication/index";
 import { DprStatusSummary, DprDecisionSummary } from "@/types";
+import { CommentSentiment } from "@/types/odp-types/schemas/postSubmissionApplication/enums/CommentSentiment";
+import { CommentTopic } from "@/types/odp-types/schemas/postSubmissionApplication/enums/CommentTopic";
 
 /**
  *
@@ -203,6 +205,26 @@ export interface DprComment {
    */
   sentiment?: string;
 }
+
+/**
+ *
+ *
+ *
+ * DprCommentSubmission
+ * What comments look like when they are submitted
+ *
+ *
+ *
+ */
+export type DprCommentSubmission = {
+  name: string;
+  address: string;
+  email?: string;
+  // telephone?: string;
+  response: string;
+  summary_tag: CommentSentiment;
+  tags: CommentTopic[];
+};
 
 /**
  *

--- a/src/types/schemas.d.ts
+++ b/src/types/schemas.d.ts
@@ -51,3 +51,12 @@ export interface DprApplicationSubmissionApiResponse {
   application: DprPlanningApplication["application"];
   submission: DprApplicationSubmissionData | null;
 }
+
+/**
+ * /api/postComment
+ * Comment posting
+ */
+export type DprApplicationPostCommentApiResponse = {
+  id?: string;
+  message: string;
+};

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -62,13 +62,11 @@ export interface SearchParams {
   query?: string;
   page: number;
   resultsPerPage: number;
-  /**
-   * beginning of advanced search P05
-   * also used for comments filtering
-   */
+}
+export type SearchParamsDocuments = SearchParams;
+export interface SearchParamsComments extends SearchParams {
   type?: string;
 }
-
 /**
  *
  *

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -41,7 +41,7 @@ import { AssessmentDecision } from "@/types/odp-types/schemas/postSubmissionAppl
 export interface ApiResponse<T> {
   data: T | null;
   pagination?: DprPagination;
-  status?: {
+  status: {
     code: number;
     message: string;
     detail?: string;


### PR DESCRIPTION
Ahead of the advanced search work this PR some little tidying things.

- defines the new `SearchParamsDocuments` and `SearchParamsComments` types and adds it into the various api and handlers and documentation 
- passes the `SearchParamsDocuments` through to the handlers where it wasn't before (must have been missed out)
- Fixed a bug where in the local test mode every page was given application form and decision notice so you never thought you were changing pages
- Defines comment submission structure `DprCommentSubmission` and sets apiData to that type updating the documentation to go along with it for future work
- Defined our own `DprApplicationPostCommentApiResponse` ready for the future work (we were using BOPS one before)