### PR TITLE
DSNPI-1233 / adding a comment - doesn't always error

### DIFF
--- a/src/components/comment_text_entry/index.tsx
+++ b/src/components/comment_text_entry/index.tsx
@@ -105,7 +105,7 @@ const CommentTextEntry = ({
     e.preventDefault();
     setHasSubmitted(true);
 
-    if (comment && normalisedCharCount <= MAX_COMMENT_LENGTH) {
+    if (normalisedCharCount > 0 && normalisedCharCount <= MAX_COMMENT_LENGTH) {
       sessionStorage.setItem(`comment_${currentTopic}_${reference}`, comment);
       updateProgress(3);
       onContinue();
@@ -126,7 +126,7 @@ const CommentTextEntry = ({
             ref={textareaRef}
             className={`govuk-form-group ${validationError || isMaxLength ? "govuk-form-group--error" : ""}`}
           >
-            {validationError && !comment && (
+            {validationError && normalisedCharCount === 0 && (
               <p
                 id="comment-error"
                 className="govuk-error-message"
@@ -168,9 +168,11 @@ const CommentTextEntry = ({
               value={comment}
               onChange={handleCommentChange}
               maxLength={MAX_COMMENT_LENGTH}
-              aria-invalid={validationError || isMaxLength}
+              aria-invalid={
+                (validationError && normalisedCharCount === 0) || isMaxLength
+              }
               aria-errormessage={
-                validationError
+                validationError && normalisedCharCount === 0
                   ? "comment-error"
                   : isMaxLength
                     ? "length-error"


### PR DESCRIPTION
[Ticket 1233](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-1233) 🐛 

This PR fixes the validation errors experienced on the comment flow, where if a space was entered into the `CommentTextEntry` component, the validation would trigger but we wouldn't see a proper error. This was because we were checking the raw `comment` string, rather than its noramlised length. Now we are using `normalisedCharCount` instead of comment.
