### PR TITLE
Add new tracking system into DPR

### DIFF
--- a/__tests__/components/comment_check_answer.test.tsx
+++ b/__tests__/components/comment_check_answer.test.tsx
@@ -20,9 +20,9 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { ApiV1 } from "@/actions/api";
 import CommentCheckAnswer from "@/components/comment_check_answer";
 import "@testing-library/jest-dom";
-import { sendGTMEvent } from "@next/third-parties/google";
 import { createAppConfig } from "@mocks/appConfigFactory";
 import { getAppConfig } from "@/config";
+import { trackClient } from "@/lib/dprAnalytics";
 
 jest.mock("@/actions/api", () => ({
   ApiV1: {
@@ -30,12 +30,12 @@ jest.mock("@/actions/api", () => ({
   },
 }));
 
-jest.mock("@next/third-parties/google", () => ({
-  sendGTMEvent: jest.fn(),
-}));
-
 jest.mock("@/config", () => ({
   getAppConfig: jest.fn(),
+}));
+
+jest.mock("@/lib/dprAnalytics", () => ({
+  trackClient: jest.fn(),
 }));
 
 beforeAll(() => {
@@ -164,7 +164,7 @@ describe("CommentCheckAnswer", () => {
         "REF-001",
         expect.any(Object),
       );
-      expect(sendGTMEvent).toHaveBeenCalledWith({ event: "comment_submit" });
+      expect(trackClient).toHaveBeenCalledWith("comment_submit");
       expect(defaultProps.updateProgress).toHaveBeenCalledWith(5);
       expect(defaultProps.navigateToPage).toHaveBeenCalledWith(6);
       expect(sessionStorage.getItem("sentiment_REF-001")).toBeNull();
@@ -185,7 +185,7 @@ describe("CommentCheckAnswer", () => {
       expect(
         screen.getByText("There was a problem submitting your comment"),
       ).toBeInTheDocument();
-      expect(sendGTMEvent).toHaveBeenCalledWith({ event: "error_submission" });
+      expect(trackClient).toHaveBeenCalledWith("error_submission");
       expect(defaultProps.updateProgress).not.toHaveBeenCalled();
       expect(defaultProps.navigateToPage).not.toHaveBeenCalled();
     });

--- a/__tests__/components/comment_personal_details.test.tsx
+++ b/__tests__/components/comment_personal_details.test.tsx
@@ -19,11 +19,11 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import CommentPersonalDetails from "@/components/comment_personal_details";
 import "@testing-library/jest-dom";
-import { sendGTMEvent } from "@next/third-parties/google";
 import { createAppConfig } from "@mocks/appConfigFactory";
+import { trackClient } from "@/lib/dprAnalytics";
 
-jest.mock("@next/third-parties/google", () => ({
-  sendGTMEvent: jest.fn(),
+jest.mock("@/lib/dprAnalytics", () => ({
+  trackClient: jest.fn(),
 }));
 
 describe("CommentPersonalDetails", () => {
@@ -69,8 +69,7 @@ describe("CommentPersonalDetails", () => {
     ).toBeInTheDocument();
     expect(defaultProps.navigateToPage).not.toHaveBeenCalled();
     expect(defaultProps.updateProgress).not.toHaveBeenCalled();
-    expect(sendGTMEvent).toHaveBeenCalledWith({
-      event: "comment_validation_error",
+    expect(trackClient).toHaveBeenCalledWith("comment_validation_error", {
       message: "error in personal details",
     });
   });
@@ -128,6 +127,6 @@ describe("CommentPersonalDetails", () => {
     expect(screen.getByLabelText("Telephone number")).toHaveValue(
       "09876543210",
     );
-    expect(sendGTMEvent).not.toHaveBeenCalled();
+    expect(trackClient).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/components/comment_sentiment.test.tsx
+++ b/__tests__/components/comment_sentiment.test.tsx
@@ -19,10 +19,10 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import CommentSentiment from "@/components/comment_sentiment";
 import "@testing-library/jest-dom";
-import { sendGTMEvent } from "@next/third-parties/google";
+import { trackClient } from "@/lib/dprAnalytics";
 
-jest.mock("@next/third-parties/google", () => ({
-  sendGTMEvent: jest.fn(),
+jest.mock("@/lib/dprAnalytics", () => ({
+  trackClient: jest.fn(),
 }));
 
 describe("CommentSentiment", () => {
@@ -61,8 +61,7 @@ describe("CommentSentiment", () => {
     expect(screen.getByText("Please select an option")).toBeInTheDocument();
     expect(defaultProps.navigateToPage).not.toHaveBeenCalled();
     expect(defaultProps.updateProgress).not.toHaveBeenCalled();
-    expect(sendGTMEvent).toHaveBeenCalledWith({
-      event: "comment_validation_error",
+    expect(trackClient).toHaveBeenCalledWith("comment_validation_error", {
       message: "error in sentiment",
     });
   });

--- a/__tests__/components/comment_text_entry.test.tsx
+++ b/__tests__/components/comment_text_entry.test.tsx
@@ -19,11 +19,10 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import CommentTextEntry from "@/components/comment_text_entry";
 import "@testing-library/jest-dom";
-import { sendGTMEvent } from "@next/third-parties/google";
+import { trackClient } from "@/lib/dprAnalytics";
 
-// Mock sendGTMEvent to track its calls
-jest.mock("@next/third-parties/google", () => ({
-  sendGTMEvent: jest.fn(),
+jest.mock("@/lib/dprAnalytics", () => ({
+  trackClient: jest.fn(),
 }));
 
 describe("CommentTextEntry", () => {
@@ -63,8 +62,7 @@ describe("CommentTextEntry", () => {
     expect(screen.getByText("Your comment is required")).toBeInTheDocument();
     expect(defaultProps.onContinue).not.toHaveBeenCalled();
     expect(defaultProps.updateProgress).not.toHaveBeenCalled();
-    expect(sendGTMEvent).toHaveBeenCalledWith({
-      event: "comment_validation_error",
+    expect(trackClient).toHaveBeenCalledWith("comment_validation_error", {
       message: "error in comment text entry",
     });
   });

--- a/__tests__/components/comment_topic_selection.test.tsx
+++ b/__tests__/components/comment_topic_selection.test.tsx
@@ -19,11 +19,10 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import CommentTopicSelection from "@/components/comment_topic_selection";
 import "@testing-library/jest-dom";
-import { sendGTMEvent } from "@next/third-parties/google"; // Import the GTM event mock
+import { trackClient } from "@/lib/dprAnalytics";
 
-// Mock sendGTMEvent to track its calls
-jest.mock("@next/third-parties/google", () => ({
-  sendGTMEvent: jest.fn(),
+jest.mock("@/lib/dprAnalytics", () => ({
+  trackClient: jest.fn(),
 }));
 
 describe("CommentTopicSelection", () => {
@@ -68,8 +67,7 @@ describe("CommentTopicSelection", () => {
     ).toBeInTheDocument();
     expect(defaultProps.onTopicSelection).not.toHaveBeenCalled();
     expect(defaultProps.updateProgress).not.toHaveBeenCalled();
-    expect(sendGTMEvent).toHaveBeenCalledWith({
-      event: "comment_validation_error",
+    expect(trackClient).toHaveBeenCalledWith("comment_validation_error", {
       message: "error in topic selection",
     });
   });

--- a/src/actions/cookies.ts
+++ b/src/actions/cookies.ts
@@ -18,6 +18,20 @@
 "use server";
 import { cookies } from "next/headers";
 
+/**
+ * Checks for cookie consent from user
+ * @returns true if the user has accepted cookies, false otherwise
+ */
+export async function checkCookieConsent(): Promise<boolean> {
+  const cookieStore = cookies();
+  const consentCookie = cookieStore.get("consentCookie");
+  const acceptAnalytics = consentCookie?.value === "true";
+  return acceptAnalytics;
+}
+
+/**
+ * Sets the consent cookie
+ */
 export async function setConsentCookie(value: boolean) {
   const cookieStore = cookies();
   cookieStore.set("consentCookie", value.toString(), {
@@ -27,6 +41,9 @@ export async function setConsentCookie(value: boolean) {
   });
 }
 
+/**
+ * Clears the analytics cookies
+ */
 export async function clearAnalyticsCookies() {
   const cookieStore = cookies();
   cookieStore.getAll().forEach((cookie) => {
@@ -39,4 +56,24 @@ export async function clearAnalyticsCookies() {
       cookieStore.delete(cookie.name);
     }
   });
+}
+
+/**
+ * Gets the ClientId from the _ga cookie, used for Server side Google Analytics
+ * @returns the client ID from the _ga cookie
+ */
+export async function getClientIdFromCookies() {
+  const cookieStore = cookies();
+  const gaCookie = cookieStore.get("_ga")?.value;
+  if (!gaCookie) {
+    throw new Error("Google Analytics (_ga) cookie is missing.");
+  }
+
+  const match = gaCookie.match(/^GA\d+\.\d+\.(\d+\.\d+)$/);
+
+  if (!match) {
+    throw new Error("Invalid _ga cookie format.");
+  }
+
+  return match[1];
 }

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -15,4 +15,4 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-export * from "./set-cookies";
+export * from "./cookies";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,8 +21,7 @@ import { CookieBanner } from "@/components/CookieBanner";
 import { SkipLink } from "@/components/govuk/SkipLink";
 import { GovUkInitAll } from "@/components/GovUkInitAll";
 import { Metadata } from "next";
-import { GoogleTagManager, GoogleAnalytics } from "@next/third-parties/google";
-import { cookies } from "next/headers";
+import { DprAnalytics } from "@/lib/dprAnalytics";
 
 export function generateMetadata(): Metadata {
   const title = "Digital Planning Register";
@@ -57,11 +56,10 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const consentCookie = cookies().get("consentCookie");
-  const acceptAnalytics = consentCookie?.value === "true";
   return (
     <html lang="en" className="govuk-template">
       <body className={`govuk-template__body`}>
+        <DprAnalytics />
         <noscript>
           <div className="govuk-visually-hidden" id="js-disabled-notification">
             You have disabled javascript on this page
@@ -71,12 +69,6 @@ export default async function RootLayout({
         <SkipLink href="#main" />
         {children}
         <GovUkInitAll />
-        {acceptAnalytics && (
-          <>
-            {process.env.GTM && <GoogleTagManager gtmId={process.env.GTM} />}
-            {process.env.GA && <GoogleAnalytics gaId={process.env.GA} />}
-          </>
-        )}
       </body>
     </html>
   );

--- a/src/components/ApplicationMap/ApplicationMap.tsx
+++ b/src/components/ApplicationMap/ApplicationMap.tsx
@@ -18,8 +18,8 @@
 "use client";
 import { DprBoundaryGeojson } from "@/types";
 import { useState, useEffect } from "react";
-import { sendGTMEvent } from "@next/third-parties/google";
 import { determineMapTypeProps } from "./utils";
+import { trackClient } from "@/lib/dprAnalytics";
 
 export interface ApplicationMapProps {
   reference: string;
@@ -60,9 +60,7 @@ export interface ApplicationMapProps {
 
 export const handleScroll = () => {
   // console.log("scrolling");
-  sendGTMEvent({
-    event: "map-scroll",
-  });
+  trackClient("map-scroll");
 };
 
 export const ApplicationMap = ({

--- a/src/components/comment_check_answer/index.tsx
+++ b/src/components/comment_check_answer/index.tsx
@@ -19,7 +19,6 @@
 import React, { useEffect, useState } from "react";
 import { Button } from "@/components/button";
 import { ApiV1 } from "@/actions/api";
-import { sendGTMEvent } from "@next/third-parties/google";
 import { AppConfig } from "@/config/types";
 import "./CommentCheckAnswer.scss";
 import { Details } from "../govukDpr/Details";
@@ -29,6 +28,7 @@ import { PersonalDetails } from "../comment_personal_details";
 import { DprCommentSubmission } from "@/types";
 import { CommentSentiment } from "@/types/odp-types/schemas/postSubmissionApplication/enums/CommentSentiment";
 import { CommentTopic } from "@/types/odp-types/schemas/postSubmissionApplication/enums/CommentTopic";
+import { trackClient } from "@/lib/dprAnalytics";
 
 const topics_selection = [
   {
@@ -146,9 +146,7 @@ const CommentCheckAnswer = ({
     setSubmissionError(false);
 
     if (!personalDetails) {
-      sendGTMEvent({
-        event: "error_submission",
-      });
+      trackClient("error_submission");
       setSubmissionError(true);
       window.scrollTo(0, 0);
       return false;
@@ -181,7 +179,7 @@ const CommentCheckAnswer = ({
         if (response?.status?.code === 200) {
           sessionStorage.setItem(`submissionComplete_${reference}`, "true");
           // google analytic
-          sendGTMEvent({ event: "comment_submit" });
+          trackClient("comment_submit");
 
           // Clear all other sessionStorage items for this reference
           Object.keys(sessionStorage).forEach((key) => {
@@ -195,16 +193,12 @@ const CommentCheckAnswer = ({
           updateProgress(5); // Update progress to allow access to confirmation page and redirect to it
           navigateToPage(6);
         } else {
-          sendGTMEvent({
-            event: "error_submission",
-          });
+          trackClient("error_submission");
           throw new Error(`Submission failed ${response.status.detail}`);
         }
       }
     } catch (error) {
-      sendGTMEvent({
-        event: "error_submission",
-      });
+      trackClient("error_submission");
       console.error("Error submitting comment:", error);
       setSubmissionError(true);
       window.scrollTo(0, 0);

--- a/src/components/comment_personal_details/index.tsx
+++ b/src/components/comment_personal_details/index.tsx
@@ -18,10 +18,10 @@
 "use client";
 import React, { useEffect, useRef, useState } from "react";
 import { emailValidation, phoneValidation, postcodeValidation } from "@/util";
-import { sendGTMEvent } from "@next/third-parties/google";
 import { AppConfig } from "@/config/types";
 import { Details } from "../govukDpr/Details";
 import { Button } from "@/components/button";
+import { trackClient } from "@/lib/dprAnalytics";
 
 type PersonalDetailKeys = keyof PersonalDetails;
 export interface PersonalDetails {
@@ -168,8 +168,7 @@ const CommentPersonalDetails = ({
       return true;
     } else {
       setValidationErrors(errors);
-      sendGTMEvent({
-        event: "comment_validation_error",
+      trackClient("comment_validation_error", {
         message: "error in personal details",
       });
       scrollToError(errors);

--- a/src/components/comment_sentiment/index.tsx
+++ b/src/components/comment_sentiment/index.tsx
@@ -17,8 +17,8 @@
 
 "use client";
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { sendGTMEvent } from "@next/third-parties/google";
 import { sentiment_options } from "@/lib/comments";
+import { trackClient } from "@/lib/dprAnalytics";
 
 const CommentSentiment = ({
   reference,
@@ -77,8 +77,7 @@ const CommentSentiment = ({
         navigateToPage(nextPage);
       } else {
         setValidationError(true);
-        sendGTMEvent({
-          event: "comment_validation_error",
+        trackClient("comment_validation_error", {
           message: "error in sentiment",
         });
         scrollAndFocusError();

--- a/src/components/comment_text_entry/index.tsx
+++ b/src/components/comment_text_entry/index.tsx
@@ -17,9 +17,9 @@
 
 "use client";
 import React, { useEffect, useRef, useState } from "react";
-import { sendGTMEvent } from "@next/third-parties/google";
 import { Button } from "@/components/button";
 import { topicLabels, topicLabelsHint } from "@/lib/comments";
+import { trackClient } from "@/lib/dprAnalytics";
 
 const MAX_COMMENT_LENGTH = 6000;
 
@@ -111,8 +111,7 @@ const CommentTextEntry = ({
       onContinue();
     } else {
       setValidationError(true);
-      sendGTMEvent({
-        event: "comment_validation_error",
+      trackClient("comment_validation_error", {
         message: "error in comment text entry",
       });
       scrollAndFocusError();

--- a/src/components/comment_topic_selection/index.tsx
+++ b/src/components/comment_topic_selection/index.tsx
@@ -17,9 +17,9 @@
 
 "use client";
 import React, { useEffect, useRef, useState } from "react";
-import { sendGTMEvent } from "@next/third-parties/google";
 import { Details } from "../govukDpr/Details";
 import { Button } from "@/components/button";
+import { trackClient } from "@/lib/dprAnalytics";
 
 export const topics_selection = [
   {
@@ -117,8 +117,7 @@ const CommentTopicSelection = ({
       onTopicSelection(selectedTopics);
     } else {
       setValidationError(true);
-      sendGTMEvent({
-        event: "comment_validation_error",
+      trackClient("comment_validation_error", {
         message: "error in topic selection",
       });
       scrollAndFocusError();

--- a/src/handlers/bops/v2/postComment.ts
+++ b/src/handlers/bops/v2/postComment.ts
@@ -29,6 +29,7 @@ import {
 import { handleBopsGetRequest, handleBopsPostRequest } from "../requests";
 import { apiReturnError } from "@/handlers/lib";
 import { getAppConfig } from "@/config";
+import { trackServer } from "@/lib/dprAnalytics";
 
 /**
  * POST planning_applications/${id}/neighbour_responses
@@ -75,6 +76,10 @@ export async function postComment(
       postRequest.status.detail || "Failed to post comment",
     );
   }
+
+  await trackServer("commentSuccessfullySubmitted", {
+    message: `Comment for application ${reference} at ${council} successfully submitted`,
+  });
 
   return postRequest;
 }

--- a/src/lib/dprAnalytics/DprAnalytics.tsx
+++ b/src/lib/dprAnalytics/DprAnalytics.tsx
@@ -1,0 +1,20 @@
+import { checkCookieConsent } from "@/actions";
+import { GoogleTagManager } from "@next/third-parties/google";
+
+/**
+ * Loads the google tag manager if the user has accepted cookies.
+ * Google analytics is included in the google tag manager.
+ * @returns
+ */
+export async function DprAnalytics() {
+  const acceptAnalytics = await checkCookieConsent();
+  return (
+    <>
+      {acceptAnalytics && process.env.GTM && (
+        <GoogleTagManager gtmId={process.env.GTM} />
+      )}
+    </>
+  );
+}
+
+export default DprAnalytics;

--- a/src/lib/dprAnalytics/dprAnalytics.utils.ts
+++ b/src/lib/dprAnalytics/dprAnalytics.utils.ts
@@ -1,0 +1,80 @@
+/**
+ * MODE
+ */
+
+export type Mode = "auto" | "development" | "production";
+
+export function isBrowser(): boolean {
+  return typeof window !== "undefined";
+}
+
+export function isDevelopment(): boolean {
+  return getMode() === "development";
+}
+
+export function isProduction(): boolean {
+  return getMode() === "production";
+}
+
+export function getMode(): Mode {
+  const mode = detectEnvironment();
+  return mode || "production";
+}
+
+export function detectEnvironment(): "development" | "production" {
+  try {
+    const env = process.env.NODE_ENV;
+    if (env === "development" || env === "test") {
+      return "development";
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (e) {
+    // do nothing, this is okay
+  }
+  return "production";
+}
+
+/**
+ * Parse properties
+ */
+
+export type AllowedPropertyValues = string | number | boolean | null;
+
+export function parseProperties(
+  properties: Record<string, unknown> | undefined,
+  options: {
+    strip?: boolean;
+  },
+): Error | Record<string, AllowedPropertyValues> | undefined {
+  if (!properties) return undefined;
+  let props = properties;
+  const errorProperties: string[] = [];
+  for (const [key, value] of Object.entries(properties)) {
+    if (typeof value === "object" && value !== null) {
+      if (options.strip) {
+        props = removeKey(key, props);
+      } else {
+        errorProperties.push(key);
+      }
+    }
+  }
+
+  if (errorProperties.length > 0 && !options.strip) {
+    throw Error(
+      `The following properties are not valid: ${errorProperties.join(
+        ", ",
+      )}. Only strings, numbers, booleans, and null are allowed.`,
+    );
+  }
+  return props as Record<string, AllowedPropertyValues>;
+}
+
+/**
+ * Remove key from object
+ */
+export function removeKey(
+  key: string,
+  { [key]: _, ...rest },
+): Record<string, unknown> {
+  return rest;
+}

--- a/src/lib/dprAnalytics/index.ts
+++ b/src/lib/dprAnalytics/index.ts
@@ -1,0 +1,4 @@
+export * from "./DprAnalytics";
+export * from "./dprAnalytics.utils";
+export * from "./trackClient";
+export * from "./trackServer";

--- a/src/lib/dprAnalytics/trackClient.ts
+++ b/src/lib/dprAnalytics/trackClient.ts
@@ -1,0 +1,54 @@
+import { checkCookieConsent } from "@/actions";
+import {
+  AllowedPropertyValues,
+  isBrowser,
+  isDevelopment,
+  isProduction,
+  parseProperties,
+} from ".";
+import { sendGTMEvent } from "@next/third-parties/google";
+
+/**
+ * Call this to track an event on the client-side.
+ * @param eventName
+ * @param properties
+ * @returns
+ */
+export async function trackClient(
+  eventName: string,
+  properties?: Record<string, AllowedPropertyValues>,
+): Promise<void> {
+  if (!isBrowser()) {
+    const msg =
+      "Please use trackServer in server-side code. This function is only available in the browser.";
+
+    if (isProduction()) {
+      // eslint-disable-next-line no-console -- Show warning in production
+      console.warn(msg);
+    } else {
+      throw new Error(msg);
+    }
+
+    return;
+  }
+
+  const acceptAnalytics = await checkCookieConsent();
+  if (!acceptAnalytics) {
+    return;
+  }
+
+  const props = parseProperties(properties, {
+    strip: isProduction(),
+  });
+
+  if (props instanceof Error) {
+    throw props;
+  }
+
+  if (isDevelopment()) {
+    console.log("trackClientEvent", eventName, props);
+  }
+
+  // send event to gtm
+  sendGTMEvent({ event: eventName, ...props });
+}

--- a/src/lib/dprAnalytics/trackServer.ts
+++ b/src/lib/dprAnalytics/trackServer.ts
@@ -1,0 +1,73 @@
+"use server";
+import { checkCookieConsent, getClientIdFromCookies } from "@/actions";
+import { AllowedPropertyValues, isProduction, parseProperties } from ".";
+
+export async function trackServer(
+  eventName: string,
+  properties?: Record<string, AllowedPropertyValues>,
+): Promise<void> {
+  if (typeof window !== "undefined") {
+    if (!isProduction()) {
+      throw new Error(
+        `Please use trackServer in a server component. This function is only available in a server environment.`,
+      );
+    }
+
+    return;
+  }
+
+  const acceptAnalytics = await checkCookieConsent();
+  if (!acceptAnalytics) {
+    return;
+  }
+
+  const props = parseProperties(properties, {
+    strip: isProduction(),
+  });
+
+  // push the event to the analytics endpoint through GA4 server
+
+  if (!isProduction()) {
+    console.log("trackServerEvent", eventName, props);
+  }
+
+  let clientId;
+  try {
+    clientId = await getClientIdFromCookies();
+  } catch (err) {
+    if (!isProduction()) {
+      console.error(err);
+    }
+    return;
+  }
+
+  const body = {
+    client_id: clientId,
+    events: [
+      {
+        name: eventName,
+        params: props,
+      },
+    ],
+  };
+
+  const debug = false;
+  const url = `https://www.google-analytics.com/${debug ? "debug/" : ""}mp/collect?measurement_id=${process.env.GA}&api_secret=${process.env.GA_API_SECRET}`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    console.error("Failed to send event to GA4:", response.statusText);
+  }
+
+  if (debug) {
+    const result = await response.json();
+    console.log(result);
+  }
+}


### PR DESCRIPTION
This PR moves the sendGTM call into into the DprAnalytics library - the intention being we can now send events to the client and the server and also add in custom tracking that may not require cookies - ie the site notices (coming soon!) Also it double checks for cookie consent before sending!

nb the new `GA_API_SECRET` variable is in the 1password