### PR TITLE
DSNPI-1037 - InfoIcons validate they link to valid locations and have defaults or don't show

### DIFF
--- a/src/components/ApplicationHero/ApplicationHero.stories.tsx
+++ b/src/components/ApplicationHero/ApplicationHero.stories.tsx
@@ -160,3 +160,14 @@ export const Withdrawn: Story = {
     application: withdrawn,
   },
 };
+
+// This helps us see that the info icon link just links to the status help page instead of to a specific status within the status page
+export const UnknownStatus: Story = {
+  name: "Unknown status",
+  args: {
+    application: {
+      ...committeeDetermined,
+      applicationStatusSummary: "Unknown",
+    },
+  },
+};

--- a/src/components/ApplicationHero/ApplicationHero.tsx
+++ b/src/components/ApplicationHero/ApplicationHero.tsx
@@ -109,16 +109,18 @@ export const ApplicationHero = ({
                   />
                 }
                 infoIcon={
-                  applicationStatusSummary &&
-                  documentedApplicationStatuses.includes(
-                    applicationStatusSummary,
-                  ) ? (
-                    <InfoIcon
-                      href={`/${councilSlug}/help/application-statuses#${slugify(applicationStatusSummary)}`}
-                      title="Understanding application statuses"
-                      ariaLabel="Understanding application statuses"
-                    />
-                  ) : undefined
+                  <InfoIcon
+                    href={
+                      `/${councilSlug}/help/application-statuses` +
+                      (documentedApplicationStatuses.includes(
+                        applicationStatusSummary,
+                      )
+                        ? `#${slugify(applicationStatusSummary)}`
+                        : ``)
+                    }
+                    title="Understanding application statuses"
+                    ariaLabel="Understanding application statuses"
+                  />
                 }
               />
             )}
@@ -129,48 +131,56 @@ export const ApplicationHero = ({
                 title="Application type"
                 value={getPrimaryApplicationType(application.applicationType)}
                 infoIcon={
-                  getDocumentedApplicationType(application.applicationType) ? (
-                    <InfoIcon
-                      href={`/${councilSlug}/help/application-types#${slugify(getDocumentedApplicationType(application.applicationType) ?? "")}`}
-                      title="Understanding application types"
-                      ariaLabel="Understanding application types"
-                    />
-                  ) : undefined
+                  <InfoIcon
+                    href={
+                      `/${councilSlug}/help/application-types` +
+                      (getDocumentedApplicationType(application.applicationType)
+                        ? `#${slugify(
+                            getDocumentedApplicationType(
+                              application.applicationType,
+                            )!,
+                          )}`
+                        : ``)
+                    }
+                    title="Understanding application types"
+                    ariaLabel="Understanding application types"
+                  />
                 }
               />
             )}
 
             {/* decision */}
             {getCouncilDecision(application) && (
-              <>
-                <ApplicationDataField
-                  title="Council decision"
-                  value={
-                    applicationDecisionSummary && (
-                      <Tag
-                        label={applicationDecisionSummary}
-                        sentiment={getApplicationDecisionSummarySentiment(
-                          applicationDecisionSummary,
-                        )}
-                        isInline={true}
-                      />
-                    )
-                  }
-                  infoIcon={
-                    applicationDecisionSummary &&
-                    documentedApplicationDecisions.includes(
-                      applicationDecisionSummary,
-                    ) ? (
-                      <InfoIcon
-                        href={`/${councilSlug}/help/decisions#${slugify(applicationDecisionSummary)}`}
-                        title="Understanding council decisions"
-                        ariaLabel="Understanding council decisions"
-                      />
-                    ) : undefined
-                  }
-                  isFull={application?.data?.appeal?.decision ? false : true}
-                />
-              </>
+              <ApplicationDataField
+                title="Council decision"
+                value={
+                  applicationDecisionSummary && (
+                    <Tag
+                      label={applicationDecisionSummary}
+                      sentiment={getApplicationDecisionSummarySentiment(
+                        applicationDecisionSummary,
+                      )}
+                      isInline
+                    />
+                  )
+                }
+                infoIcon={
+                  <InfoIcon
+                    href={
+                      `/${councilSlug}/help/decisions` +
+                      (applicationDecisionSummary &&
+                      documentedApplicationDecisions.includes(
+                        applicationDecisionSummary,
+                      )
+                        ? `#${slugify(applicationDecisionSummary)}`
+                        : ``)
+                    }
+                    title="Understanding council decisions"
+                    ariaLabel="Understanding council decisions"
+                  />
+                }
+                isFull={application?.data?.appeal?.decision ? false : true}
+              />
             )}
 
             {/* Appeal decision */}
@@ -181,9 +191,10 @@ export const ApplicationHero = ({
                   applicationAppealDecisionSummary && (
                     <Tag
                       label={applicationAppealDecisionSummary}
-                      isInline={true}
-                      {...(applicationAppealDecisionSummary &&
-                      appealDecisionSentiment[applicationAppealDecisionSummary]
+                      isInline
+                      {...(appealDecisionSentiment[
+                        applicationAppealDecisionSummary
+                      ]
                         ? {
                             sentiment:
                               appealDecisionSentiment[
@@ -195,16 +206,19 @@ export const ApplicationHero = ({
                   )
                 }
                 infoIcon={
-                  applicationAppealDecisionSummary &&
-                  documentedApplicationDecisions.includes(
-                    applicationAppealDecisionSummary,
-                  ) ? (
-                    <InfoIcon
-                      href={`/${councilSlug}/help/decisions#${slugify(applicationAppealDecisionSummary)}`}
-                      title="Understanding appeal decisions"
-                      ariaLabel="Understanding appeal decisions"
-                    />
-                  ) : undefined
+                  <InfoIcon
+                    href={
+                      `/${councilSlug}/help/decisions` +
+                      (applicationAppealDecisionSummary &&
+                      documentedApplicationDecisions.includes(
+                        applicationAppealDecisionSummary,
+                      )
+                        ? `#${slugify(applicationAppealDecisionSummary)}`
+                        : ``)
+                    }
+                    title="Understanding appeal decisions"
+                    ariaLabel="Understanding appeal decisions"
+                  />
                 }
               />
             )}


### PR DESCRIPTION
[Ticket 1037](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?jql=assignee%20%3D%2062a6f3cb6085950068acebf7&selectedIssue=DSNPI-1037)

This PR adds a default href to the `<InfoIcon />` components within the `<ApplicationHero />` component. If there is no valid status/decision/type/appeal decision, instead of linking to a specific part of the relevant help page, we just link to the help page itself.

Added a storybook story to demonstrate when an invalid status is provided. If you hover over the info icon, it should just show the url to the status help page.