### PR TITLE
Dsnpi 574/filter by sentiment and published date

### DIFF
--- a/__tests__/components/PageApplicationComments.test.tsx
+++ b/__tests__/components/PageApplicationComments.test.tsx
@@ -49,4 +49,80 @@ describe("PageApplicationComments", () => {
     const comment = screen.getByText(`Comment #${comments[0].id.toString()}`);
     expect(comment).toBeInTheDocument();
   });
+  it("renders sortBy", async () => {
+    const appConfig = createAppConfig("public-council-1");
+    const comments = generateNResults<DprComment>(10, () => generateComment());
+    const pagination = generatePagination(1, 10);
+    const application = generateApplicationSubmission;
+
+    render(
+      <PageApplicationComments
+        reference="123"
+        comments={comments}
+        application={application}
+        appConfig={appConfig}
+        params={{ council: "public-council-1", reference: "123" }}
+        type="public"
+        pagination={pagination}
+        searchParams={{
+          page: 1,
+          resultsPerPage: 10,
+          orderBy: "asc",
+          publishedAtFrom: "2023-01-01",
+          publishedAtTo: "2023-12-31",
+        }}
+      />,
+    );
+
+    // Comment is rendered
+    expect(
+      screen.getByText(`Comment #${comments[0].id.toString()}`),
+    ).toBeInTheDocument();
+
+    // Date filter inputs
+    expect(screen.getByDisplayValue("2023-01-01")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("2023-12-31")).toBeInTheDocument();
+
+    // orderBy (Sort order)
+    expect(screen.getByLabelText("Sort by")).toHaveValue("asc");
+
+    // sortBy dropdown (you'll need to ensure this input exists in your form)
+    const sortBy = screen.getByRole("combobox", {
+      name: /sort by/i,
+    });
+    expect(sortBy).toHaveValue("asc");
+  });
+
+  it("renders comments and shows selected sentiment in filter", async () => {
+    const appConfig = createAppConfig("public-council-1");
+    const comments = generateNResults<DprComment>(10, () => generateComment());
+    const pagination = generatePagination(1, 10);
+    const application = generateApplicationSubmission;
+
+    render(
+      <PageApplicationComments
+        reference="123"
+        comments={comments}
+        application={application}
+        appConfig={appConfig}
+        params={{ council: "public-council-1", reference: "123" }}
+        type="public"
+        pagination={pagination}
+        searchParams={{
+          page: 1,
+          resultsPerPage: 10,
+          sentiment: "neutral",
+        }}
+      />,
+    );
+
+    // Check a comment renders
+    expect(
+      screen.getByText(`Comment #${comments[0].id.toString()}`),
+    ).toBeInTheDocument();
+
+    // Check sentiment filter is set correctly
+    const sentimentSelect = screen.getByLabelText("Sentiment");
+    expect(sentimentSelect).toHaveValue("neutral");
+  });
 });

--- a/src/components/ContentNoResult/ContentNoResult.tsx
+++ b/src/components/ContentNoResult/ContentNoResult.tsx
@@ -20,13 +20,19 @@ import { AppConfig } from "@/config/types";
 
 interface ContentNoResultProps {
   councilConfig?: AppConfig["council"];
+  isCommentPage?: boolean;
 }
 
-export const ContentNoResult = ({ councilConfig }: ContentNoResultProps) => {
+export const ContentNoResult = ({
+  councilConfig,
+  isCommentPage = false,
+}: ContentNoResultProps) => {
   return (
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-full">
-        <h2 className="govuk-heading-s">No applications match your search</h2>
+        <h2 className="govuk-heading-s">
+          No {isCommentPage ? "comments" : "applications"} match your search
+        </h2>
         {councilConfig?.slug && (
           <p className="govuk-body">
             You can try searching again, or{" "}

--- a/src/components/FormCommentsSort/FormCommentsSort.scss
+++ b/src/components/FormCommentsSort/FormCommentsSort.scss
@@ -15,10 +15,16 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
  
+ @import "src/styles/component-base";
+
 .dpr-comment-filter {
     &__button {
          width: auto
   }
+    &__to-label {
+      display: inline-block;
+      margin: govuk-spacing(0) govuk-spacing(1) govuk-spacing(4) govuk-spacing(1);
+    }
 }
 
 .drp-dropdown {

--- a/src/components/FormCommentsSort/FormCommentsSort.stories.ts
+++ b/src/components/FormCommentsSort/FormCommentsSort.stories.ts
@@ -41,3 +41,24 @@ export const OldestFirst: Story = {
     defaultOrderBy: "asc",
   },
 };
+
+export const SupportiveSentiment: Story = {
+  args: {
+    defaultSentiment: "supportive",
+  },
+};
+
+export const ObjectionSentimentWithDateRange: Story = {
+  args: {
+    defaultSentiment: "objection",
+    defaultPublishedAtFrom: "2023-01-01",
+    defaultPublishedAtTo: "2023-12-31",
+  },
+};
+
+export const NeutralSentimentSortedAsc: Story = {
+  args: {
+    defaultSentiment: "neutral",
+    defaultOrderBy: "asc",
+  },
+};

--- a/src/components/FormCommentsSort/FormCommentsSort.tsx
+++ b/src/components/FormCommentsSort/FormCommentsSort.tsx
@@ -69,7 +69,7 @@ export const FormCommentsSort = ({
         <div className="govuk-grid-row govuk-!-margin-left-0">
           <div className="govuk-grid-column-one-third">
             <div className="govuk-form-group">
-              <label htmlFor="sortOrder" className="govuk-label">
+              <label htmlFor="publishedDate" className="govuk-label">
                 Published date
               </label>
               <input
@@ -77,6 +77,8 @@ export const FormCommentsSort = ({
                 name="publishedAtFrom"
                 className="govuk-input govuk-input--width-5"
                 defaultValue={defaultPublishedAtFrom}
+                title="Published at from"
+                aria-label="Published at from"
               />
               <p className="govuk-body dpr-comment-filter__to-label">to</p>
               <input
@@ -84,6 +86,8 @@ export const FormCommentsSort = ({
                 name="publishedAtTo"
                 className="govuk-input govuk-input--width-5"
                 defaultValue={defaultPublishedAtTo}
+                title="Published at to"
+                aria-label="Published at to"
               />
             </div>
           </div>

--- a/src/components/FormCommentsSort/FormCommentsSort.tsx
+++ b/src/components/FormCommentsSort/FormCommentsSort.tsx
@@ -78,12 +78,7 @@ export const FormCommentsSort = ({
                 className="govuk-input govuk-input--width-5"
                 defaultValue={defaultPublishedAtFrom}
               />
-              <p
-                style={{ display: "inline-block" }}
-                className="govuk-body govuk-!-margin-left-1 govuk-!-margin-right-1 govuk-!-margin-bottom-4"
-              >
-                to
-              </p>
+              <p className="govuk-body dpr-comment-filter__to-label">to</p>
               <input
                 type="date"
                 name="publishedAtTo"

--- a/src/components/FormCommentsSort/FormCommentsSort.tsx
+++ b/src/components/FormCommentsSort/FormCommentsSort.tsx
@@ -42,7 +42,7 @@ export const FormCommentsSort = ({
       method="get"
       action={`/${council}/${reference}/comments`}
     >
-      <div className="govuk-grid-row govuk-!-margin-left-0">
+      <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
           <h2 className="govuk-heading-m">Search comments</h2>
         </div>

--- a/src/components/FormCommentsSort/FormCommentsSort.tsx
+++ b/src/components/FormCommentsSort/FormCommentsSort.tsx
@@ -33,10 +33,9 @@ export const FormCommentsSort = ({
   reference,
   type,
   defaultSentiment = "all",
-  defaultPublishedAtFrom = new Date().toISOString().split("T")[0],
-  defaultPublishedAtTo = new Date().toISOString().split("T")[0],
+  defaultPublishedAtFrom,
+  defaultPublishedAtTo,
 }: FormCommentsSortProps) => {
-  console.log({ type }, { defaultPublishedAtFrom });
   return (
     <form
       className="govuk-form dpr-comment-filter"
@@ -50,7 +49,7 @@ export const FormCommentsSort = ({
         <div className="govuk-grid-row govuk-!-margin-left-0">
           <div className="govuk-grid-column-one-third">
             <div className="govuk-form-group">
-              <label htmlFor="sortOrder" className="govuk-label">
+              <label htmlFor="sentiment" className="govuk-label">
                 Sentiment
               </label>
               <select
@@ -87,7 +86,7 @@ export const FormCommentsSort = ({
               </p>
               <input
                 type="date"
-                name="pubblishedAtTo"
+                name="publishedAtTo"
                 className="govuk-input govuk-input--width-5"
                 defaultValue={defaultPublishedAtTo}
               />
@@ -95,23 +94,22 @@ export const FormCommentsSort = ({
           </div>
           <div className="govuk-grid-row govuk-!-margin-left-0 grid-row-extra-bottom-margin">
             <div className="govuk-grid-column-full govuk-button-group">
-              <input type="hidden" name="type" value={type} />
               <button
                 type="submit"
                 className="govuk-button govuk-button dpr-comment-filter__button"
               >
                 Search
               </button>
-              <button
-                type="reset"
+              <a
+                href={`/${council}/${reference}/comments?type=${type}`}
                 className="govuk-button govuk-button--secondary"
+                role="button"
               >
                 Clear search
-              </button>
+              </a>
             </div>
           </div>
         </div>
-        {/* start sort by*/}
         <div className="govuk-grid-row govuk-!-margin-left-0">
           <div className="govuk-grid-column-one-third dpr-dropdown">
             <div className="govuk-form-group drp-dropdown__group">

--- a/src/components/FormCommentsSort/FormCommentsSort.tsx
+++ b/src/components/FormCommentsSort/FormCommentsSort.tsx
@@ -22,6 +22,7 @@ export interface FormCommentsSortProps {
   council: string;
   reference: string;
   type: "public" | "specialist";
+  defaultSentiment?: "all" | "objection" | "neutral" | "supportive";
 }
 
 export const FormCommentsSort = ({
@@ -29,6 +30,7 @@ export const FormCommentsSort = ({
   council,
   reference,
   type = "public",
+  defaultSentiment = "all",
 }: FormCommentsSortProps) => {
   return (
     <form
@@ -40,6 +42,32 @@ export const FormCommentsSort = ({
         <div className="govuk-grid-column-full">
           <h2 className="govuk-heading-m">Search comments</h2>
         </div>
+        <div>
+          <label htmlFor="sortOrder" className="govuk-label">
+            Sentiment
+          </label>
+          <select
+            id="sentiment"
+            name="sentiment"
+            defaultValue={defaultSentiment}
+            className="govuk-select drp-dropdown__select"
+          >
+            <option value="all">All</option>
+            <option value="objection">Opposed</option>
+            <option value="supportive">Support</option>
+            <option value="neutral">Neutral</option>
+          </select>
+          <div className="govuk-grid-column-two-thirds govuk-!-padding-top-6">
+            <input type="hidden" name="type" value={type} />
+            <button
+              type="submit"
+              className="govuk-button govuk-button--secondary dpr-comment-filter__button"
+            >
+              Search
+            </button>
+          </div>
+        </div>
+        {/* start sort by*/}
         <div className="govuk-grid-row govuk-!-margin-left-0">
           <div className="govuk-grid-column-one-third dpr-dropdown">
             <div className="govuk-form-group drp-dropdown__group">

--- a/src/components/FormCommentsSort/FormCommentsSort.tsx
+++ b/src/components/FormCommentsSort/FormCommentsSort.tsx
@@ -22,49 +22,93 @@ export interface FormCommentsSortProps {
   council: string;
   reference: string;
   type: "public" | "specialist";
-  defaultSentiment?: "all" | "objection" | "neutral" | "supportive";
+  defaultSentiment?: string;
+  defaultPublishedAtFrom?: string;
+  defaultPublishedAtTo?: string;
 }
 
 export const FormCommentsSort = ({
   defaultOrderBy = "desc",
   council,
   reference,
-  type = "public",
+  type,
   defaultSentiment = "all",
+  defaultPublishedAtFrom = new Date().toISOString().split("T")[0],
+  defaultPublishedAtTo = new Date().toISOString().split("T")[0],
 }: FormCommentsSortProps) => {
+  console.log({ type }, { defaultPublishedAtFrom });
   return (
     <form
       className="govuk-form dpr-comment-filter"
       method="get"
       action={`/${council}/${reference}/comments`}
     >
-      <div className="govuk-grid-row">
+      <div className="govuk-grid-row govuk-!-margin-left-0">
         <div className="govuk-grid-column-full">
           <h2 className="govuk-heading-m">Search comments</h2>
         </div>
-        <div>
-          <label htmlFor="sortOrder" className="govuk-label">
-            Sentiment
-          </label>
-          <select
-            id="sentiment"
-            name="sentiment"
-            defaultValue={defaultSentiment}
-            className="govuk-select drp-dropdown__select"
-          >
-            <option value="all">All</option>
-            <option value="objection">Opposed</option>
-            <option value="supportive">Support</option>
-            <option value="neutral">Neutral</option>
-          </select>
-          <div className="govuk-grid-column-two-thirds govuk-!-padding-top-6">
-            <input type="hidden" name="type" value={type} />
-            <button
-              type="submit"
-              className="govuk-button govuk-button--secondary dpr-comment-filter__button"
-            >
-              Search
-            </button>
+        <div className="govuk-grid-row govuk-!-margin-left-0">
+          <div className="govuk-grid-column-one-third">
+            <div className="govuk-form-group">
+              <label htmlFor="sortOrder" className="govuk-label">
+                Sentiment
+              </label>
+              <select
+                id="sentiment"
+                name="sentiment"
+                defaultValue={defaultSentiment}
+                className="govuk-select drp-dropdown__select"
+              >
+                <option value="">All</option>
+                <option value="objection">Opposed</option>
+                <option value="supportive">Support</option>
+                <option value="neutral">Neutral</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div className="govuk-grid-row govuk-!-margin-left-0">
+          <div className="govuk-grid-column-one-third">
+            <div className="govuk-form-group">
+              <label htmlFor="sortOrder" className="govuk-label">
+                Published date
+              </label>
+              <input
+                type="date"
+                name="publishedAtFrom"
+                className="govuk-input govuk-input--width-5"
+                defaultValue={defaultPublishedAtFrom}
+              />
+              <p
+                style={{ display: "inline-block" }}
+                className="govuk-body govuk-!-margin-left-1 govuk-!-margin-right-1 govuk-!-margin-bottom-4"
+              >
+                to
+              </p>
+              <input
+                type="date"
+                name="pubblishedAtTo"
+                className="govuk-input govuk-input--width-5"
+                defaultValue={defaultPublishedAtTo}
+              />
+            </div>
+          </div>
+          <div className="govuk-grid-row govuk-!-margin-left-0 grid-row-extra-bottom-margin">
+            <div className="govuk-grid-column-full govuk-button-group">
+              <input type="hidden" name="type" value={type} />
+              <button
+                type="submit"
+                className="govuk-button govuk-button dpr-comment-filter__button"
+              >
+                Search
+              </button>
+              <button
+                type="reset"
+                className="govuk-button govuk-button--secondary"
+              >
+                Clear search
+              </button>
+            </div>
           </div>
         </div>
         {/* start sort by*/}
@@ -96,6 +140,7 @@ export const FormCommentsSort = ({
           </div>
         </div>
       </div>
+      <hr className="govuk-section-break govuk-section-break--visible govuk-section-break--l" />
     </form>
   );
 };

--- a/src/components/PageApplicationComments/PageApplicationComments.tsx
+++ b/src/components/PageApplicationComments/PageApplicationComments.tsx
@@ -83,6 +83,9 @@ export const PageApplicationComments = ({
           council={councilSlug}
           reference={reference}
           defaultOrderBy={searchParams?.orderBy}
+          defaultPublishedAtFrom={searchParams?.publishedAtFrom}
+          defaultPublishedAtTo={searchParams?.publishedAtTo}
+          defaultSentiment={searchParams?.sentiment}
           type={type}
         />
         {comments && comments.length > 0 ? (

--- a/src/components/PageApplicationComments/PageApplicationComments.tsx
+++ b/src/components/PageApplicationComments/PageApplicationComments.tsx
@@ -31,6 +31,7 @@ import { PageMain } from "../PageMain";
 import { createPathFromParams } from "@/lib/navigation";
 import { FormCommentsSort } from "@/components/FormCommentsSort";
 import { getPropertyAddress } from "@/lib/planningApplication/application";
+import { ContentNoResult } from "../ContentNoResult";
 
 export interface PageApplicationCommentsProps {
   reference: string;
@@ -95,7 +96,10 @@ export const PageApplicationComments = ({
             ))}
           </>
         ) : (
-          <ContentNotFound />
+          <ContentNoResult
+            isCommentPage={true}
+            councilConfig={appConfig.council}
+          />
         )}
         {pagination && pagination.totalPages > 1 && (
           <Pagination

--- a/src/handlers/bops/v2/publicComments.ts
+++ b/src/handlers/bops/v2/publicComments.ts
@@ -80,7 +80,6 @@ export async function publicComments(
       }
     }
     url = `${url}?${params.toString()}`;
-    console.log("url", url);
   }
 
   const request = await handleBopsGetRequest<

--- a/src/handlers/bops/v2/publicComments.ts
+++ b/src/handlers/bops/v2/publicComments.ts
@@ -36,6 +36,8 @@ import { defaultPagination } from "@/handlers/lib";
  * @param council
  * @param reference
  * @param sentiment
+ * @param publishedAtFrom
+ * @param publishedAtTo
  * @returns
  */
 export async function publicComments(
@@ -57,11 +59,17 @@ export async function publicComments(
     if (searchParams.sortBy) {
       params.append("sortBy", searchParams.sortBy);
     }
+    if (searchParams.orderBy) {
+      params.append("orderBy", searchParams.orderBy);
+    }
     if (searchParams.sentiment) {
       params.append("sentiment", searchParams.sentiment);
     }
-    if (searchParams.orderBy) {
-      params.append("orderBy", searchParams.orderBy);
+    if (searchParams.publishedAtFrom) {
+      params.append("publishedAtFrom", searchParams.publishedAtFrom);
+    }
+    if (searchParams.publishedAtTo) {
+      params.append("publishedAtTo", searchParams.publishedAtTo);
     }
     url = `${url}?${params.toString()}`;
   }

--- a/src/handlers/bops/v2/publicComments.ts
+++ b/src/handlers/bops/v2/publicComments.ts
@@ -35,6 +35,7 @@ import { defaultPagination } from "@/handlers/lib";
  * @param orderBy
  * @param council
  * @param reference
+ * @param sentiment
  * @returns
  */
 export async function publicComments(
@@ -55,6 +56,9 @@ export async function publicComments(
     }
     if (searchParams.sortBy) {
       params.append("sortBy", searchParams.sortBy);
+    }
+    if (searchParams.sentiment) {
+      params.append("sentiment", searchParams.sentiment);
     }
     if (searchParams.orderBy) {
       params.append("orderBy", searchParams.orderBy);

--- a/src/handlers/bops/v2/publicComments.ts
+++ b/src/handlers/bops/v2/publicComments.ts
@@ -67,11 +67,20 @@ export async function publicComments(
     }
     if (searchParams.publishedAtFrom) {
       params.append("publishedAtFrom", searchParams.publishedAtFrom);
+      if (searchParams.publishedAtTo === "") {
+        params.append("publishedAtTo", new Date().toISOString().split("T")[0]);
+      }
     }
     if (searchParams.publishedAtTo) {
       params.append("publishedAtTo", searchParams.publishedAtTo);
+      if (searchParams.publishedAtFrom === "") {
+        const date = new Date(searchParams.publishedAtTo);
+        date.setDate(date.getDate() - 1);
+        params.append("publishedAtFrom", date.toISOString().split("T")[0]);
+      }
     }
     url = `${url}?${params.toString()}`;
+    console.log("url", url);
   }
 
   const request = await handleBopsGetRequest<

--- a/src/handlers/bops/v2/specialistComments.ts
+++ b/src/handlers/bops/v2/specialistComments.ts
@@ -67,9 +67,17 @@ export async function specialistComments(
     }
     if (searchParams.publishedAtFrom) {
       params.append("publishedAtFrom", searchParams.publishedAtFrom);
+      if (searchParams.publishedAtTo === "") {
+        params.append("publishedAtTo", new Date().toISOString().split("T")[0]);
+      }
     }
     if (searchParams.publishedAtTo) {
       params.append("publishedAtTo", searchParams.publishedAtTo);
+      if (searchParams.publishedAtFrom === "") {
+        const date = new Date(searchParams.publishedAtTo);
+        date.setDate(date.getDate() - 1);
+        params.append("publishedAtFrom", date.toISOString().split("T")[0]);
+      }
     }
     url = `${url}?${params.toString()}`;
   }

--- a/src/handlers/bops/v2/specialistComments.ts
+++ b/src/handlers/bops/v2/specialistComments.ts
@@ -35,6 +35,9 @@ import { defaultPagination } from "@/handlers/lib";
  * @param orderBy
  * @param council
  * @param reference
+ * @param sentiment
+ * @param publishedAtFrom
+ * @param publishedAtTo
  * @returns
  */
 export async function specialistComments(
@@ -58,6 +61,15 @@ export async function specialistComments(
     }
     if (searchParams.orderBy) {
       params.append("orderBy", searchParams.orderBy);
+    }
+    if (searchParams.sentiment) {
+      params.append("sentiment", searchParams.sentiment);
+    }
+    if (searchParams.publishedAtFrom) {
+      params.append("publishedAtFrom", searchParams.publishedAtFrom);
+    }
+    if (searchParams.publishedAtTo) {
+      params.append("publishedAtTo", searchParams.publishedAtTo);
     }
     url = `${url}?${params.toString()}`;
   }

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -65,6 +65,7 @@ export interface SearchParams {
   resultsPerPage: number;
   sortBy?: string;
   orderBy?: string;
+  sentiment?: string;
 }
 export type SearchParamsDocuments = SearchParams;
 export interface SearchParamsComments extends SearchParams {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -66,6 +66,8 @@ export interface SearchParams {
   sortBy?: string;
   orderBy?: string;
   sentiment?: string;
+  publishedAtFrom?: string;
+  publishedAtTo?: string;
 }
 export type SearchParamsDocuments = SearchParams;
 export interface SearchParamsComments extends SearchParams {


### PR DESCRIPTION
It's covering this two tickets:
[1](https://tpximpact.atlassian.net/browse/DSNPI-572?atlOrigin=eyJpIjoiMTRlZGM2ZTVlODM3NDMyOGFmOGUzMjkzMzE5MTYyMWYiLCJwIjoiaiJ9)
[2](https://tpximpact.atlassian.net/browse/DSNPI-572?atlOrigin=eyJpIjoiMDQzYjQwNGYyMDgyNDQ5Yjk2ZGE4NmIzNzg3OTQ1NzQiLCJwIjoiaiJ9)

This tickets add the sentiment filter and publishedAtFrom to publishedAtTo
To test it's needed to set up Bops locally, since the PR is not approved and merged yet. 