### PR TITLE
FIX: Consultation can sometimes fall too recently for the tests

### DIFF
--- a/__mocks__/dprNewApplicationFactory.ts
+++ b/__mocks__/dprNewApplicationFactory.ts
@@ -98,7 +98,10 @@ type PossibleDates = {
 export const generateAllPossibleDates = (
   consultationInProgress: boolean = false,
 ): PossibleDates => {
-  let startDate = faker.date.past({ years: 10 });
+  let startDate = faker.date.past({
+    years: 10,
+    refDate: dayjs().subtract(2, "year").toDate(),
+  });
   if (consultationInProgress) {
     startDate = dayjs()
       .subtract(1, "day")


### PR DESCRIPTION
Another intermittent test issue - the startDate in generateAllPossibleDates is randomly anytime in the last 10 years this means that occasionally the consultation dates fall right now causing tests to fail


<img width="639" alt="image" src="https://github.com/user-attachments/assets/d923921c-585b-423b-a8f6-431271fce2ab" />
