### PR TITLE
FIX: generatePagination sometimes returning unpredictable results

### DIFF
--- a/__mocks__/dprApplicationFactory.ts
+++ b/__mocks__/dprApplicationFactory.ts
@@ -30,7 +30,7 @@ import { AppealDecision } from "@/types/odp-types/schemas/postSubmissionApplicat
 import { ApplicationType } from "@/types/odp-types/schemas/prototypeApplication/enums/ApplicationType";
 import { formatDateToYmd } from "@/util";
 
-import { faker, fakerEN_GB } from "@faker-js/faker";
+import { faker } from "@faker-js/faker";
 import {
   generateAgent,
   generateBaseApplicant,
@@ -98,20 +98,11 @@ export const generateDocument = (): DprDocument => {
  * @returns {object} A random pagination object.
  */
 export const generatePagination = (
-  currentPage?: number,
-  totalResults?: number,
+  currentPage: number,
+  totalResults: number,
+  resultsPerPage: number = 10,
 ): DprPagination => {
-  totalResults = totalResults ?? faker.number.int({ min: 10, max: 500 });
-  const resultsPerPage = 10;
   const totalPages = Math.ceil(totalResults / resultsPerPage);
-
-  if (
-    currentPage === undefined ||
-    currentPage < 1 ||
-    currentPage > totalPages
-  ) {
-    currentPage = faker.number.int({ min: 1, max: totalPages || 1 });
-  }
 
   return {
     resultsPerPage,

--- a/__tests__/mocks/dprApplicationFactory.test.ts
+++ b/__tests__/mocks/dprApplicationFactory.test.ts
@@ -96,7 +96,7 @@ describe("generateDocument", () => {
 
 describe("generatePagination", () => {
   it("should generate pagination data with the correct structure", () => {
-    const pagination = generatePagination();
+    const pagination = generatePagination(1, 100);
     expect(pagination).toHaveProperty("resultsPerPage");
     expect(pagination).toHaveProperty("currentPage");
     expect(pagination).toHaveProperty("totalPages");
@@ -104,13 +104,13 @@ describe("generatePagination", () => {
   });
 
   it("should generate pagination data with the correct values when current page provided", () => {
-    const pagination = generatePagination(5);
+    const pagination = generatePagination(5, 100);
     expect(pagination.currentPage).toBe(5);
   });
 
   it("should generate different pagination data on subsequent calls", () => {
-    const pagination1 = generatePagination();
-    const pagination2 = generatePagination();
+    const pagination1 = generatePagination(1, 100);
+    const pagination2 = generatePagination(2, 100);
     expect(pagination1).not.toEqual(pagination2);
   });
 });

--- a/src/components/PageApplicationComments/PageApplicationComments.stories.tsx
+++ b/src/components/PageApplicationComments/PageApplicationComments.stories.tsx
@@ -26,6 +26,7 @@ import { DprComment } from "@/types";
 import { createAppConfig } from "@mocks/appConfigFactory";
 import { generateDprApplication } from "@mocks/dprNewApplicationFactory";
 
+const comments = generateNResults<DprComment>(50, generateComment);
 const meta = {
   title: "Council pages/Application comments",
   component: PageApplicationComments,
@@ -51,8 +52,8 @@ const meta = {
   args: {
     reference: "12345",
     application: generateDprApplication(),
-    comments: generateNResults<DprComment>(50, generateComment),
-    pagination: generatePagination(1),
+    comments: comments,
+    pagination: generatePagination(1, comments.length),
     appConfig: createAppConfig("public-council-1"),
     type: "public",
   },
@@ -80,19 +81,16 @@ export const NoComments: Story = {
 };
 export const FirstPage: Story = {
   args: {
-    comments: generateNResults<DprComment>(30, generateComment),
-    pagination: generatePagination(1),
+    pagination: generatePagination(1, comments.length),
   },
 };
 export const SecondPage: Story = {
   args: {
-    comments: generateNResults<DprComment>(30, generateComment),
-    pagination: generatePagination(2),
+    pagination: generatePagination(2, comments.length),
   },
 };
 export const ThirdPage: Story = {
   args: {
-    comments: generateNResults<DprComment>(30, generateComment),
-    pagination: generatePagination(3),
+    pagination: generatePagination(3, comments.length),
   },
 };

--- a/src/components/PageApplicationDocuments/PageApplicationDocuments.stories.tsx
+++ b/src/components/PageApplicationDocuments/PageApplicationDocuments.stories.tsx
@@ -26,6 +26,8 @@ import { DprDocument } from "@/types";
 import { createAppConfig } from "@mocks/appConfigFactory";
 import { generateDprApplication } from "@mocks/dprNewApplicationFactory";
 
+const documents = generateNResults<DprDocument>(50, generateDocument);
+
 const meta = {
   title: "Council pages/Application documents",
   component: PageApplicationDocuments,
@@ -51,8 +53,8 @@ const meta = {
   args: {
     reference: "12345",
     application: generateDprApplication(),
-    documents: generateNResults<DprDocument>(50, generateDocument),
-    pagination: generatePagination(1),
+    documents: documents,
+    pagination: generatePagination(1, documents.length),
     appConfig: createAppConfig("public-council-1"),
   },
 } satisfies Meta<typeof PageApplicationDocuments>;
@@ -69,19 +71,16 @@ export const NoDocuments: Story = {
 };
 export const FirstPage: Story = {
   args: {
-    documents: generateNResults<DprDocument>(50, generateDocument),
-    pagination: generatePagination(1),
+    pagination: generatePagination(1, documents.length),
   },
 };
 export const SecondPage: Story = {
   args: {
-    documents: generateNResults<DprDocument>(50, generateDocument),
-    pagination: generatePagination(2),
+    pagination: generatePagination(2, documents.length),
   },
 };
 export const ThirdPage: Story = {
   args: {
-    documents: generateNResults<DprDocument>(50, generateDocument),
-    pagination: generatePagination(3),
+    pagination: generatePagination(3, documents.length),
   },
 };

--- a/src/handlers/local/v1/documents.ts
+++ b/src/handlers/local/v1/documents.ts
@@ -66,7 +66,7 @@ const responseQuery = (
 
   return {
     data: documents,
-    pagination: generatePagination(searchParams?.page ?? 1),
+    pagination: generatePagination(searchParams?.page ?? 1, documents.length),
     status: {
       code: 200,
       message: "",

--- a/src/handlers/local/v1/search.ts
+++ b/src/handlers/local/v1/search.ts
@@ -53,7 +53,10 @@ const responseQuery = (
     appealDetermined,
     withdrawn,
   ];
-  let pagination = generatePagination(searchParams?.page, resultsPerPage * 5);
+  let pagination = generatePagination(
+    searchParams?.page ?? 1,
+    resultsPerPage * 5,
+  );
 
   // if we've done a search just rename the first result to match the query
   if (searchParams?.query) {


### PR DESCRIPTION
The generatePagination method could sometimes cause tests to fail since its relying on a random number for totalResults.

I've updated the method to optionally take resultsPerPage bit it now requires current page and total results.
