### PR TITLE
QA - DSNPI-1093 / Specialist & Public Comments - update the /details page to use new public comment endpoints

### DIFF
--- a/src/components/CommentsList/CommentsList.tsx
+++ b/src/components/CommentsList/CommentsList.tsx
@@ -120,7 +120,7 @@ export const CommentsList = ({
   );
 };
 
-export function CommentsListSkeleton({ type }: { type?: DprCommentTypes }) {
+export const CommentsListSkeleton = ({ type }: { type?: DprCommentTypes }) => {
   const sectionId =
     type === "specialist" ? "specialist-comments" : "public-comments";
   const headingId =
@@ -133,11 +133,11 @@ export function CommentsListSkeleton({ type }: { type?: DprCommentTypes }) {
       <h2 id={headingId} className="govuk-heading-l">
         {type === "specialist" ? "Specialist Comments" : "Public Comments"}
       </h2>
-      <div>
+      <div className="govuk-grid-row grid-row-extra-bottom-margin">
         {Array.from({ length: 3 }).map((_, index) => (
           <CommentCard key={index} />
         ))}
       </div>
     </section>
   );
-}
+};

--- a/src/components/CommentsListWithSuspense/CommentsListWithSuspense.tsx
+++ b/src/components/CommentsListWithSuspense/CommentsListWithSuspense.tsx
@@ -33,22 +33,22 @@ async function fetchData({
   params,
   type,
 }: {
-  params: { council: string; reference: string };
+  params: { councilSlug: string; reference: string };
   type?: DprCommentTypes;
 }): Promise<{
   response: ApiResponse<
     DprPublicCommentsApiResponse | DprSpecialistCommentsApiResponse | null
   >;
 }> {
-  const { reference, council } = params;
-  const appConfig = getAppConfig(council);
+  const { reference, councilSlug } = params;
+  const appConfig = getAppConfig(councilSlug);
 
   const commentsApi =
     type === "specialist" ? ApiV1.specialistComments : ApiV1.publicComments;
 
   const response = await commentsApi(
     appConfig.council?.dataSource ?? "none",
-    council,
+    councilSlug,
     reference,
   );
 
@@ -93,7 +93,7 @@ export function CommentsListWithSuspense({
       <CommentsListLoader
         reference={reference}
         type={type}
-        council={councilSlug}
+        councilSlug={councilSlug}
         resultsPerPage={resultsPerPage}
       />
     </Suspense>
@@ -101,18 +101,18 @@ export function CommentsListWithSuspense({
 }
 
 async function CommentsListLoader({
-  council,
+  councilSlug,
   reference,
   type,
   resultsPerPage,
 }: {
-  council: string;
+  councilSlug: string;
   reference: string;
   type?: DprCommentTypes;
   resultsPerPage?: number;
 }) {
   const { response } = await fetchData({
-    params: { council, reference },
+    params: { councilSlug, reference },
     type,
   });
   const summary = response.data?.summary;
@@ -121,7 +121,7 @@ async function CommentsListLoader({
     <CommentsList
       summary={summary}
       comments={loadedComments}
-      councilSlug={council}
+      councilSlug={councilSlug}
       reference={reference}
       type={type}
       resultsPerPage={resultsPerPage}


### PR DESCRIPTION
Returned from QA

[Ticket 1093](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-1093)

- changed params to use `councilSlug` instead of `council`. 
- Added missing classes in `CommentsListSkeleton` to stop unnecessary padding.