### PR TITLE
DSNPI - 1201 / Document attachment overflow

### DIFF
--- a/src/components/govukDpr/Attachment/Attachment.scss
+++ b/src/components/govukDpr/Attachment/Attachment.scss
@@ -30,7 +30,7 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey");
   position: relative;
   @include govuk-font(19);
   @include govuk-clearfix;
-
+  word-break: break-word;
   .govuk-details {
     margin: govuk-spacing(3) 0;
   }

--- a/src/components/govukDpr/Attachment/Attachment.scss
+++ b/src/components/govukDpr/Attachment/Attachment.scss
@@ -69,6 +69,7 @@ $thumbnail-icon-border-colour: govuk-colour("mid-grey");
 
   &__title {
     margin: 0 0 govuk-spacing(3);
+    word-break: break-word;
   }
 
   &__link {


### PR DESCRIPTION
[Ticket 1201](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?jql=assignee%20%3D%2062a6f3cb6085950068acebf7&selectedIssue=DSNPI-1201)

Adds word-break to attachment title to stop overflow.
![image](https://github.com/user-attachments/assets/eb42fb5e-71b0-4d4f-91db-5c495013b8a3)
