### PR TITLE
DSNPI-1248 - Add environment-variable-based feature flag support for filtering

### DIFF
--- a/__tests__/util/featureFlag.test.tsx
+++ b/__tests__/util/featureFlag.test.tsx
@@ -1,0 +1,58 @@
+import { getEnabledFields } from "../../src/util/featureFlag";
+
+describe("getEnabledFields", () => {
+  it("returns all fields when disabledFields is empty", () => {
+    const allFields = [
+      "sentiment",
+      "query",
+      "resultsPerPage",
+      "publishedAtFrom",
+      "publishedAtTo",
+    ];
+    const disabledFields: string[] = [];
+    expect(getEnabledFields(allFields, disabledFields)).toEqual([
+      "sentiment",
+      "query",
+      "resultsPerPage",
+      "publishedAtFrom",
+      "publishedAtTo",
+    ]);
+  });
+
+  it("filters out disabled fields", () => {
+    const allFields = [
+      "sentiment",
+      "query",
+      "resultsPerPage",
+      "publishedAtFrom",
+      "publishedAtTo",
+    ];
+    const disabledFields = [
+      "resultsPerPage",
+      "publishedAtFrom",
+      "publishedAtTo",
+    ];
+    expect(getEnabledFields(allFields, disabledFields)).toEqual([
+      "sentiment",
+      "query",
+    ]);
+  });
+
+  it("returns empty array when all fields are disabled", () => {
+    const allFields = [
+      "sentiment",
+      "query",
+      "resultsPerPage",
+      "publishedAtFrom",
+      "publishedAtTo",
+    ];
+    const disabledFields = [
+      "sentiment",
+      "query",
+      "resultsPerPage",
+      "publishedAtFrom",
+      "publishedAtTo",
+    ];
+    expect(getEnabledFields(allFields, disabledFields)).toEqual([]);
+  });
+});

--- a/__tests__/util/featureFlag.test.tsx
+++ b/__tests__/util/featureFlag.test.tsx
@@ -1,58 +1,37 @@
-import { getEnabledFields } from "../../src/util/featureFlag";
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
 
-describe("getEnabledFields", () => {
-  it("returns all fields when disabledFields is empty", () => {
-    const allFields = [
-      "sentiment",
-      "query",
-      "resultsPerPage",
-      "publishedAtFrom",
-      "publishedAtTo",
-    ];
-    const disabledFields: string[] = [];
-    expect(getEnabledFields(allFields, disabledFields)).toEqual([
-      "sentiment",
-      "query",
-      "resultsPerPage",
-      "publishedAtFrom",
-      "publishedAtTo",
-    ]);
+import { computeEnabledFields } from "@/util/featureFlag";
+
+describe("computeEnabledFields", () => {
+  it("returns all fields when envVar is undefined", () => {
+    const all = ["sentiment", "publishedAtTo", "publishedAtFrom"];
+    expect(computeEnabledFields(all, undefined)).toEqual(all);
   });
 
-  it("filters out disabled fields", () => {
-    const allFields = [
-      "sentiment",
-      "query",
-      "resultsPerPage",
-      "publishedAtFrom",
-      "publishedAtTo",
-    ];
-    const disabledFields = [
-      "resultsPerPage",
-      "publishedAtFrom",
-      "publishedAtTo",
-    ];
-    expect(getEnabledFields(allFields, disabledFields)).toEqual([
-      "sentiment",
-      "query",
-    ]);
+  it("filters out fields listed in envVar", () => {
+    const all = ["sentiment", "publishedAtTo", "publishedAtFrom"];
+    const envVar = "publishedAtTo,publishedAtFrom";
+    expect(computeEnabledFields(all, envVar)).toEqual(["sentiment"]);
   });
 
-  it("returns empty array when all fields are disabled", () => {
-    const allFields = [
-      "sentiment",
-      "query",
-      "resultsPerPage",
-      "publishedAtFrom",
-      "publishedAtTo",
-    ];
-    const disabledFields = [
-      "sentiment",
-      "query",
-      "resultsPerPage",
-      "publishedAtFrom",
-      "publishedAtTo",
-    ];
-    expect(getEnabledFields(allFields, disabledFields)).toEqual([]);
+  it("returns empty array when all fields disabled", () => {
+    const all = ["sentiment", "publishedAtTo", "publishedAtFrom", "query"];
+    const envVar = "sentiment,publishedAtTo,publishedAtFrom,query";
+    expect(computeEnabledFields(all, envVar)).toEqual([]);
   });
 });

--- a/src/components/PageApplicationComments/PageApplicationComments.tsx
+++ b/src/components/PageApplicationComments/PageApplicationComments.tsx
@@ -31,12 +31,7 @@ import { PageMain } from "../PageMain";
 import { createPathFromParams } from "@/lib/navigation";
 import { FormCommentsSort } from "@/components/FormCommentsSort";
 import { getPropertyAddress } from "@/lib/planningApplication/application";
-import {
-  getEnabledFields,
-  COMMENT_SEARCH_FIELDS,
-  disabledCommentSearchFields,
-} from "@/util/featureFlag";
-import { useMemo } from "react";
+import { commentSearchFields } from "@/util/featureFlag";
 
 export interface PageApplicationCommentsProps {
   reference: string;
@@ -65,10 +60,6 @@ export const PageApplicationComments = ({
   searchParams,
   comments,
 }: PageApplicationCommentsProps) => {
-  const commentSearchFields = useMemo(
-    () => getEnabledFields(COMMENT_SEARCH_FIELDS, disabledCommentSearchFields),
-    [],
-  );
   if (!appConfig || !appConfig.council) {
     return (
       <PageMain>

--- a/src/components/PageApplicationComments/PageApplicationComments.tsx
+++ b/src/components/PageApplicationComments/PageApplicationComments.tsx
@@ -31,6 +31,12 @@ import { PageMain } from "../PageMain";
 import { createPathFromParams } from "@/lib/navigation";
 import { FormCommentsSort } from "@/components/FormCommentsSort";
 import { getPropertyAddress } from "@/lib/planningApplication/application";
+import {
+  getEnabledFields,
+  COMMENT_SEARCH_FIELDS,
+  disabledCommentSearchFields,
+} from "@/util/featureFlag";
+import { useMemo } from "react";
 
 export interface PageApplicationCommentsProps {
   reference: string;
@@ -59,6 +65,10 @@ export const PageApplicationComments = ({
   searchParams,
   comments,
 }: PageApplicationCommentsProps) => {
+  const commentSearchFields = useMemo(
+    () => getEnabledFields(COMMENT_SEARCH_FIELDS, disabledCommentSearchFields),
+    [],
+  );
   if (!appConfig || !appConfig.council) {
     return (
       <PageMain>
@@ -79,6 +89,26 @@ export const PageApplicationComments = ({
         <h1 className="govuk-heading-l">
           {type === "public" ? "Public Comments" : "Specialist Comments"}
         </h1>
+        {/* Temporary disabled filters  */}
+        {commentSearchFields.includes("sentiment") && (
+          <p>Pretend I am the sentiment filter</p>
+        )}
+        {commentSearchFields.includes("publishedAtTo") && (
+          <p>Pretend I am the publishedAtTo filter</p>
+        )}
+        {commentSearchFields.includes("publishedAtFrom") && (
+          <p>Pretend I am the publishedAtFrom filter</p>
+        )}
+        {commentSearchFields.includes("query") && (
+          <p>Pretend I am the query filter</p>
+        )}
+        {commentSearchFields.includes("resultsPerPage") && (
+          <p>Pretend I am the resultsPerPage filter</p>
+        )}
+        {commentSearchFields.includes("page") && (
+          <p>Pretend I am the page filter</p>
+        )}
+
         <FormCommentsSort
           council={councilSlug}
           reference={reference}

--- a/src/components/PageApplicationComments/PageApplicationComments.tsx
+++ b/src/components/PageApplicationComments/PageApplicationComments.tsx
@@ -31,7 +31,6 @@ import { PageMain } from "../PageMain";
 import { createPathFromParams } from "@/lib/navigation";
 import { FormCommentsSort } from "@/components/FormCommentsSort";
 import { getPropertyAddress } from "@/lib/planningApplication/application";
-import { commentSearchFields } from "@/util/featureFlag";
 
 export interface PageApplicationCommentsProps {
   reference: string;
@@ -80,26 +79,6 @@ export const PageApplicationComments = ({
         <h1 className="govuk-heading-l">
           {type === "public" ? "Public Comments" : "Specialist Comments"}
         </h1>
-        {/* Temporary disabled filters  */}
-        {commentSearchFields.includes("sentiment") && (
-          <p>Pretend I am the sentiment filter</p>
-        )}
-        {commentSearchFields.includes("publishedAtTo") && (
-          <p>Pretend I am the publishedAtTo filter</p>
-        )}
-        {commentSearchFields.includes("publishedAtFrom") && (
-          <p>Pretend I am the publishedAtFrom filter</p>
-        )}
-        {commentSearchFields.includes("query") && (
-          <p>Pretend I am the query filter</p>
-        )}
-        {commentSearchFields.includes("resultsPerPage") && (
-          <p>Pretend I am the resultsPerPage filter</p>
-        )}
-        {commentSearchFields.includes("page") && (
-          <p>Pretend I am the page filter</p>
-        )}
-
         <FormCommentsSort
           council={councilSlug}
           reference={reference}

--- a/src/util/featureFlag.ts
+++ b/src/util/featureFlag.ts
@@ -1,5 +1,71 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
- * All available filter fields for the comments search form.
+ * Generic function to compute enabled fields based on feature flags.
+ * @param allFields - The complete list of fields.
+ * @param envVar - The environment variable that contains the disabled fields (comma-separated).
+ * @returns A subset of allFields excluding the fields listed in the environment variable.
+ */
+export const computeEnabledFields = (
+  allFields: readonly string[],
+  envVar: string | undefined,
+): string[] => {
+  const disabledFields = envVar?.split(",").filter(Boolean) ?? [];
+  return allFields.filter((field) => !disabledFields.includes(field));
+};
+
+/**
+ * Utility function to log enabled and disabled fields in development mode.
+ * @param type - The type of search fields (e.g., "Comment", "Document", "Application").
+ * @param disabledFields - The list of disabled fields.
+ * @param enabledFields - The list of enabled fields.
+ */
+const logFields = (
+  type: string,
+  disabledFields: string[],
+  enabledFields: string[],
+) => {
+  if (process.env.NODE_ENV === "development") {
+    console.log(`Disabled ${type} Search Fields:`, disabledFields);
+    console.log(`Enabled ${type} Search Fields:`, enabledFields);
+  }
+};
+
+/**
+ * Generic function to handle feature flags for a specific type.
+ * @param type - The type of search fields (e.g., "Comment", "Document", "Application").
+ * @param allFields - The complete list of fields.
+ * @param envVar - The environment variable that contains the disabled fields (comma-separated).
+ * @returns The enabled fields for the given type.
+ */
+export const handleFeatureFlags = (
+  type: string,
+  allFields: readonly string[],
+  envVar: string | undefined,
+): string[] => {
+  const enabledFields = computeEnabledFields(allFields, envVar);
+  const disabledFields = envVar?.split(",").filter(Boolean) ?? [];
+  logFields(type, disabledFields, enabledFields);
+  return enabledFields;
+};
+
+/**
+ * Comment Search Fields
  */
 export const COMMENT_SEARCH_FIELDS = [
   "query",
@@ -10,77 +76,40 @@ export const COMMENT_SEARCH_FIELDS = [
   "sentiment",
 ] as const;
 
-/**
- * Filters out any fields that are listed in disabledFields.
- * @param allFields - The complete list of fields.
- * @param disabledFields - Fields to remove.
- * @returns A subset of allFields excluding disabledFields.
- */
-export const getEnabledFields = (
-  allFields: readonly string[],
-  disabledFields: string[],
-) => {
-  return allFields.filter((field) => !disabledFields.includes(field));
-};
-
-/**
- * Reads the `COMMENT_FILTERING_DISABLED` env var (comma-separated list)
- * and returns an array of disabled field names.
- */
-export const disabledCommentSearchFields =
-  process.env.COMMENT_FILTERING_DISABLED?.split(",").filter(Boolean) ?? [];
-
-/**
- * Computed list of enabled comment filter fields, based on feature flags.
- */
-export const commentSearchFields = getEnabledFields(
+export const commentSearchFields = handleFeatureFlags(
+  "Comment",
   COMMENT_SEARCH_FIELDS,
-  disabledCommentSearchFields,
+  process.env.COMMENT_FILTERING_DISABLED,
 );
 
-if (process.env.NODE_ENV === "development") {
-  console.log("Disabled Comment Search Fields:", disabledCommentSearchFields);
-  console.log("Enabled Comment Search Fields:", commentSearchFields);
-}
+/**
+ * Document Search Fields
+ */
+export const DOCUMENT_SEARCH_FIELDS = [
+  "title",
+  "author",
+  "datePublished",
+  "fileType",
+] as const;
 
-// /**
-//  * Below are the placeholders for the future feature flags (documents and application search)
-//  */
+export const documentSearchFields = handleFeatureFlags(
+  "Document",
+  DOCUMENT_SEARCH_FIELDS,
+  process.env.DOCUMENT_FILTERING_DISABLED,
+);
 
-// /**
-//  * Placeholder for document search feature flags.
-//  * Extend DOCUMENT_SEARCH_FIELDS.
-//  */
-// export const DOCUMENT_SEARCH_FIELDS = [] as const;
-// export const disabledDocumentSearchFields =
-//   process.env.DOCUMENT_FILTERING_DISABLED?.split(",").filter(Boolean) ?? [];
+/**
+ * Application Search Fields
+ */
+export const APPLICATION_SEARCH_FIELDS = [
+  "applicationId",
+  "status",
+  "submittedDate",
+  "applicantName",
+] as const;
 
-// export const documentSearchFields = getEnabledFields(
-//   DOCUMENT_SEARCH_FIELDS,
-//   disabledDocumentSearchFields,
-// );
-
-// if (process.env.NODE_ENV === "development") {
-//   console.log("Disabled Document Search Fields:", disabledDocumentSearchFields);
-//   console.log("Enabled Document Search Fields:", documentSearchFields);
-// }
-
-// /**
-//  * Placeholder for application search feature flags.
-//  * Extend APPLICATION_SEARCH_FIELDS.
-//  */
-// export const APPLICATION_SEARCH_FIELDS = [] as const;
-// export const disabledApplicationSearchFields =
-//   process.env.APPLICATION_FILTERING_DISABLED?.split(",").filter(Boolean) ?? [];
-// export const applicationSearchFields = getEnabledFields(
-//   APPLICATION_SEARCH_FIELDS,
-//   disabledApplicationSearchFields,
-// );
-
-// if (process.env.NODE_ENV === "development") {
-//   console.log(
-//     "Disabled Application Search Fields:",
-//     disabledApplicationSearchFields,
-//   );
-//   console.log("Enabled Application Search Fields:", applicationSearchFields);
-// }
+export const applicationSearchFields = handleFeatureFlags(
+  "Application",
+  APPLICATION_SEARCH_FIELDS,
+  process.env.APPLICATION_FILTERING_DISABLED,
+);

--- a/src/util/featureFlag.ts
+++ b/src/util/featureFlag.ts
@@ -1,0 +1,86 @@
+/**
+ * All available filter fields for the comments search form.
+ */
+export const COMMENT_SEARCH_FIELDS = [
+  "query",
+  "resultsPerPage",
+  "page",
+  "publishedAtFrom",
+  "publishedAtTo",
+  "sentiment",
+] as const;
+
+/**
+ * Filters out any fields that are listed in disabledFields.
+ * @param allFields - The complete list of fields.
+ * @param disabledFields - Fields to remove.
+ * @returns A subset of allFields excluding disabledFields.
+ */
+export const getEnabledFields = (
+  allFields: readonly string[],
+  disabledFields: string[],
+) => {
+  return allFields.filter((field) => !disabledFields.includes(field));
+};
+
+/**
+ * Reads the `COMMENT_FILTERING_DISABLED` env var (comma-separated list)
+ * and returns an array of disabled field names.
+ */
+export const disabledCommentSearchFields =
+  process.env.COMMENT_FILTERING_DISABLED?.split(",").filter(Boolean) ?? [];
+
+/**
+ * Computed list of enabled comment filter fields, based on feature flags.
+ */
+export const commentSearchFields = getEnabledFields(
+  COMMENT_SEARCH_FIELDS,
+  disabledCommentSearchFields,
+);
+
+if (process.env.NODE_ENV === "development") {
+  console.log("Disabled Comment Search Fields:", disabledCommentSearchFields);
+  console.log("Enabled Comment Search Fields:", commentSearchFields);
+}
+
+// /**
+//  * Below are the placeholders for the future feature flags (documents and application search)
+//  */
+
+// /**
+//  * Placeholder for document search feature flags.
+//  * Extend DOCUMENT_SEARCH_FIELDS.
+//  */
+// export const DOCUMENT_SEARCH_FIELDS = [] as const;
+// export const disabledDocumentSearchFields =
+//   process.env.DOCUMENT_FILTERING_DISABLED?.split(",").filter(Boolean) ?? [];
+
+// export const documentSearchFields = getEnabledFields(
+//   DOCUMENT_SEARCH_FIELDS,
+//   disabledDocumentSearchFields,
+// );
+
+// if (process.env.NODE_ENV === "development") {
+//   console.log("Disabled Document Search Fields:", disabledDocumentSearchFields);
+//   console.log("Enabled Document Search Fields:", documentSearchFields);
+// }
+
+// /**
+//  * Placeholder for application search feature flags.
+//  * Extend APPLICATION_SEARCH_FIELDS.
+//  */
+// export const APPLICATION_SEARCH_FIELDS = [] as const;
+// export const disabledApplicationSearchFields =
+//   process.env.APPLICATION_FILTERING_DISABLED?.split(",").filter(Boolean) ?? [];
+// export const applicationSearchFields = getEnabledFields(
+//   APPLICATION_SEARCH_FIELDS,
+//   disabledApplicationSearchFields,
+// );
+
+// if (process.env.NODE_ENV === "development") {
+//   console.log(
+//     "Disabled Application Search Fields:",
+//     disabledApplicationSearchFields,
+//   );
+//   console.log("Enabled Application Search Fields:", applicationSearchFields);
+// }


### PR DESCRIPTION
[Ticket 1248](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?jql=&selectedIssue=DSNPI-1248)

We have created a util `featureFlag.ts` to determine which features should be disabled/enabled whilst we have some dependencies. 
To disable, you must add the .env variable: `COMMENT_FILTERING_DISABLED=`
For example, to disable all comment features: 
`COMMENT_FILTERING_DISABLED=query,resultsPerPage,page,publishedAtFrom,publishedAtTo,sentiment`


There are some placeholders for documents and application search too.
