### PR TITLE
DSNPI - 987 / Create new handlers for the new comment endpoints 

### DIFF
--- a/__mocks__/dprApplicationFactory.ts
+++ b/__mocks__/dprApplicationFactory.ts
@@ -61,6 +61,7 @@ export const generateReference = (): string => {
  */
 export const generateComment = (): DprComment => {
   return {
+    id: faker.number.int({ min: 1000000000, max: 9999999999 }),
     comment: faker.lorem.paragraphs(),
     receivedDate: faker.date.anytime().toISOString(),
     sentiment: faker.helpers.arrayElement([

--- a/__mocks__/dprNewApplicationFactory.ts
+++ b/__mocks__/dprNewApplicationFactory.ts
@@ -57,6 +57,7 @@ import { PriorApprovalAssessment } from "@/types/odp-types/schemas/postSubmissio
 import { PostSubmissionMetadata } from "@/types/odp-types/schemas/postSubmissionApplication/Metadata";
 import { PostSubmissionApplication } from "@/types/odp-types/schemas/postSubmissionApplication";
 import { AppealDecision } from "@/types/odp-types/schemas/postSubmissionApplication/enums/AppealDecision";
+
 import {
   Agent,
   BaseApplicant,

--- a/src/actions/api/v1/index.ts
+++ b/src/actions/api/v1/index.ts
@@ -20,12 +20,16 @@ import { applicationSubmission } from "./applicationSubmission";
 import { documents } from "./documents";
 import { postComment } from "./postComment";
 import { show } from "./show";
+import { specialistComments } from "./specialistComments";
+import { publicComments } from "./publicComments";
 
 import { documentation as searchDocumentation } from "./search.documentation";
 import { documentation as applicationSubmissionDocumentation } from "./applicationSubmission.documentation";
 import { documentation as documentsDocumentation } from "./documents.documentation";
 import { documentation as postCommentDocumentation } from "./postComment.documentation";
 import { documentation as showDocumentation } from "./show.documentation";
+import { documentation as publicCommentsDocumentation } from "./publicComments.documentation";
+import { documentation as specialistCommentsDocumentation } from "./specialistComments.documentation";
 
 import { Documentation } from "@/types";
 
@@ -40,6 +44,8 @@ const handlers: Record<string, HandlerFunction> = {
   documents,
   postComment,
   show,
+  publicComments,
+  specialistComments,
 };
 
 const documentations: Record<string, Documentation> = {
@@ -48,6 +54,8 @@ const documentations: Record<string, Documentation> = {
   documents: documentsDocumentation,
   postComment: postCommentDocumentation,
   show: showDocumentation,
+  publicComments: publicCommentsDocumentation,
+  specialistComments: specialistCommentsDocumentation,
 };
 
 export const ApiV1 = handlers;

--- a/src/actions/api/v1/publicComments.documentation.tsx
+++ b/src/actions/api/v1/publicComments.documentation.tsx
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Documentation, SearchParamsComments } from "@/types";
+import { publicComments } from "./publicComments";
+
+export const documentation: Documentation = {
+  url: `/docs/json?handler=ApiV1&method=publicComments`,
+  file: `src/actions/api/v1/publicComments.ts`,
+  description: "[publicComments]",
+  arguments: [
+    "source",
+    "council",
+    "reference",
+    "page",
+    "resultsPerPage",
+    "searchQuery",
+  ],
+  run: async (args: [string, string, string, SearchParamsComments]) => {
+    return await publicComments(...args);
+  },
+  examples: [
+    // Southwark
+    {
+      url: `/docs/json?handler=ApiV1&method=publicComments&source=bops&council=southwark&reference=25-00292-HAPP`,
+      description: "publicComments exists",
+    },
+    {
+      url: `/docs/json?handler=ApiV1&method=publicComments&source=bops&council=southwark&reference=doesnotexist`,
+      description: "publicComments doesn't exist",
+    },
+    // Camden
+    {
+      url: `/docs/json?handler=ApiV1&method=publicComments&source=bops&council=camden&reference=24-00129-HAPP`,
+      description: "publicComments exists",
+    },
+    {
+      url: `/docs/json?handler=ApiV1&method=publicComments&source=bops&council=camden&reference=doesnotexist`,
+      description: "publicComments doesn't exist",
+    },
+  ],
+};

--- a/src/actions/api/v1/publicComments.ts
+++ b/src/actions/api/v1/publicComments.ts
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+"use server";
+import { BopsV2 } from "@/handlers/bops";
+import { LocalV1 } from "@/handlers/local";
+import { apiReturnError } from "@/handlers/lib";
+import {
+  ApiResponse,
+  DprPublicCommentsApiResponse,
+  SearchParamsComments,
+} from "@/types";
+
+/**
+ * /api/docs?handler=ApiV1&method=publicComments
+ */
+export async function publicComments(
+  source: string,
+  council: string,
+  reference: string,
+  searchParams: SearchParamsComments,
+): Promise<ApiResponse<DprPublicCommentsApiResponse | null>> {
+  if (!council || !reference) {
+    return apiReturnError("Council and reference are required");
+  }
+
+  switch (source) {
+    case "bops":
+      return await BopsV2.publicComments(council, reference, searchParams);
+    case "local":
+      return await LocalV1.publicComments(council, reference, searchParams);
+    default:
+      return apiReturnError("Invalid source");
+  }
+}

--- a/src/actions/api/v1/specialistComments.documentation.tsx
+++ b/src/actions/api/v1/specialistComments.documentation.tsx
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Documentation, SearchParamsComments } from "@/types";
+import { specialistComments } from "./specialistComments";
+
+export const documentation: Documentation = {
+  url: `/docs/json?handler=ApiV1&method=specialistComments`,
+  file: `src/actions/api/v1/specialistComments.ts`,
+  description: "[specialistComments]",
+  arguments: [
+    "source",
+    "council",
+    "reference",
+    "page",
+    "resultsPerPage",
+    "searchQuery",
+  ],
+  run: async (args: [string, string, string, SearchParamsComments]) => {
+    return await specialistComments(...args);
+  },
+  examples: [
+    {
+      // Southwark
+      url: `/docs/json?handler=ApiV1&method=specialistComments&source=bops&council=southwark&reference=25-00292-HAPP`,
+      description: "specialistComments exists",
+    },
+    {
+      url: `/docs/json?handler=ApiV1&method=specialistComments&source=bops&council=southwark&reference=doesnotexist`,
+      description: "specialistComments doesn't exist",
+    },
+    // Camden
+    {
+      url: `/docs/json?handler=ApiV1&method=specialistComments&source=bops&council=camden&reference=24-00129-HAPP`,
+      description: "specialistComments exists",
+    },
+    {
+      url: `/docs/json?handler=ApiV1&method=specialistComments&source=bops&council=camden&reference=doesnotexist`,
+      description: "specialistComments doesn't exist",
+    },
+  ],
+};

--- a/src/actions/api/v1/specialistComments.ts
+++ b/src/actions/api/v1/specialistComments.ts
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+"use server";
+import { BopsV2 } from "@/handlers/bops";
+import { LocalV1 } from "@/handlers/local";
+import { apiReturnError } from "@/handlers/lib";
+import {
+  ApiResponse,
+  DprSpecialistCommentsApiResponse,
+  SearchParamsComments,
+} from "@/types";
+
+/**
+ * /api/docs?handler=ApiV1&method=specialistComments
+ */
+export async function specialistComments(
+  source: string,
+  council: string,
+  reference: string,
+  searchParams: SearchParamsComments,
+): Promise<ApiResponse<DprSpecialistCommentsApiResponse | null>> {
+  if (!council || !reference) {
+    return apiReturnError("Council and reference are required");
+  }
+
+  switch (source) {
+    case "bops":
+      return await BopsV2.specialistComments(council, reference, searchParams);
+    case "local":
+      return await LocalV1.specialistComments(council, reference, searchParams);
+    default:
+      return apiReturnError("Invalid source");
+  }
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -428,7 +428,7 @@ const councils: Council[] = [
     slug: "southwark",
     visibility: "public",
     dataSource: "bops",
-    publicComments: false,
+    publicComments: true,
     specialistComments: false,
     features: {
       logoInHeader: false,

--- a/src/handlers/bops/converters/comments.ts
+++ b/src/handlers/bops/converters/comments.ts
@@ -15,8 +15,8 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { DprComment, DprPagination } from "@/types";
-import { BopsComment, BopsSearchMetadata } from "../types";
+import { DprComment } from "@/types";
+import { BopsComment } from "../types";
 import { convertDateTimeToUtc } from "@/util";
 
 /**
@@ -27,20 +27,8 @@ import { convertDateTimeToUtc } from "@/util";
  */
 export const convertCommentBops = (comment: BopsComment): DprComment => {
   return {
-    id: comment.id,
     comment: comment.comment,
     receivedDate: convertDateTimeToUtc(comment.receivedAt),
-    sentiment: comment.sentiment || "",
-  };
-};
-
-export const convertBopsToDprPagination = (
-  bopsPagination: BopsSearchMetadata,
-): DprPagination => {
-  return {
-    resultsPerPage: bopsPagination.results,
-    currentPage: bopsPagination.page,
-    totalPages: bopsPagination.total_pages,
-    totalItems: bopsPagination.total_results,
+    sentiment: comment.summaryTag || "",
   };
 };

--- a/src/handlers/bops/converters/comments.ts
+++ b/src/handlers/bops/converters/comments.ts
@@ -15,8 +15,8 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { DprComment } from "@/types";
-import { BopsComment } from "../types";
+import { DprComment, DprPagination } from "@/types";
+import { BopsComment, BopsSearchMetadata } from "../types";
 import { convertDateTimeToUtc } from "@/util";
 
 /**
@@ -27,8 +27,20 @@ import { convertDateTimeToUtc } from "@/util";
  */
 export const convertCommentBops = (comment: BopsComment): DprComment => {
   return {
+    id: comment.id,
     comment: comment.comment,
     receivedDate: convertDateTimeToUtc(comment.receivedAt),
-    sentiment: comment.summaryTag || "",
+    sentiment: comment.sentiment || "",
+  };
+};
+
+export const convertBopsToDprPagination = (
+  bopsPagination: BopsSearchMetadata,
+): DprPagination => {
+  return {
+    resultsPerPage: bopsPagination.results,
+    currentPage: bopsPagination.page,
+    totalPages: bopsPagination.total_pages,
+    totalItems: bopsPagination.total_results,
   };
 };

--- a/src/handlers/bops/types/definitions/comment.d.ts
+++ b/src/handlers/bops/types/definitions/comment.d.ts
@@ -16,10 +16,9 @@
  */
 
 export interface BopsComment {
-  id?: number;
   comment: string;
   receivedAt: string;
-  sentiment?: string;
+  summaryTag?: string;
 }
 
 /**

--- a/src/handlers/bops/v2/index.ts
+++ b/src/handlers/bops/v2/index.ts
@@ -20,13 +20,16 @@ import { applicationSubmission } from "./applicationSubmission";
 import { documents } from "./documents";
 import { postComment } from "./postComment";
 import { show } from "./show";
+import { publicComments } from "./publicComments";
+import { specialistComments } from "./specialistComments";
 
 import { documentation as searchDocumentation } from "./search.documentation";
 import { documentation as applicationSubmissionDocumentation } from "./applicationSubmission.documentation";
 import { documentation as documentsDocumentation } from "./documents.documentation";
 import { documentation as postCommentDocumentation } from "./postComment.documentation";
 import { documentation as showDocumentation } from "./show.documentation";
-
+import { documentation as publicCommentsDocumentation } from "./publicComments.documentation";
+import { documentation as specialistCommentsDocumentation } from "./specialistComments.documentation";
 import { Documentation } from "@/types";
 
 // only allowing any here because we don't (yet!) export the types for each handler and it would be too big a change rn
@@ -40,6 +43,8 @@ const handlers: Record<string, HandlerFunction> = {
   documents,
   postComment,
   show,
+  publicComments,
+  specialistComments,
 };
 
 const documentations: Record<string, Documentation> = {
@@ -48,6 +53,8 @@ const documentations: Record<string, Documentation> = {
   documents: documentsDocumentation,
   postComment: postCommentDocumentation,
   show: showDocumentation,
+  publicComments: publicCommentsDocumentation,
+  specialistComments: specialistCommentsDocumentation,
 };
 
 export const BopsV2 = handlers;

--- a/src/handlers/bops/v2/publicComments.documentation.tsx
+++ b/src/handlers/bops/v2/publicComments.documentation.tsx
@@ -1,0 +1,55 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Documentation } from "@/types";
+import { publicComments } from "./publicComments";
+
+export const documentation: Documentation = {
+  url: `/docs/json?handler=BopsV2&method=publicComments`,
+  file: `src/handlers/bops/v2/publicComments.ts`,
+  description: "publicComments",
+  arguments: [
+    "source",
+    "council",
+    "reference",
+    "page",
+    "resultsPerPage",
+    "searchQuery",
+  ],
+  run: async (args: [string, string]) => {
+    return await publicComments(...args);
+  },
+  examples: [
+    // Southwark
+    {
+      url: `/docs/json?handler=BopsV2&method=publicComments&council=southwark&reference=25-00292-HAPP`,
+      description: "publicComments has publicComments",
+    },
+    {
+      url: `/docs/json?handler=BopsV2&method=publicComments&council=southwark&reference=doesnotexist`,
+      description: "publicComments doesn't have publicComments",
+    },
+    // Camden
+    {
+      url: `/docs/json?handler=BopsV2&method=publicComments&council=camden&reference=24-00129-HAPP`,
+      description: "publicComments has publicComments",
+    },
+    {
+      url: `/docs/json?handler=BopsV2&method=publicComments&council=camden&reference=doesnotexist`,
+      description: "publicComments doesn't have publicComments",
+    },
+  ],
+};

--- a/src/handlers/bops/v2/publicComments.documentation.tsx
+++ b/src/handlers/bops/v2/publicComments.documentation.tsx
@@ -14,22 +14,15 @@
  * You should have received a copy of the GNU General Public License
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
-import { Documentation } from "@/types";
+import { Documentation, SearchParamsComments } from "@/types";
 import { publicComments } from "./publicComments";
 
 export const documentation: Documentation = {
   url: `/docs/json?handler=BopsV2&method=publicComments`,
   file: `src/handlers/bops/v2/publicComments.ts`,
   description: "publicComments",
-  arguments: [
-    "source",
-    "council",
-    "reference",
-    "page",
-    "resultsPerPage",
-    "searchQuery",
-  ],
-  run: async (args: [string, string]) => {
+  arguments: ["council", "reference", "searchParams"],
+  run: async (args: [string, string, SearchParamsComments]) => {
     return await publicComments(...args);
   },
   examples: [

--- a/src/handlers/bops/v2/publicComments.ts
+++ b/src/handlers/bops/v2/publicComments.ts
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {
+  ApiResponse,
+  DprPublicCommentsApiResponse,
+  SearchParams,
+} from "@/types";
+import { handleBopsGetRequest } from "../requests";
+import { defaultPagination } from "@/handlers/lib";
+
+/**
+ * Get the public comments for an application
+ * @param page
+ * @param resultsPerPage
+ * @param query
+ * @param sortBy
+ * @param orderBy
+ * @param council
+ * @param reference
+ * @returns
+ */
+export async function publicComments(
+  council: string,
+  reference: string,
+  search?: SearchParams,
+): Promise<ApiResponse<DprPublicCommentsApiResponse | null>> {
+  let url = `public/planning_applications/${reference}/comments/public`;
+
+  if (search) {
+    const params = new URLSearchParams({
+      page: search?.page?.toString(),
+      maxresults: search?.resultsPerPage?.toString() ?? "10",
+    });
+
+    if (search.query) {
+      params.append("q", search.query);
+    }
+    if (search.sortBy) {
+      params.append("sortBy", search.sortBy);
+    }
+    if (search.orderBy) {
+      params.append("orderBy", search.orderBy);
+    }
+    url = `${url}?${params.toString()}`;
+  }
+
+  const request = await handleBopsGetRequest<
+    ApiResponse<DprPublicCommentsApiResponse | null>
+  >(council, url);
+
+  if (!request.data) {
+    return {
+      ...request,
+      data: null,
+      pagination: defaultPagination,
+    };
+  }
+
+  const { comments, summary } = request.data;
+  const pagination = request.pagination;
+  return {
+    ...request,
+    data: {
+      comments,
+      summary,
+    },
+    pagination: pagination,
+  };
+}

--- a/src/handlers/bops/v2/publicComments.ts
+++ b/src/handlers/bops/v2/publicComments.ts
@@ -37,24 +37,24 @@ import { defaultPagination } from "@/handlers/lib";
 export async function publicComments(
   council: string,
   reference: string,
-  search?: SearchParams,
+  searchParams?: SearchParams,
 ): Promise<ApiResponse<DprPublicCommentsApiResponse | null>> {
   let url = `public/planning_applications/${reference}/comments/public`;
 
-  if (search) {
+  if (searchParams) {
     const params = new URLSearchParams({
-      page: search?.page?.toString(),
-      maxresults: search?.resultsPerPage?.toString() ?? "10",
+      page: searchParams?.page?.toString(),
+      maxresults: searchParams?.resultsPerPage?.toString() ?? "10",
     });
 
-    if (search.query) {
-      params.append("q", search.query);
+    if (searchParams.query) {
+      params.append("q", searchParams.query);
     }
-    if (search.sortBy) {
-      params.append("sortBy", search.sortBy);
+    if (searchParams.sortBy) {
+      params.append("sortBy", searchParams.sortBy);
     }
-    if (search.orderBy) {
-      params.append("orderBy", search.orderBy);
+    if (searchParams.orderBy) {
+      params.append("orderBy", searchParams.orderBy);
     }
     url = `${url}?${params.toString()}`;
   }

--- a/src/handlers/bops/v2/publicComments.ts
+++ b/src/handlers/bops/v2/publicComments.ts
@@ -18,7 +18,7 @@
 import {
   ApiResponse,
   DprPublicCommentsApiResponse,
-  SearchParams,
+  SearchParamsComments,
 } from "@/types";
 import { handleBopsGetRequest } from "../requests";
 import { defaultPagination } from "@/handlers/lib";
@@ -37,7 +37,7 @@ import { defaultPagination } from "@/handlers/lib";
 export async function publicComments(
   council: string,
   reference: string,
-  searchParams?: SearchParams,
+  searchParams?: SearchParamsComments,
 ): Promise<ApiResponse<DprPublicCommentsApiResponse | null>> {
   let url = `public/planning_applications/${reference}/comments/public`;
 

--- a/src/handlers/bops/v2/specialistComments.documentation.tsx
+++ b/src/handlers/bops/v2/specialistComments.documentation.tsx
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Documentation } from "@/types";
+import { specialistComments } from "./specialistComments";
+
+export const documentation: Documentation = {
+  url: `/docs/json?handler=BopsV2&method=specialistComments`,
+  file: `src/handlers/bops/v2/specialistComments.ts`,
+  description: "specialistComments",
+  arguments: [
+    "source",
+    "council",
+    "reference",
+    "page",
+    "resultsPerPage",
+    "searchQuery",
+  ],
+  run: async (args: [string, string]) => {
+    return await specialistComments(...args);
+  },
+  examples: [
+    // Southwark
+    {
+      url: `/docs/json?handler=BopsV2&method=specialistComments&council=southwark&reference=25-00292-HAPP`,
+      description: "specialistComments has specialistComments",
+    },
+    {
+      url: `/docs/json?handler=BopsV2&method=specialistComments&council=southwark&reference=doesnotexist`,
+      description: "specialistComments doesn't have specialistComments",
+    },
+    // Camden
+    {
+      url: `/docs/json?handler=BopsV2&method=specialistComments&council=camden&reference=24-00129-HAPP`,
+      description: "specialistComments has specialistComments",
+    },
+    {
+      url: `/docs/json?handler=BopsV2&method=specialistComments&council=camden&reference=doesnotexist`,
+      description: "specialistComments doesn't have specialistComments",
+    },
+  ],
+};

--- a/src/handlers/bops/v2/specialistComments.documentation.tsx
+++ b/src/handlers/bops/v2/specialistComments.documentation.tsx
@@ -15,22 +15,15 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Documentation } from "@/types";
+import { Documentation, SearchParamsComments } from "@/types";
 import { specialistComments } from "./specialistComments";
 
 export const documentation: Documentation = {
   url: `/docs/json?handler=BopsV2&method=specialistComments`,
   file: `src/handlers/bops/v2/specialistComments.ts`,
   description: "specialistComments",
-  arguments: [
-    "source",
-    "council",
-    "reference",
-    "page",
-    "resultsPerPage",
-    "searchQuery",
-  ],
-  run: async (args: [string, string]) => {
+  arguments: ["council", "reference", "searchParams"],
+  run: async (args: [string, string, SearchParamsComments]) => {
     return await specialistComments(...args);
   },
   examples: [

--- a/src/handlers/bops/v2/specialistComments.ts
+++ b/src/handlers/bops/v2/specialistComments.ts
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {
+  SearchParams,
+  ApiResponse,
+  DprSpecialistCommentsApiResponse,
+} from "@/types";
+import { handleBopsGetRequest } from "../requests";
+import { defaultPagination } from "@/handlers/lib";
+
+/**
+ * Get the specialist comments for an application
+ * @param page
+ * @param resultsPerPage
+ * @param query
+ * @param sortBy
+ * @param orderBy
+ * @param council
+ * @param reference
+ * @returns
+ */
+export async function specialistComments(
+  council: string,
+  reference: string,
+  search?: SearchParams,
+): Promise<ApiResponse<DprSpecialistCommentsApiResponse | null>> {
+  let url = `public/planning_applications/${reference}/comments/specialist`;
+
+  if (search) {
+    const params = new URLSearchParams({
+      page: search?.page?.toString(),
+      maxresults: search?.resultsPerPage?.toString() ?? "10",
+    });
+
+    if (search.query) {
+      params.append("q", search.query);
+    }
+    if (search.sortBy) {
+      params.append("sortBy", search.sortBy);
+    }
+    if (search.orderBy) {
+      params.append("orderBy", search.orderBy);
+    }
+    url = `${url}?${params.toString()}`;
+  }
+
+  const request = await handleBopsGetRequest<
+    ApiResponse<DprSpecialistCommentsApiResponse | null>
+  >(council, url);
+
+  if (!request.data) {
+    return {
+      ...request,
+      data: null,
+      pagination: defaultPagination,
+    };
+  }
+
+  const { comments, summary } = request.data;
+  const pagination = request.pagination;
+
+  return {
+    ...request,
+    data: {
+      comments,
+      summary,
+    },
+    pagination: pagination,
+  };
+}

--- a/src/handlers/bops/v2/specialistComments.ts
+++ b/src/handlers/bops/v2/specialistComments.ts
@@ -16,9 +16,9 @@
  */
 
 import {
-  SearchParams,
   ApiResponse,
   DprSpecialistCommentsApiResponse,
+  SearchParamsComments,
 } from "@/types";
 import { handleBopsGetRequest } from "../requests";
 import { defaultPagination } from "@/handlers/lib";
@@ -37,7 +37,7 @@ import { defaultPagination } from "@/handlers/lib";
 export async function specialistComments(
   council: string,
   reference: string,
-  searchParams?: SearchParams,
+  searchParams?: SearchParamsComments,
 ): Promise<ApiResponse<DprSpecialistCommentsApiResponse | null>> {
   let url = `public/planning_applications/${reference}/comments/specialist`;
 

--- a/src/handlers/bops/v2/specialistComments.ts
+++ b/src/handlers/bops/v2/specialistComments.ts
@@ -37,24 +37,24 @@ import { defaultPagination } from "@/handlers/lib";
 export async function specialistComments(
   council: string,
   reference: string,
-  search?: SearchParams,
+  searchParams?: SearchParams,
 ): Promise<ApiResponse<DprSpecialistCommentsApiResponse | null>> {
   let url = `public/planning_applications/${reference}/comments/specialist`;
 
-  if (search) {
+  if (searchParams) {
     const params = new URLSearchParams({
-      page: search?.page?.toString(),
-      maxresults: search?.resultsPerPage?.toString() ?? "10",
+      page: searchParams?.page?.toString(),
+      maxresults: searchParams?.resultsPerPage?.toString() ?? "10",
     });
 
-    if (search.query) {
-      params.append("q", search.query);
+    if (searchParams.query) {
+      params.append("q", searchParams.query);
     }
-    if (search.sortBy) {
-      params.append("sortBy", search.sortBy);
+    if (searchParams.sortBy) {
+      params.append("sortBy", searchParams.sortBy);
     }
-    if (search.orderBy) {
-      params.append("orderBy", search.orderBy);
+    if (searchParams.orderBy) {
+      params.append("orderBy", searchParams.orderBy);
     }
     url = `${url}?${params.toString()}`;
   }
@@ -64,6 +64,7 @@ export async function specialistComments(
   >(council, url);
 
   if (!request.data) {
+    console.log("no data");
     return {
       ...request,
       data: null,

--- a/src/handlers/local/v1/index.ts
+++ b/src/handlers/local/v1/index.ts
@@ -20,12 +20,16 @@ import { applicationSubmission } from "./applicationSubmission";
 import { documents } from "./documents";
 import { postComment } from "./postComment";
 import { show } from "./show";
+import { publicComments } from "./publicComments";
+import { specialistComments } from "./specialistComments";
 
 import { documentation as searchDocumentation } from "./search.documentation";
 import { documentation as applicationSubmissionDocumentation } from "./applicationSubmission.documentation";
 import { documentation as documentsDocumentation } from "./documents.documentation";
 import { documentation as postCommentDocumentation } from "./postComment.documentation";
 import { documentation as showDocumentation } from "./show.documentation";
+import { documentation as publicCommentsDocumentation } from "./publicComments.documentation";
+import { documentation as specialistCommentsDocumentation } from "./specialistComments.documentation";
 
 import { Documentation } from "@/types";
 
@@ -40,6 +44,8 @@ const handlers: Record<string, HandlerFunction> = {
   documents,
   postComment,
   show,
+  publicComments,
+  specialistComments,
 };
 
 const documentations: Record<string, Documentation> = {
@@ -48,6 +54,8 @@ const documentations: Record<string, Documentation> = {
   documents: documentsDocumentation,
   postComment: postCommentDocumentation,
   show: showDocumentation,
+  publicComments: publicCommentsDocumentation,
+  specialistComments: specialistCommentsDocumentation,
 };
 
 export const LocalV1 = handlers;

--- a/src/handlers/local/v1/publicComments.documentation.tsx
+++ b/src/handlers/local/v1/publicComments.documentation.tsx
@@ -14,20 +14,29 @@
  * You should have received a copy of the GNU General Public License
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
+import { Documentation, SearchParamsComments } from "@/types";
+import { publicComments } from "./publicComments";
 
-export interface BopsComment {
-  id?: number;
-  comment: string;
-  receivedAt: string;
-  sentiment?: string;
-}
+export const documentation: Documentation = {
+  url: `/docs/json?handler=LocalV1&method=publicComments`,
+  file: `src/handlers/local/v1/publicComments.ts`,
+  description: "publicComments",
+  arguments: [
+    "source",
+    "council",
+    "reference",
+    "page",
+    "resultsPerPage",
+    "searchQuery",
+  ],
+  run: async (args: [string, string, SearchParamsComments]) => {
+    return await publicComments(...args);
+  },
 
-/**
- * Another one that goes along with the soon to be deprecated endpoint
- * @deprecated
- */
-interface BopsNonStandardComment {
-  comment: string;
-  received_at: string;
-  summary_tag?: string;
-}
+  examples: [
+    {
+      url: `/docs/json?handler=LocalV1&method=publicComments`,
+      description: "publicComments",
+    },
+  ],
+};

--- a/src/handlers/local/v1/publicComments.ts
+++ b/src/handlers/local/v1/publicComments.ts
@@ -1,0 +1,87 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+"use server";
+
+import { getAppConfig } from "@/config";
+import {
+  ApiResponse,
+  DprPublicCommentsApiResponse,
+  SearchParamsComments,
+} from "@/types";
+import {
+  generateNResults,
+  generateComment,
+} from "@mocks/dprApplicationFactory";
+
+const response = (
+  council: string,
+  reference: string,
+  searchParams: SearchParamsComments,
+): ApiResponse<DprPublicCommentsApiResponse> => {
+  const exampleComments = generateNResults(20, generateComment);
+  const sentimentSummary = exampleComments.reduce(
+    (acc, comment) => {
+      if (comment.sentiment === "supportive") {
+        acc.supportive++;
+      } else if (comment.sentiment === "objection") {
+        acc.objection++;
+      } else if (comment.sentiment === "neutral") {
+        acc.neutral++;
+      }
+      return acc;
+    },
+    { supportive: 0, objection: 0, neutral: 0 },
+  );
+  const appConfig = getAppConfig(council);
+  const resultsPerPage = appConfig?.defaults?.resultsPerPage || 10;
+  const currentPage = searchParams?.page || 1;
+  const startIndex = (currentPage - 1) * resultsPerPage;
+  const paginatedComments = exampleComments.slice(
+    startIndex,
+    startIndex + resultsPerPage,
+  );
+  const totalPages = Math.ceil(exampleComments.length / resultsPerPage);
+
+  return {
+    data: {
+      comments: paginatedComments,
+      summary: {
+        totalComments: exampleComments.length,
+        sentiment: sentimentSummary,
+      },
+    },
+    status: {
+      code: 200,
+      message: "Success",
+    },
+    pagination: {
+      resultsPerPage: resultsPerPage,
+      currentPage: currentPage,
+      totalPages: totalPages,
+      totalItems: exampleComments.length,
+    },
+  };
+};
+
+export const publicComments = (
+  council: string,
+  reference: string,
+  searchParams: SearchParamsComments,
+): Promise<ApiResponse<DprPublicCommentsApiResponse | null>> => {
+  return Promise.resolve(response(council, reference, searchParams));
+};

--- a/src/handlers/local/v1/specialistComments.documentation.tsx
+++ b/src/handlers/local/v1/specialistComments.documentation.tsx
@@ -15,19 +15,28 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-export interface BopsComment {
-  id?: number;
-  comment: string;
-  receivedAt: string;
-  sentiment?: string;
-}
+import { Documentation, SearchParamsComments } from "@/types";
+import { specialistComments } from "./specialistComments";
 
-/**
- * Another one that goes along with the soon to be deprecated endpoint
- * @deprecated
- */
-interface BopsNonStandardComment {
-  comment: string;
-  received_at: string;
-  summary_tag?: string;
-}
+export const documentation: Documentation = {
+  url: `/docs/json?handler=LocalV1&method=specialistComments`,
+  file: `src/handlers/local/v1/specialistComments.ts`,
+  description: "specialistComments",
+  arguments: [
+    "source",
+    "council",
+    "reference",
+    "page",
+    "resultsPerPage",
+    "searchQuery",
+  ],
+  run: async (args: [string, string, SearchParamsComments]) => {
+    return await specialistComments(...args);
+  },
+  examples: [
+    {
+      url: `/docs/json?handler=LocalV1&method=specialistComments`,
+      description: "specialistComments",
+    },
+  ],
+};

--- a/src/handlers/local/v1/specialistComments.ts
+++ b/src/handlers/local/v1/specialistComments.ts
@@ -1,0 +1,86 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+"use server";
+
+import { getAppConfig } from "@/config";
+import {
+  ApiResponse,
+  DprSpecialistCommentsApiResponse,
+  SearchParamsComments,
+} from "@/types";
+import {
+  generateNResults,
+  generateComment,
+} from "@mocks/dprApplicationFactory";
+
+const response = (
+  council: string,
+  reference: string,
+  searchParams: SearchParamsComments,
+): ApiResponse<DprSpecialistCommentsApiResponse> => {
+  const exampleComments = generateNResults(20, generateComment);
+  const sentimentSummary = exampleComments.reduce(
+    (acc, comment) => {
+      if (comment.sentiment === "supportive") {
+        acc.supportive++;
+      } else if (comment.sentiment === "objection") {
+        acc.objection++;
+      } else if (comment.sentiment === "neutral") {
+        acc.neutral++;
+      }
+      return acc;
+    },
+    { supportive: 0, objection: 0, neutral: 0 },
+  );
+  const appConfig = getAppConfig(council);
+  const resultsPerPage = appConfig?.defaults?.resultsPerPage || 10;
+  const currentPage = searchParams?.page || 1;
+  const startIndex = (currentPage - 1) * resultsPerPage;
+  const paginatedComments = exampleComments.slice(
+    startIndex,
+    startIndex + resultsPerPage,
+  );
+  const totalPages = Math.ceil(exampleComments.length / resultsPerPage);
+  return {
+    data: {
+      comments: paginatedComments,
+      summary: {
+        totalConsulted: exampleComments.length + 5,
+        totalComments: exampleComments.length,
+        sentiment: sentimentSummary,
+      },
+    },
+    status: {
+      code: 200,
+      message: "Success",
+    },
+    pagination: {
+      resultsPerPage: resultsPerPage,
+      currentPage: currentPage,
+      totalPages: totalPages,
+      totalItems: exampleComments.length,
+    },
+  };
+};
+
+export const specialistComments = (
+  council: string,
+  reference: string,
+  searchParams: SearchParamsComments,
+): Promise<ApiResponse<DprSpecialistCommentsApiResponse | null>> => {
+  return Promise.resolve(response(council, reference, searchParams));
+};

--- a/src/types/definitions.d.ts
+++ b/src/types/definitions.d.ts
@@ -213,6 +213,7 @@ export interface DprDocument {
  */
 export type DprCommentTypes = "specialist" | "public";
 export interface DprComment {
+  id?: number;
   comment: string;
   /**
    * 2024-05-30T14:23:21.936Z

--- a/src/types/schemas.d.ts
+++ b/src/types/schemas.d.ts
@@ -21,13 +21,21 @@
  * show
  * documents
  * applicationSubmission
+ * postComment
+ * publicComments
+ * specialistComments
  */
 import {
   DprPlanningApplication,
   DprDocument,
+  DprComment,
   DprApplication,
 } from "./definitions";
 import { DprApplicationSubmissionData } from "./applicationSubmission";
+import {
+  PublicCommentSummary,
+  SpecialistCommentSummary,
+} from "./odp-types/schemas/postSubmissionApplication/data/CommentSummary";
 
 /**
  * /api/search
@@ -63,4 +71,23 @@ export interface DprApplicationSubmissionApiResponse {
 export type DprApplicationPostCommentApiResponse = {
   id?: string;
   message: string;
+};
+
+/**
+ * /api/comments/public
+ * Public comments for a single application
+ */
+
+export type DprPublicCommentsApiResponse = {
+  comments: DprComment[];
+  summary: PublicCommentSummary;
+};
+
+/**
+ * /api/comments/specialist
+ * Specialist comments for a single application
+ */
+export type DprSpecialistCommentsApiResponse = {
+  comments: DprComment[];
+  summary: SpecialistCommentSummary;
 };

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -62,6 +62,8 @@ export interface SearchParams {
   query?: string;
   page: number;
   resultsPerPage: number;
+  sortBy?: string;
+  orderBy?: string;
 }
 export type SearchParamsDocuments = SearchParams;
 export interface SearchParamsComments extends SearchParams {


### PR DESCRIPTION
[Ticket 987](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?assignee=62a6f3cb6085950068acebf7&selectedIssue=DSNPI-897)

This PR creates new handlers for the new comment endpoints we will be switching to.

Handlers:
- local handler and documentation for /docs/json
- bops handler and documentation for /docs/json

New ApiV1 endpoints for public and specialist comment handlers in the actions API folder (includes documentation for /docs/json).


To test locally:
- run bops locally on the new comments endpoint branch, create applications with specialist and public comments.
- point DPR to bops. If using Southwark, enable public/specialist comments in the /config/index.ts file so they show on DPR.
- go to the URLs in the .documentation files in the handlers, replacing the reference number with the one generated in your local bops.