### PR TITLE
Debug docs page

### DIFF
--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,0 +1,210 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { ApiResponse, DprSearchApiResponse, SearchParams } from "@/types";
+import { ApiV1 } from "@/actions/api";
+import { getAppConfig } from "@/config";
+import { ContentError } from "@/components/ContentError";
+import { PageMain } from "@/components/PageMain";
+import { notFound } from "next/navigation";
+import { PageTemplate } from "@/components/PageTemplate";
+import Link from "next/link";
+import {
+  getApplicationDecisionSummary,
+  getApplicationStatusSummary,
+} from "@/lib/planningApplication";
+import { Pagination } from "@/components/govuk/Pagination";
+
+interface HomeProps {
+  searchParams?: SearchParams & {
+    council: string;
+  };
+}
+
+const setCouncil = ({ searchParams }: HomeProps) => {
+  const backupCouncil = process.env.TEST_COUNCILS
+    ? "public-council-1"
+    : "camden";
+  const council = searchParams?.council ?? backupCouncil;
+  return council;
+};
+
+async function fetchData({
+  searchParams,
+}: HomeProps): Promise<ApiResponse<DprSearchApiResponse | null>> {
+  const council = setCouncil({ searchParams });
+  const appConfig = getAppConfig(council);
+
+  const response = await ApiV1.search(
+    appConfig.council?.dataSource ?? "none",
+    council,
+    {
+      ...searchParams,
+      page: searchParams?.page ?? 1,
+      resultsPerPage:
+        searchParams?.resultsPerPage ?? appConfig.defaults.resultsPerPage,
+    },
+  );
+
+  return response;
+}
+
+export async function generateMetadata() {
+  return {
+    title: "Documentation",
+    description: "DPR documentation",
+  };
+}
+
+export default async function PlanningApplicationSearch({
+  searchParams,
+}: HomeProps) {
+  if (process.env.NODE_ENV !== "development") {
+    return notFound();
+  }
+
+  const council = setCouncil({ searchParams });
+  const appConfig = getAppConfig(council);
+  const response = await fetchData({ searchParams });
+
+  if (
+    !response ||
+    response?.status?.code !== 200 ||
+    appConfig.council === undefined
+  ) {
+    return (
+      <PageTemplate appConfig={appConfig}>
+        <PageMain>
+          <ContentError />
+        </PageMain>
+      </PageTemplate>
+    );
+  }
+
+  const applications = response.data;
+  const pagination = response.pagination;
+
+  return (
+    <PageTemplate appConfig={appConfig}>
+      <PageMain>
+        <h1 className="govuk-heading-xl">Documentation</h1>
+        {applications && (
+          <>
+            <table className="govuk-table">
+              <caption className="govuk-table__caption govuk-table__caption--m">
+                All {appConfig.council.name} applications
+              </caption>
+              <thead className="govuk-table__head">
+                <tr className="govuk-table__row">
+                  <th scope="col" className="govuk-table__header">
+                    Reference
+                  </th>
+                  <th scope="col" className="govuk-table__header">
+                    ApplicationType
+                  </th>
+                  <th scope="col" className="govuk-table__header">
+                    Status
+                  </th>
+                  <th scope="col" className="govuk-table__header">
+                    Status Summary
+                  </th>
+                  <th scope="col" className="govuk-table__header">
+                    Decision
+                  </th>
+                  <th scope="col" className="govuk-table__header">
+                    Decision Summary
+                  </th>
+                  <th
+                    scope="col"
+                    className="govuk-table__header govuk-table__header--numeric"
+                  >
+                    Public comments
+                  </th>
+                  <th
+                    scope="col"
+                    className="govuk-table__header govuk-table__header--numeric"
+                  >
+                    Specialist comments
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="govuk-table__body">
+                {applications.map((application) => (
+                  <tr
+                    key={application.application.reference}
+                    className="govuk-table__row"
+                  >
+                    <td className="govuk-table__cell">
+                      <Link
+                        className="govuk-link"
+                        href={`/${council}/${application.application.reference}`}
+                      >
+                        {application.application.reference}
+                      </Link>
+                    </td>
+                    <td className="govuk-table__cell">
+                      {application.applicationType}
+                    </td>
+                    <td className="govuk-table__cell">
+                      {application.application.status}
+                    </td>
+                    <td className="govuk-table__cell">
+                      {getApplicationStatusSummary(
+                        application.application.status,
+                        application.application.consultation.startDate,
+                        application.application.consultation.endDate,
+                      )}
+                    </td>
+                    <td className="govuk-table__cell">
+                      {application.application?.decision}
+                    </td>
+                    <td className="govuk-table__cell">
+                      {getApplicationDecisionSummary(
+                        application.applicationType,
+                        application.application?.decision ?? undefined,
+                      )}
+                    </td>
+                    <td className="govuk-table__cell govuk-table__cell--numeric">
+                      {
+                        application.application?.consultation?.publishedComments
+                          ?.length
+                      }
+                    </td>
+                    <td className="govuk-table__cell govuk-table__cell--numeric">
+                      {
+                        application.application?.consultation?.consulteeComments
+                          ?.length
+                      }
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {pagination && pagination.total_pages > 1 && (
+              <Pagination
+                baseUrl={"/docs"}
+                searchParams={searchParams}
+                pagination={pagination}
+              />
+            )}
+          </>
+        )}
+      </PageMain>
+    </PageTemplate>
+  );
+}


### PR DESCRIPTION
My local BOPS and staging have applications that I frequently use to test documents/comments etc. We have the local API but sometimes you need real data and I can never find them again! I've been using this for a while and just copying it to my desktop but since working on the appeals stuff its become very handy to debug the API work!

We already have http://localhost:3000/docs/json for viewing json result's from the API, BOPS and Local Handlers.

This PR gives us http://localhost:3000/docs / http://localhost:3000/docs?resultsPerPage=20&council=southwark 
This is a simple paginated table to help us find example applications when we're developing. It's not accessible outside of the development environment!

![image](https://github.com/user-attachments/assets/7e1b45f7-7f8f-4f8f-b456-5361950e2d36)
![image](https://github.com/user-attachments/assets/ba8803ac-56fd-4d84-94dc-d69e6d01fc1e)

