### PR TITLE
DSNPI - 1058 / Rename pagination fields to the proposed API structure

### DIFF
--- a/__mocks__/dprApplicationFactory.ts
+++ b/__mocks__/dprApplicationFactory.ts
@@ -94,28 +94,19 @@ export const generatePagination = (
   const resultsPerPage = 10;
   const totalPages = Math.ceil(totalResults / resultsPerPage);
 
-  currentPage =
-    currentPage && (currentPage >= totalPages || currentPage <= totalPages)
-      ? currentPage
-      : faker.number.int({ min: 1, max: totalPages || 1 });
-
-  const from = (currentPage - 1) * resultsPerPage + 1;
-  const to = Math.min(currentPage * resultsPerPage, totalResults);
-  const results = to - from + 1;
+  if (
+    currentPage === undefined ||
+    currentPage < 1 ||
+    currentPage > totalPages
+  ) {
+    currentPage = faker.number.int({ min: 1, max: totalPages || 1 });
+  }
 
   return {
-    // @todo something simpler
-    // currentPage: Number(currentPage),
-    // totalPages: totalPages,
-    // itemsPerPage: resultsPerPage,
-    // totalItems: totalResults,
-
-    page: Number(currentPage),
-    results: results,
-    from: from,
-    to: to,
-    total_pages: totalPages,
-    total_results: totalResults,
+    resultsPerPage,
+    currentPage: Number(currentPage),
+    totalPages,
+    totalItems: totalResults,
   };
 };
 

--- a/__tests__/components/CommentsList.test.tsx
+++ b/__tests__/components/CommentsList.test.tsx
@@ -14,11 +14,10 @@
  * You should have received a copy of the GNU General Public License
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
-
 import React from "react";
-import { queryAllByTestId, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { CommentsList, CommentsListProps } from "@/components/CommentsList";
+import { CommentsList } from "@/components/CommentsList";
 import { DprComment } from "@/types";
 import { CommentCardProps } from "@/components/CommentCard";
 import {
@@ -38,14 +37,16 @@ jest.mock("@/components/CommentCard", () => ({
 }));
 
 describe("CommentsList", () => {
-  it("shows correct results", () => {
+  it("shows correct public comments results", () => {
+    const comments = generateNResults<DprComment>(20, generateComment);
+    const pagination = generatePagination(2, 20);
     render(
       <CommentsList
-        type={"public"}
-        councilSlug={"public-council-1"}
-        reference={"12345"}
-        comments={generateNResults<DprComment>(20, generateComment)}
-        pagination={generatePagination(2, 20)}
+        type="public"
+        councilSlug="public-council-1"
+        reference="12345"
+        comments={comments}
+        pagination={pagination}
         showMoreButton={true}
       />,
     );
@@ -59,37 +60,42 @@ describe("CommentsList", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows correct results", () => {
+  it("shows correct specialist comments results", () => {
+    const comments = generateNResults<DprComment>(10, generateComment);
+    const pagination = generatePagination(1, 10);
     render(
       <CommentsList
-        type={"specialist"}
-        councilSlug={"public-council-1"}
-        reference={"12345"}
-        comments={generateNResults<DprComment>(8, generateComment)}
-        pagination={generatePagination(0, 8)}
+        type="specialist"
+        councilSlug="public-council-1"
+        reference="12345"
+        comments={comments}
+        pagination={pagination}
         showMoreButton={true}
       />,
     );
     expect(screen.getByRole("heading")).toHaveTextContent(
       "Specialist Comments",
     );
-    expect(screen.getAllByTestId("comment-card")).toHaveLength(8);
+    expect(screen.getAllByTestId("comment-card")).toHaveLength(10);
     expect(screen.getByText("comment number: 1")).toBeInTheDocument();
-    expect(screen.getByText("comment number: 8")).toBeInTheDocument();
-    expect(screen.getByText("Showing 8 of 8 comments")).toBeInTheDocument();
+    expect(screen.getByText("comment number: 10")).toBeInTheDocument();
     expect(
-      screen.getByText("Show all 8 professional consultee comments"),
+      screen.getByText(/Showing\s*10\s*of\s*10\s*comments/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Show all 10 professional consultee comments"),
     ).toBeInTheDocument();
   });
 
   it("shows message when there are no public comments", () => {
+    const pagination = generatePagination(0, 0);
     render(
       <CommentsList
-        type={"public"}
-        councilSlug={"public-council-1"}
-        reference={"12345"}
+        type="public"
+        councilSlug="public-council-1"
+        reference="12345"
         comments={[]}
-        pagination={generatePagination(0, 0)}
+        pagination={pagination}
       />,
     );
     expect(screen.getByRole("heading")).toHaveTextContent("Public Comments");
@@ -101,13 +107,14 @@ describe("CommentsList", () => {
   });
 
   it("shows message when there are no specialist comments", () => {
+    const pagination = generatePagination(0, 0);
     render(
       <CommentsList
-        type={"specialist"}
-        councilSlug={"public-council-1"}
-        reference={"12345"}
+        type="specialist"
+        councilSlug="public-council-1"
+        reference="12345"
         comments={[]}
-        pagination={generatePagination(0, 0)}
+        pagination={pagination}
       />,
     );
     expect(screen.getByRole("heading")).toHaveTextContent(

--- a/__tests__/components/govuk/Pagination/Pagination.test.tsx
+++ b/__tests__/components/govuk/Pagination/Pagination.test.tsx
@@ -14,15 +14,11 @@
  * You should have received a copy of the GNU General Public License
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
-
 import { Pagination } from "@/components/govuk/Pagination";
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { ArrowLink } from "@/components/govuk/Pagination/ArrowLink";
-import {
-  PageItem,
-  PageItemProps,
-} from "@/components/govuk/Pagination/PageItem";
+import { PageItem } from "@/components/govuk/Pagination/PageItem";
 
 jest.mock("@/components/govuk/Pagination/ArrowLink", () => ({
   ArrowLink: jest.fn(() => <div>Mocked ArrowLink</div>),
@@ -39,12 +35,10 @@ describe("Pagination", () => {
 
   it("first page", () => {
     const pagination = {
-      page: 1,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 1,
+      resultsPerPage: 10,
+      totalPages: 100,
+      totalItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -110,14 +104,13 @@ describe("Pagination", () => {
       expect.anything(),
     );
   });
+
   it("second page", () => {
     const pagination = {
-      page: 2,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 2,
+      resultsPerPage: 10,
+      totalPages: 100,
+      totalItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -201,14 +194,13 @@ describe("Pagination", () => {
       expect.anything(),
     );
   });
+
   it("third page", () => {
     const pagination = {
-      page: 3,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 3,
+      resultsPerPage: 10,
+      totalPages: 100,
+      totalItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -300,14 +292,13 @@ describe("Pagination", () => {
       expect.anything(),
     );
   });
+
   it("fourth page", () => {
     const pagination = {
-      page: 4,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 4,
+      resultsPerPage: 10,
+      totalPages: 100,
+      totalItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -407,14 +398,13 @@ describe("Pagination", () => {
       expect.anything(),
     );
   });
+
   it("fifth page", () => {
     const pagination = {
-      page: 5,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 5,
+      resultsPerPage: 10,
+      totalPages: 100,
+      totalItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -514,14 +504,13 @@ describe("Pagination", () => {
       expect.anything(),
     );
   });
+
   it("ninety eighth page", () => {
     const pagination = {
-      page: 98,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 98,
+      resultsPerPage: 10,
+      totalPages: 100,
+      totalItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -613,14 +602,13 @@ describe("Pagination", () => {
       expect.anything(),
     );
   });
+
   it("ninety ninth page", () => {
     const pagination = {
-      page: 99,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 99,
+      resultsPerPage: 10,
+      totalPages: 100,
+      totalItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -704,14 +692,13 @@ describe("Pagination", () => {
       expect.anything(),
     );
   });
+
   it("last page", () => {
     const pagination = {
-      page: 100,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 100,
+      resultsPerPage: 10,
+      totalPages: 100,
+      totalItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -775,14 +762,13 @@ describe("Pagination", () => {
       expect.anything(),
     );
   });
+
   it("improbable page", () => {
     const pagination = {
-      page: 0,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 0,
+      resultsPerPage: 10,
+      totalPages: 100,
+      totalItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -850,6 +836,7 @@ describe("Pagination", () => {
       expect.anything(),
     );
   });
+
   it("block page", () => {
     const prev = {
       href: "prev-page",
@@ -880,6 +867,7 @@ describe("Pagination", () => {
 
     expect(PageItem).not.toHaveBeenCalled();
   });
+
   it("block page with description", () => {
     const prev = {
       labelText: "Applying for a provisional lorry or bus licence",

--- a/__tests__/mocks/dprApplicationFactory.test.ts
+++ b/__tests__/mocks/dprApplicationFactory.test.ts
@@ -97,22 +97,15 @@ describe("generateDocument", () => {
 describe("generatePagination", () => {
   it("should generate pagination data with the correct structure", () => {
     const pagination = generatePagination();
-    // expect(pagination).toHaveProperty("currentPage");
-    // expect(pagination).toHaveProperty("totalPages");
-    // expect(pagination).toHaveProperty("itemsPerPage");
-    // expect(pagination).toHaveProperty("totalItems");
-    expect(pagination).toHaveProperty("page");
-    expect(pagination).toHaveProperty("results");
-    expect(pagination).toHaveProperty("from");
-    expect(pagination).toHaveProperty("to");
-    expect(pagination).toHaveProperty("total_pages");
-    expect(pagination).toHaveProperty("total_results");
+    expect(pagination).toHaveProperty("resultsPerPage");
+    expect(pagination).toHaveProperty("currentPage");
+    expect(pagination).toHaveProperty("totalPages");
+    expect(pagination).toHaveProperty("totalItems");
   });
 
   it("should generate pagination data with the correct values when current page provided", () => {
     const pagination = generatePagination(5);
-    // expect(pagination.currentPage).toBe(5);
-    expect(pagination.page).toBe(5);
+    expect(pagination.currentPage).toBe(5);
   });
 
   it("should generate different pagination data on subsequent calls", () => {

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -195,7 +195,7 @@ export default async function PlanningApplicationSearch({
                 ))}
               </tbody>
             </table>
-            {pagination && pagination.total_pages > 1 && (
+            {pagination && pagination.totalPages > 1 && (
               <Pagination
                 baseUrl={"/docs"}
                 searchParams={searchParams}

--- a/src/components/ApplicationDetails/ApplicationDetails.tsx
+++ b/src/components/ApplicationDetails/ApplicationDetails.tsx
@@ -184,8 +184,8 @@ export const ApplicationDetails = ({
               reference={reference}
               type="specialist"
               pagination={{
-                page: 1,
-                results: 3,
+                currentPage: 1,
+                resultsPerPage: 3,
               }}
               showMoreButton={true}
               comments={application.application.consultation.consulteeComments}
@@ -197,8 +197,8 @@ export const ApplicationDetails = ({
               reference={reference}
               type="public"
               pagination={{
-                page: 1,
-                results: 3,
+                currentPage: 1,
+                resultsPerPage: 3,
               }}
               showMoreButton={true}
               comments={application.application.consultation.publishedComments}

--- a/src/components/CommentsList/CommentsList.stories.ts
+++ b/src/components/CommentsList/CommentsList.stories.ts
@@ -13,31 +13,30 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
- */
-
-import type { Meta, StoryObj } from "@storybook/react";
+ */ import type { Meta, StoryObj } from "@storybook/react";
 import { CommentsList } from "./CommentsList";
 import {
   generateComment,
   generateNResults,
   generatePagination,
 } from "@mocks/dprApplicationFactory";
-import { DprComment } from "@/types";
+import { DprComment, DprPagination } from "@/types";
 
 const meta = {
   title: "DPR Components/CommentsList",
   component: CommentsList,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ["autodocs"],
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
     layout: "fullscreen",
   },
   args: {
     councilSlug: "public-council-1",
     reference: "12345",
     comments: generateNResults<DprComment>(30, generateComment),
-    pagination: generatePagination(1),
+    pagination: (({ resultsPerPage, currentPage }: DprPagination) => ({
+      resultsPerPage,
+      currentPage,
+    }))(generatePagination(1, 30)),
   },
 } satisfies Meta<typeof CommentsList>;
 
@@ -45,46 +44,55 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
 export const NoComments: Story = {
   args: {
     comments: undefined,
   },
 };
+
 export const ApplicationCommentCta: Story = {
   args: {
     comments: generateNResults<DprComment>(30, generateComment),
-    pagination: {
-      results: 3,
-      page: 1,
-    },
+    pagination: { resultsPerPage: 3, currentPage: 1 },
     showMoreButton: true,
   },
 };
+
 export const ApplicationCommentCtaLessThan3Comments: Story = {
   args: {
     comments: generateNResults<DprComment>(2, generateComment),
-    pagination: {
-      results: 3,
-      page: 1,
-    },
+    pagination: { resultsPerPage: 3, currentPage: 1 },
     showMoreButton: true,
   },
 };
+
 export const FirstPage: Story = {
   args: {
     comments: generateNResults<DprComment>(30, generateComment),
-    pagination: generatePagination(1),
+    pagination: (({ resultsPerPage, currentPage }: DprPagination) => ({
+      resultsPerPage,
+      currentPage,
+    }))(generatePagination(1, 30)),
   },
 };
+
 export const SecondPage: Story = {
   args: {
     comments: generateNResults<DprComment>(30, generateComment),
-    pagination: generatePagination(2),
+    pagination: (({ resultsPerPage, currentPage }: DprPagination) => ({
+      resultsPerPage,
+      currentPage,
+    }))(generatePagination(2, 30)),
   },
 };
+
 export const ThirdPage: Story = {
   args: {
     comments: generateNResults<DprComment>(30, generateComment),
-    pagination: generatePagination(3),
+    pagination: (({ resultsPerPage, currentPage }: DprPagination) => ({
+      resultsPerPage,
+      currentPage,
+    }))(generatePagination(3, 30)),
   },
 };

--- a/src/components/CommentsList/CommentsList.tsx
+++ b/src/components/CommentsList/CommentsList.tsx
@@ -24,7 +24,7 @@ export interface CommentsListProps {
   councilSlug: string;
   reference: string;
   comments: DprComment[] | null;
-  pagination: Pick<DprPagination, "results" | "page">;
+  pagination: Pick<DprPagination, "resultsPerPage" | "currentPage">;
   showMoreButton?: boolean;
   type?: DprCommentTypes;
 }
@@ -46,11 +46,12 @@ export const CommentsList = ({
   if (!pagination) {
     return null;
   }
-  const { results: resultsPerPage, page } = pagination;
-  const startIndex = (page - 1) * resultsPerPage;
+  const { resultsPerPage, currentPage } = pagination;
+  const startIndex = (currentPage - 1) * resultsPerPage;
   const endIndex = startIndex + resultsPerPage;
   const displayedComments = comments?.slice(startIndex, endIndex);
   const totalComments = comments ? comments.length : 0;
+
   return (
     <section
       aria-labelledby={

--- a/src/components/PageApplicationComments/PageApplicationComments.tsx
+++ b/src/components/PageApplicationComments/PageApplicationComments.tsx
@@ -63,6 +63,7 @@ export const PageApplicationComments = ({
     );
   }
   const councilSlug = appConfig.council.slug;
+
   return (
     <>
       <BackButton baseUrl={`/${councilSlug}/${reference}`} />
@@ -78,12 +79,13 @@ export const PageApplicationComments = ({
           comments={comments}
           pagination={
             pagination ?? {
-              results: appConfig.defaults.resultsPerPage,
-              page: 1,
+              resultsPerPage: appConfig.defaults.resultsPerPage,
+              currentPage: 1,
             }
           }
         />
-        {pagination && pagination.total_pages > 1 && (
+
+        {pagination && pagination.totalPages > 1 && (
           <Pagination
             baseUrl={createPathFromParams(params, "comments")}
             searchParams={searchParams}

--- a/src/components/PageApplicationDocuments/PageApplicationDocuments.tsx
+++ b/src/components/PageApplicationDocuments/PageApplicationDocuments.tsx
@@ -55,11 +55,18 @@ export const PageApplicationDocuments = ({
     return null;
   }
   const councilSlug = appConfig.council.slug;
-  const from = (pagination?.from ?? 1) - 1;
-  const displayedDocuments = documents?.slice(
-    from,
-    from + (searchParams?.resultsPerPage ?? 9),
-  );
+
+  const documentsPagination = pagination ?? {
+    currentPage: 1,
+    resultsPerPage: searchParams?.resultsPerPage ?? 9,
+    totalPages: 1,
+    totalItems: documents?.length ?? 0,
+  };
+
+  const { currentPage, resultsPerPage } = documentsPagination;
+  const from = (currentPage - 1) * resultsPerPage;
+  const displayedDocuments = documents?.slice(from, from + resultsPerPage);
+
   return (
     <>
       <BackButton baseUrl={`/${councilSlug}/${reference}`} />
@@ -69,13 +76,13 @@ export const PageApplicationDocuments = ({
           address={application.property.address.singleLine}
         />
         <DocumentsList
-          councilSlug={appConfig.council?.slug}
+          councilSlug={appConfig.council.slug}
           reference={reference}
           documents={displayedDocuments ?? null}
           totalDocuments={documents?.length ?? displayedDocuments?.length ?? 0}
           showMoreButton={false}
         />
-        {pagination && pagination.total_pages > 1 && (
+        {pagination && pagination.totalPages > 1 && (
           <Pagination
             baseUrl={createPathFromParams(params, "documents")}
             searchParams={searchParams}

--- a/src/components/PageSearch/PageSearch.tsx
+++ b/src/components/PageSearch/PageSearch.tsx
@@ -111,7 +111,7 @@ export const PageSearch = ({
                 application={application}
               />
             ))}
-            {pagination && pagination.total_pages > 1 && (
+            {pagination && pagination.totalPages > 1 && (
               <Pagination
                 baseUrl={createPathFromParams(params)}
                 searchParams={searchParams}

--- a/src/components/govuk/Pagination/Pagination.stories.ts
+++ b/src/components/govuk/Pagination/Pagination.stories.ts
@@ -21,20 +21,15 @@ import { Pagination } from "./Pagination";
 const meta = {
   title: "GOV UK Components/Pagination",
   component: Pagination,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
-  // tags: ["autodocs"],
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
     layout: "fullscreen",
   },
   args: {
     pagination: {
-      page: 50,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 50,
+      totalPages: 100,
+      resultsPerPage: 10,
+      totalItems: 1000,
     },
     baseUrl: "search",
     searchParams: {
@@ -69,12 +64,10 @@ export const Default: Story = {};
 export const FirstPage: Story = {
   args: {
     pagination: {
-      page: 1,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 1,
+      totalPages: 100,
+      resultsPerPage: 10,
+      totalItems: 1000,
     },
   },
 };
@@ -82,12 +75,10 @@ export const FirstPage: Story = {
 export const SecondPage: Story = {
   args: {
     pagination: {
-      page: 2,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 2,
+      totalPages: 100,
+      resultsPerPage: 10,
+      totalItems: 1000,
     },
   },
 };
@@ -95,12 +86,10 @@ export const SecondPage: Story = {
 export const ThirdPage: Story = {
   args: {
     pagination: {
-      page: 3,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 3,
+      totalPages: 100,
+      resultsPerPage: 10,
+      totalItems: 1000,
     },
   },
 };
@@ -108,12 +97,10 @@ export const ThirdPage: Story = {
 export const FourthPage: Story = {
   args: {
     pagination: {
-      page: 4,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 4,
+      totalPages: 100,
+      resultsPerPage: 10,
+      totalItems: 1000,
     },
   },
 };
@@ -121,12 +108,10 @@ export const FourthPage: Story = {
 export const FifthPage: Story = {
   args: {
     pagination: {
-      page: 5,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 5,
+      totalPages: 100,
+      resultsPerPage: 10,
+      totalItems: 1000,
     },
   },
 };
@@ -134,12 +119,10 @@ export const FifthPage: Story = {
 export const NinetyEighthPage: Story = {
   args: {
     pagination: {
-      page: 98,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 98,
+      totalPages: 100,
+      resultsPerPage: 10,
+      totalItems: 1000,
     },
   },
 };
@@ -147,12 +130,10 @@ export const NinetyEighthPage: Story = {
 export const NinetyNinthPage: Story = {
   args: {
     pagination: {
-      page: 99,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 99,
+      totalPages: 100,
+      resultsPerPage: 10,
+      totalItems: 1000,
     },
   },
 };
@@ -160,12 +141,10 @@ export const NinetyNinthPage: Story = {
 export const LastPage: Story = {
   args: {
     pagination: {
-      page: 100,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 100,
+      totalPages: 100,
+      resultsPerPage: 10,
+      totalItems: 1000,
     },
   },
 };
@@ -173,12 +152,10 @@ export const LastPage: Story = {
 export const HigherThanPossiblePage: Story = {
   args: {
     pagination: {
-      page: 101,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 101,
+      totalPages: 100,
+      resultsPerPage: 10,
+      totalItems: 1000,
     },
   },
 };
@@ -186,12 +163,10 @@ export const HigherThanPossiblePage: Story = {
 export const LowerThanPossiblePage: Story = {
   args: {
     pagination: {
-      page: 0,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 0,
+      totalPages: 100,
+      resultsPerPage: 10,
+      totalItems: 1000,
     },
   },
 };
@@ -199,12 +174,10 @@ export const LowerThanPossiblePage: Story = {
 export const EvenLowerThanPossiblePage: Story = {
   args: {
     pagination: {
-      page: -1,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: -1,
+      totalPages: 100,
+      resultsPerPage: 10,
+      totalItems: 1000,
     },
   },
 };
@@ -212,12 +185,10 @@ export const EvenLowerThanPossiblePage: Story = {
 export const MoreItemsThanPages: Story = {
   args: {
     pagination: {
-      page: 101,
-      from: 0,
-      to: 0,
-      total_pages: 100,
-      results: 10,
-      total_results: 1000,
+      currentPage: 101,
+      totalPages: 100,
+      resultsPerPage: 10,
+      totalItems: 1000,
     },
   },
 };

--- a/src/components/govuk/Pagination/Pagination.tsx
+++ b/src/components/govuk/Pagination/Pagination.tsx
@@ -78,7 +78,7 @@ export const Pagination = ({
   let firstPage = false;
   let lastPage = false;
   if (pagination) {
-    const { page: currentPage, total_pages: totalPages } = pagination;
+    const { currentPage, totalPages } = pagination;
     firstPage = currentPage === 1;
     lastPage = currentPage === totalPages;
     prev = {

--- a/src/handlers/bops/converters/documents.ts
+++ b/src/handlers/bops/converters/documents.ts
@@ -15,27 +15,9 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { DprDocument, DprPaginationBase } from "@/types";
-import {
-  BopsDocumentsMetadata,
-  BopsFile,
-  BopsNonStandardDocument,
-} from "@/handlers/bops/types";
+import { DprDocument } from "@/types";
+import { BopsFile, BopsNonStandardDocument } from "@/handlers/bops/types";
 import { convertDateTimeToUtc, formatTag } from "@/util";
-
-/**
- * Converts Bops documents metadata into our standard format
- * @param metadata
- * @returns
- */
-export const convertBopsDocumentPagination = (
-  metadata: BopsDocumentsMetadata,
-): DprPaginationBase => {
-  return {
-    results: metadata.results,
-    total_results: metadata.totalResults,
-  };
-};
 
 /**
  * Converts BOPS files into our standard format

--- a/src/handlers/bops/converters/planningApplication.ts
+++ b/src/handlers/bops/converters/planningApplication.ts
@@ -15,8 +15,12 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { DprPlanningApplication } from "@/types";
-import { BopsApplicationOverview, BopsPlanningApplication } from "../types";
+import { DprPagination, DprPlanningApplication } from "@/types";
+import {
+  BopsApplicationOverview,
+  BopsPlanningApplication,
+  BopsSearchMetadata,
+} from "../types";
 import { sortComments } from "@/lib/comments";
 import { convertCommentBops } from "./comments";
 import { convertDateTimeToUtc } from "@/util";
@@ -79,6 +83,17 @@ export const convertBopsApplicationToDpr = (
       ? convertDateTimeToUtc(application.determinedAt)
       : null,
     decision: application.decision ?? null,
+  };
+};
+
+export const convertBopsToDprPagination = (
+  bopsPagination: BopsSearchMetadata,
+): DprPagination => {
+  return {
+    resultsPerPage: bopsPagination.results,
+    currentPage: bopsPagination.page,
+    totalPages: bopsPagination.total_pages,
+    totalItems: bopsPagination.total_results,
   };
 };
 

--- a/src/handlers/bops/v2/search.ts
+++ b/src/handlers/bops/v2/search.ts
@@ -17,11 +17,19 @@
 
 "use server";
 
-import { ApiResponse, DprSearchApiResponse, SearchParams } from "@/types";
+import {
+  ApiResponse,
+  DprPagination,
+  DprSearchApiResponse,
+  SearchParams,
+} from "@/types";
 import { BopsV2PublicPlanningApplicationsSearch } from "@/handlers/bops/types";
 import { handleBopsGetRequest } from "../requests";
 import { defaultPagination } from "@/handlers/lib";
-import { convertBopsToDpr } from "../converters/planningApplication";
+import {
+  convertBopsToDpr,
+  convertBopsToDprPagination,
+} from "../converters/planningApplication";
 
 /**
  * Get list of public applications, also used for search
@@ -60,9 +68,15 @@ export async function search(
     convertBopsToDpr(application, council),
   );
 
+  const metadata = request.data?.metadata;
+  const pagination: DprPagination =
+    metadata && "results" in metadata
+      ? convertBopsToDprPagination(metadata)
+      : defaultPagination;
+
   return {
     ...request,
     data: convertedApplications,
-    pagination: request.data?.metadata ?? defaultPagination,
+    pagination,
   };
 }

--- a/src/handlers/lib/api.ts
+++ b/src/handlers/lib/api.ts
@@ -32,10 +32,8 @@ export function apiReturnError(detail: string): ApiResponse<null> {
  * Returns the default pagination
  */
 export const defaultPagination = {
-  page: 1,
-  results: 0,
-  from: 0,
-  to: 0,
-  total_pages: 1,
-  total_results: 0,
+  resultsPerPage: 0,
+  currentPage: 1,
+  totalPages: 1,
+  totalItems: 0,
 };

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -18,18 +18,6 @@
 import { DprPagination } from "@/types";
 
 /**
- * Returns the default pagination
- */
-export const defaultPagination = {
-  page: 1,
-  results: 0,
-  from: 0,
-  to: 0,
-  total_pages: 1,
-  total_results: 0,
-};
-
-/**
  * Since comments and documents aren't officially paginated we're faking it atm so
  * that the <Pagination /> component can be standardised
  * @param totalComments
@@ -43,25 +31,12 @@ export const createItemPagination = (
   maxDisplayItems: number = 10,
 ): DprPagination => {
   const currentPage = Number(paramsPage);
-  const from = (currentPage - 1) * maxDisplayItems + 1;
-  const to = Math.min(currentPage * maxDisplayItems, totalItems);
   const totalPages = Math.ceil(totalItems / maxDisplayItems);
 
   return {
-    page: currentPage,
-    results: maxDisplayItems,
-    from: from,
-    to: to,
-    total_pages: totalPages,
-    total_results: totalItems,
+    resultsPerPage: maxDisplayItems,
+    currentPage: currentPage,
+    totalPages: totalPages,
+    totalItems: totalItems,
   };
-
-  // return {
-  //   totalItems,
-  //   currentPage,
-  //   maxDisplayItems,
-  //   from,
-  //   to,
-  //   totalPages,
-  // };
 };

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -78,16 +78,23 @@ export interface SearchParamsComments extends SearchParams {
  *
  *
  */
-export interface DprPaginationBase {
-  results: number;
-  total_results: number;
-}
-
-export interface DprPagination extends DprPaginationBase {
-  page: number;
-  from: number;
-  to: number;
-  total_pages: number;
+export interface DprPagination {
+  /**
+   * Number of results per page (e.g., 10)
+   */
+  resultsPerPage: number;
+  /**
+   * Current page number (e.g., 1)
+   */
+  currentPage: number;
+  /**
+   * Total number of pages (e.g., 10)
+   */
+  totalPages: number;
+  /**
+   * Total number of items (e.g., 100)
+   */
+  totalItems: number;
 }
 
 /**


### PR DESCRIPTION
[Ticket 1058](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?assignee=62a6f3cb6085950068acebf7&selectedIssue=DSNPI-1058)

This PR standardises the pagination across the application by replacing legacy pagination fields with the proposed API structure in [this PR](https://github.com/theopensystemslab/digital-planning-data-schemas/pull/318). We’re using offset-based pagination exclusively which aligns with the GDS pagination component.

- The `convertBopsToDprPagination` function maps legacy fields (page, results, total_pages, total_results) to the new structure:

```
export interface DprPagination {
  /**
   * Number of results per page (e.g., 10)
   */
  resultsPerPage: number;
  /**
   * Current page number (e.g., 1)
   */
  currentPage: number;
  /**
   * Total number of pages (e.g., 10)
   */
  totalPages: number;
  /**
   * Total number of items (e.g., 100)
   */
  totalItems: number;
}
```
- Modified components to use the new field names.

- Adjusted pagination calculations to work with resultsPerPage and currentPage.

- Updated Storybook stories and tests to reflect the new pagination structure.

