### PR TITLE
Change revalidation time to 30 seconds for demo

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -58,7 +58,7 @@ export const getAppConfig = (council?: string): AppConfig => {
     },
     defaults: {
       resultsPerPage: 10,
-      revalidate: 3600, // 1 hour
+      revalidate: 30, // 3600 default (1 hour)
     },
     navigation: [
       {


### PR DESCRIPTION
Changes revalidation time to 30 seconds for tomorrows demo

NB we need an automated way of doing this for demos - or to set staging to be quicker to refresh than prod