### PR TITLE
DSNPI-1246 Fix for $govuk-font-family being overwritten

### DIFF
--- a/src/components/ApplicationMap/ApplicationMap.scss
+++ b/src/components/ApplicationMap/ApplicationMap.scss
@@ -15,7 +15,7 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-@import "node_modules/govuk-frontend/dist/govuk/base";
+@import "src/styles/component-base";
 
 .dpr-application-map {
   // add margin to account for the focus outline of .25em

--- a/src/components/comment-header/comment-header.scss
+++ b/src/components/comment-header/comment-header.scss
@@ -15,7 +15,7 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-@import "node_modules/govuk-frontend/dist/govuk/base";
+@import "src/styles/component-base";
 
 .comment-header {
   // map and data

--- a/src/components/comment_confirmation/comment-confirmation.scss
+++ b/src/components/comment_confirmation/comment-confirmation.scss
@@ -15,7 +15,7 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-@import "node_modules/govuk-frontend/dist/govuk/base";
+@import "src/styles/component-base";
 
 .comment-confirmation {
   // map and data

--- a/src/components/govuk/Pagination/Pagination.scss
+++ b/src/components/govuk/Pagination/Pagination.scss
@@ -15,6 +15,7 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-@import "node_modules/govuk-frontend/dist/govuk/base";
+@import "src/styles/component-base";
+
 @import "node_modules/govuk-frontend/dist/govuk/core/index";
 @import "node_modules/govuk-frontend/dist/govuk/components/pagination/index";

--- a/src/components/govuk/SummaryCard/SummaryCard.scss
+++ b/src/components/govuk/SummaryCard/SummaryCard.scss
@@ -15,5 +15,5 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-@import "node_modules/govuk-frontend/dist/govuk/base";
+@import "src/styles/component-base";
 @import "node_modules/govuk-frontend/dist/govuk/components/summary-list/index";

--- a/src/components/govuk/SummaryList/SummaryList.scss
+++ b/src/components/govuk/SummaryList/SummaryList.scss
@@ -15,5 +15,5 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-@import "node_modules/govuk-frontend/dist/govuk/base";
+@import "src/styles/component-base";
 @import "node_modules/govuk-frontend/dist/govuk/components/summary-list/index";

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -18,10 +18,6 @@
 @import "vars";
 // @import "legacy";
 
-:root {
-  --font-mono: Arial, Helvetica, sans;
-}
-
 * {
   box-sizing: border-box;
   padding: 0;
@@ -30,7 +26,7 @@
 
 html,
 body {
-  font-family: var(--font-mono);
+  font-family: $govuk-font-family;
 }
 
 a {


### PR DESCRIPTION
Found the sneaky thing!


**the issue**

We use scss in two ways:

We build the 'base' css by taking advantage of cascading, we load `vars.scss` which sets `$govuk-font-family` then we load everything else - when govuk is loaded it sets its own `$govuk-font-family` to our `$govuk-font-family`. We only load the 'essentials' in this file, the base css and components for all pages.

We include further css in our components. Each of these components should contain this on the first line:

```scss
@import "src/styles/component-base";
```

Component base includes a similar idea to above, it loads our var file first (setting `$govuk-font-family`), then our utils and then just the govuk basics `node_modules/govuk-frontend/dist/govuk/base` after that we can include things like `node_modules/govuk-frontend/dist/govuk/core` or the relevant component css `node_modules/govuk-frontend/dist/govuk/components/summary-list/index`

**the solution**

The issue was that some of the components we're directly calling `node_modules/govuk-frontend/dist/govuk/base`. This would mean that the var file isn't present to set `$govuk-font-family`. 

The reason its intermittent probably has something to do with the load order of the components being different each time.

**the future** 

Make sure this is in every scss file! 😂

```scss
@import "src/styles/component-base";
```
