### PR TITLE
Comments filtering (rest of the fields) related to DSNPI-1248 DSNPI-947 DSNPI-575

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/no-unused-vars": [
       "error",
       {
-        "ignoreRestSiblings": true
+        "ignoreRestSiblings": true,
+        "destructuredArrayIgnorePattern": "^_"
       }
     ]
   }

--- a/__tests__/components/FormCommentsSearch.test.tsx
+++ b/__tests__/components/FormCommentsSearch.test.tsx
@@ -21,16 +21,9 @@ import {
   FormCommentsSearchProps,
 } from "@/components/FormCommentsSearch";
 import { COMMENT_RESULTSPERPAGE_DEFAULT } from "@/lib/comments";
-import { useSearchParams } from "next/navigation";
-
-jest.mock("next/navigation", () => ({
-  useSearchParams: jest.fn(),
-}));
 
 describe("FormCommentsSearch", () => {
   const defaultProps: FormCommentsSearchProps = {
-    council: "public-council-1",
-    reference: "12345",
     searchParams: {
       page: 1,
       resultsPerPage: 10,
@@ -65,13 +58,7 @@ describe("FormCommentsSearch", () => {
   });
 
   it("renders without the form tag when action is not provided", () => {
-    render(
-      <FormCommentsSearch
-        council={defaultProps.council}
-        reference={defaultProps.reference}
-        searchParams={defaultProps.searchParams}
-      />,
-    );
+    render(<FormCommentsSearch searchParams={defaultProps.searchParams} />);
 
     // Check that the form is not rendered
     const form = screen.queryByRole("form", { name: /Search comments/i });
@@ -101,56 +88,5 @@ describe("FormCommentsSearch", () => {
     // Check if the form has the updated values for each field
     expect(queryInput).toHaveValue("new-query");
     expect(resultsPerPageSelect).toHaveValue("50");
-  });
-
-  it("resets the query parameters when 'Clear search' is clicked", () => {
-    render(<FormCommentsSearch {...defaultProps} />);
-
-    // Check the "Clear search" link
-    const clearSearchLink = screen.getByRole("button", {
-      name: /Clear search/i,
-    });
-    expect(clearSearchLink).toHaveAttribute(
-      "href",
-      "/public-council-1/12345/comments?",
-    );
-  });
-
-  describe("url has query parameters", () => {
-    const mockSearchParams = new URLSearchParams({
-      type: "public",
-      query: "test",
-      resultsPerPage: "10",
-      sortBy: "receivedAt",
-      orderBy: "desc",
-    });
-
-    beforeEach(() => {
-      (useSearchParams as jest.Mock).mockReturnValue(mockSearchParams);
-    });
-
-    const defaultProps: FormCommentsSearchProps = {
-      council: "public-council-1",
-      reference: "12345",
-      searchParams: {
-        page: 1,
-        resultsPerPage: 10,
-        type: "public",
-      },
-      action: "/test-action",
-    };
-
-    it("resets the query parameters when 'Clear search' is clicked", () => {
-      render(<FormCommentsSearch {...defaultProps} />);
-
-      // Check the "Clear search" link
-      const clearSearchLink = screen.getByRole("button", {
-        name: /Clear search/i,
-      });
-      expect(clearSearchLink).toHaveAttribute(
-        "href",
-        "/public-council-1/12345/comments?type=public&sortBy=receivedAt&orderBy=desc",
-      );
-    });
   });
 });

--- a/__tests__/components/FormFieldFromTo.test.tsx
+++ b/__tests__/components/FormFieldFromTo.test.tsx
@@ -1,0 +1,102 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import {
+  FormFieldFromTo,
+  FormFieldFromToProps,
+} from "@/components/FormFieldFromTo";
+
+describe("FormFieldFromTo Component", () => {
+  const defaultProps: FormFieldFromToProps = {
+    title: "Date Range",
+    from: {
+      label: "From Date",
+      name: "fromDate",
+      id: "from-date",
+      value: "2025-01-01",
+    },
+    to: {
+      label: "To Date",
+      name: "toDate",
+      id: "to-date",
+      value: "2025-12-31",
+    },
+  };
+
+  it("renders the component with the correct title", () => {
+    render(<FormFieldFromTo {...defaultProps} />);
+    expect(screen.getByText("Date Range")).toBeInTheDocument();
+  });
+
+  it("renders the 'from' input field with the correct attributes", () => {
+    render(<FormFieldFromTo {...defaultProps} />);
+    const fromInput = screen.getByLabelText("From Date", { selector: "input" });
+
+    expect(fromInput).toBeInTheDocument();
+    expect(fromInput).toHaveAttribute("id", "from-date");
+    expect(fromInput).toHaveAttribute("name", "fromDate");
+    expect(fromInput).toHaveAttribute("type", "date");
+    expect(fromInput).toHaveValue("2025-01-01");
+  });
+
+  it("renders the 'to' input field with the correct attributes", () => {
+    render(<FormFieldFromTo {...defaultProps} />);
+    const toInput = screen.getByLabelText("To Date", { selector: "input" });
+
+    expect(toInput).toBeInTheDocument();
+    expect(toInput).toHaveAttribute("id", "to-date");
+    expect(toInput).toHaveAttribute("name", "toDate");
+    expect(toInput).toHaveAttribute("type", "date");
+    expect(toInput).toHaveValue("2025-12-31");
+  });
+
+  it("renders the 'to' label as visually hidden", () => {
+    render(<FormFieldFromTo {...defaultProps} />);
+    const toLabel = screen.getByLabelText("To Date", { selector: "input" });
+    expect(toLabel).toBeInTheDocument();
+  });
+
+  it("renders the 'to' text between fields", () => {
+    render(<FormFieldFromTo {...defaultProps} />);
+    expect(screen.getByText("to")).toBeInTheDocument();
+  });
+
+  it("handles missing optional props gracefully", () => {
+    const propsWithoutIds: FormFieldFromToProps = {
+      title: "Date Range",
+      from: {
+        label: "From Date",
+        name: "fromDate",
+      },
+      to: {
+        label: "To Date",
+        name: "toDate",
+      },
+    };
+
+    render(<FormFieldFromTo {...propsWithoutIds} />);
+    const fromInput = screen.getByLabelText("From Date", { selector: "input" });
+    const toInput = screen.getByLabelText("To Date", { selector: "input" });
+
+    expect(fromInput).toHaveAttribute("id", "fromDate");
+    expect(toInput).toHaveAttribute("id", "toDate");
+  });
+});

--- a/__tests__/lib/comments.test.ts
+++ b/__tests__/lib/comments.test.ts
@@ -144,147 +144,322 @@ describe("validateSearchParams", () => {
     },
   } as unknown as AppConfig;
 
-  it("returns default values when searchParams is undefined", () => {
-    const result = validateSearchParams(mockAppConfig, undefined);
+  describe("required fields: page, resultsPerPage, type", () => {
+    it("returns default values when searchParams is undefined", () => {
+      const result = validateSearchParams(mockAppConfig, undefined);
 
-    expect(result).toEqual({
-      page: 1,
-      resultsPerPage: 10,
-      type: "public",
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+      });
+    });
+
+    it("parses valid page and resultsPerPage values", () => {
+      const searchParams = {
+        page: "2",
+        resultsPerPage: "25",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 2,
+        resultsPerPage: 25,
+        type: "public",
+      });
+    });
+
+    it("defaults to page 1 and resultsPerPage from appConfig when invalid values are provided", () => {
+      const searchParams = {
+        page: "invalid",
+        resultsPerPage: "invalid",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+      });
+    });
+
+    it("validates resultsPerPage against COMMENT_RESULTSPERPAGE_OPTIONS", () => {
+      const searchParams = {
+        resultsPerPage: "100", // Invalid value
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10, // Defaults to appConfig value
+        type: "public",
+      });
     });
   });
 
-  it("parses valid page and resultsPerPage values", () => {
-    const searchParams = {
-      page: "2",
-      resultsPerPage: "25",
-    };
+  // sortby, orderBy
+  describe("sortBy, orderBy", () => {
+    it("parses valid sortBy and orderBy values", () => {
+      const searchParams = {
+        sortBy: "receivedAt",
+        orderBy: "asc",
+      };
 
-    const result = validateSearchParams(mockAppConfig, searchParams);
+      const result = validateSearchParams(mockAppConfig, searchParams);
 
-    expect(result).toEqual({
-      page: 2,
-      resultsPerPage: 25,
-      type: "public",
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+        sortBy: "receivedAt",
+        orderBy: "asc",
+      });
+    });
+
+    it("ignores invalid sortBy and orderBy values", () => {
+      const searchParams = {
+        sortBy: "invalid",
+        orderBy: "invalid",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+      });
     });
   });
 
-  it("defaults to page 1 and resultsPerPage from appConfig when invalid values are provided", () => {
-    const searchParams = {
-      page: "invalid",
-      resultsPerPage: "invalid",
-    };
+  // query
+  describe("query", () => {
+    it("parses valid query value", () => {
+      const searchParams = {
+        query: "test-query",
+      };
 
-    const result = validateSearchParams(mockAppConfig, searchParams);
+      const result = validateSearchParams(mockAppConfig, searchParams);
 
-    expect(result).toEqual({
-      page: 1,
-      resultsPerPage: 10,
-      type: "public",
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+        query: "test-query",
+      });
+    });
+
+    it("handles query as an array and uses the first value", () => {
+      const searchParams = {
+        query: ["test-query", "another-query"],
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+        query: "test-query",
+      });
     });
   });
 
-  it("validates resultsPerPage against COMMENT_RESULTSPERPAGE_OPTIONS", () => {
-    const searchParams = {
-      resultsPerPage: "100", // Invalid value
-    };
+  // type
+  describe("type", () => {
+    it("parses type from searchParams", () => {
+      const searchParams = {
+        type: "specialist",
+      };
 
-    const result = validateSearchParams(mockAppConfig, searchParams);
+      const result = validateSearchParams(mockAppConfig, searchParams);
 
-    expect(result).toEqual({
-      page: 1,
-      resultsPerPage: 10, // Defaults to appConfig value
-      type: "public",
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "specialist",
+      });
+    });
+
+    it("defaults to 'public' type when type is invalid", () => {
+      const searchParams = {
+        type: "invalid",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+      });
     });
   });
 
-  it("parses valid sortBy and orderBy values", () => {
-    const searchParams = {
-      sortBy: "receivedAt",
-      orderBy: "asc",
-    };
+  // sentiment
+  describe("sentiment", () => {
+    it("parses valid sentiment from searchParams", () => {
+      const searchParams = {
+        sentiment: "supportive",
+      };
 
-    const result = validateSearchParams(mockAppConfig, searchParams);
+      const result = validateSearchParams(mockAppConfig, searchParams);
 
-    expect(result).toEqual({
-      page: 1,
-      resultsPerPage: 10,
-      type: "public",
-      sortBy: "receivedAt",
-      orderBy: "asc",
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+        sentiment: "supportive",
+      });
+    });
+
+    it("ignores invalid sentiment from searchParams", () => {
+      const searchParams = {
+        sentiment: "boohiss",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+      });
     });
   });
 
-  it("ignores invalid sortBy and orderBy values", () => {
-    const searchParams = {
-      sortBy: "invalid",
-      orderBy: "invalid",
-    };
+  // topic
+  describe("topic", () => {
+    it("parses valid topic from searchParams", () => {
+      const searchParams = {
+        topic: "design",
+      };
 
-    const result = validateSearchParams(mockAppConfig, searchParams);
+      const result = validateSearchParams(mockAppConfig, searchParams);
 
-    expect(result).toEqual({
-      page: 1,
-      resultsPerPage: 10,
-      type: "public",
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+        topic: "design",
+      });
+    });
+
+    it("ignores invalid topic from searchParams", () => {
+      const searchParams = {
+        topic: "nonsense",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+      });
     });
   });
 
-  it("parses valid query value", () => {
-    const searchParams = {
-      query: "test-query",
-    };
+  // publishedAtFrom publishedAtTo
+  describe("publishedAtFrom, publishedAtTo", () => {
+    it("returns valid publishedAtFrom and publishedAtTo when both are valid and in the correct order", () => {
+      const searchParams = {
+        publishedAtFrom: "2025-05-01",
+        publishedAtTo: "2025-05-31",
+      };
 
-    const result = validateSearchParams(mockAppConfig, searchParams);
+      const result = validateSearchParams(mockAppConfig, searchParams);
 
-    expect(result).toEqual({
-      page: 1,
-      resultsPerPage: 10,
-      type: "public",
-      query: "test-query",
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+        publishedAtFrom: "2025-05-01",
+        publishedAtTo: "2025-05-31",
+      });
     });
-  });
 
-  it("handles query as an array and uses the first value", () => {
-    const searchParams = {
-      query: ["test-query", "another-query"],
-    };
+    it("returns undefined for both publishedAtFrom and publishedAtTo when they are out of order", () => {
+      const searchParams = {
+        publishedAtFrom: "2025-05-31",
+        publishedAtTo: "2025-05-01",
+      };
 
-    const result = validateSearchParams(mockAppConfig, searchParams);
+      const result = validateSearchParams(mockAppConfig, searchParams);
 
-    expect(result).toEqual({
-      page: 1,
-      resultsPerPage: 10,
-      type: "public",
-      query: "test-query",
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+        publishedAtFrom: undefined,
+        publishedAtTo: undefined,
+      });
     });
-  });
 
-  it("parses type from searchParams", () => {
-    const searchParams = {
-      type: "specialist",
-    };
+    it("sets publishedAtTo to the same value as publishedAtFrom when only publishedAtFrom is valid", () => {
+      const searchParams = {
+        publishedAtFrom: "2025-05-01",
+      };
 
-    const result = validateSearchParams(mockAppConfig, searchParams);
+      const result = validateSearchParams(mockAppConfig, searchParams);
 
-    expect(result).toEqual({
-      page: 1,
-      resultsPerPage: 10,
-      type: "specialist",
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+        publishedAtFrom: "2025-05-01",
+        publishedAtTo: "2025-05-01",
+      });
     });
-  });
 
-  it("defaults to 'public' type when type is invalid", () => {
-    const searchParams = {
-      type: "invalid",
-    };
+    it("sets publishedAtFrom to the same value as publishedAtTo when only publishedAtTo is valid", () => {
+      const searchParams = {
+        publishedAtTo: "2025-05-31",
+      };
 
-    const result = validateSearchParams(mockAppConfig, searchParams);
+      const result = validateSearchParams(mockAppConfig, searchParams);
 
-    expect(result).toEqual({
-      page: 1,
-      resultsPerPage: 10,
-      type: "public",
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+        publishedAtFrom: "2025-05-31",
+        publishedAtTo: "2025-05-31",
+      });
+    });
+
+    it("returns undefined for both publishedAtFrom and publishedAtTo when neither is valid", () => {
+      const searchParams = {
+        publishedAtFrom: "invalid-date",
+        publishedAtTo: "another-invalid-date",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+        publishedAtFrom: undefined,
+        publishedAtTo: undefined,
+      });
+    });
+
+    it("returns undefined for both publishedAtFrom and publishedAtTo when both are missing", () => {
+      const searchParams = {};
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "public",
+        publishedAtFrom: undefined,
+        publishedAtTo: undefined,
+      });
     });
   });
 });

--- a/__tests__/lib/search.test.ts
+++ b/__tests__/lib/search.test.ts
@@ -1,0 +1,44 @@
+import "@testing-library/jest-dom";
+import { getValueFromUnknownSearchParams } from "@/lib/search";
+import { UnknownSearchParams } from "@/types";
+
+describe("getValueFromUnknownSearchParams", () => {
+  it("returns the value when it is a string", () => {
+    const searchParams = { key1: "value1" };
+    const result = getValueFromUnknownSearchParams(searchParams, "key1");
+    expect(result).toBe("value1");
+  });
+
+  it("returns the first value when it is an array", () => {
+    const searchParams = { key1: ["value1", "value2"] };
+    const result = getValueFromUnknownSearchParams(searchParams, "key1");
+    expect(result).toBe("value1");
+  });
+
+  it("returns undefined when the key does not exist", () => {
+    const searchParams = { key1: "value1" };
+    const result = getValueFromUnknownSearchParams(searchParams, "key2");
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when the value is undefined", () => {
+    const searchParams = { key1: undefined };
+    const result = getValueFromUnknownSearchParams(searchParams, "key1");
+    expect(result).toBeUndefined();
+  });
+
+  it("handles an empty array gracefully", () => {
+    const searchParams = { key1: [] };
+    const result = getValueFromUnknownSearchParams(searchParams, "key1");
+    expect(result).toBeUndefined();
+  });
+
+  it("handles null values gracefully", () => {
+    const searchParams = { key1: null };
+    const result = getValueFromUnknownSearchParams(
+      searchParams as unknown as UnknownSearchParams,
+      "key1",
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/src/app/[council]/[reference]/comments/search/route.ts
+++ b/src/app/[council]/[reference]/comments/search/route.ts
@@ -36,8 +36,8 @@ export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const council = searchParams.get("council");
 
+  // council parameter is missing
   if (!council) {
-    // console.error("Council parameter is missing");
     return redirect("/not-found");
   }
 
@@ -61,6 +61,5 @@ export async function GET(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
   const redirectPath = pathname.replace("/search", "");
 
-  // console.log("Redirecting to:", `${redirectPath}?${queryParams.toString()}`);
   redirect(`${redirectPath}?${queryParams.toString()}`);
 }

--- a/src/app/[council]/[reference]/comments/search/route.ts
+++ b/src/app/[council]/[reference]/comments/search/route.ts
@@ -17,34 +17,50 @@
 
 import { getAppConfig } from "@/config";
 import { validateSearchParams } from "@/lib/comments";
+import { commentSearchFields } from "@/util/featureFlag";
 import { redirect } from "next/navigation";
 import { NextRequest } from "next/server";
 
+const filterSearchParams = (
+  searchParams: URLSearchParams,
+  excludedKeys: string[],
+): URLSearchParams => {
+  return new URLSearchParams(
+    Array.from(searchParams.entries()).filter(
+      ([key]) => !excludedKeys.includes(key),
+    ),
+  );
+};
+
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
-  let queryParams = new URLSearchParams();
   const council = searchParams.get("council");
 
-  if (council) {
-    const appConfig = getAppConfig(council);
-    const searchParamsObj = Object.fromEntries(searchParams.entries());
-    const validSearchParams = validateSearchParams(appConfig, searchParamsObj);
-    const validSearchParamsObject: Record<string, string> = Object.entries(
-      validSearchParams,
-    ).reduce(
-      (acc, [key, value]) => {
-        if (value !== undefined) {
-          acc[key] = String(value); // Convert all values to strings
-        }
-        return acc;
-      },
-      {} as Record<string, string>,
-    );
-    queryParams = new URLSearchParams(validSearchParamsObject);
+  if (!council) {
+    // console.error("Council parameter is missing");
+    return redirect("/not-found");
   }
 
+  const submitAction = searchParams.get("action");
+  const filteredSearchParams =
+    submitAction === "clear"
+      ? filterSearchParams(searchParams, [...commentSearchFields, "action"])
+      : searchParams;
+
+  const appConfig = getAppConfig(council);
+  const searchParamsObj = Object.fromEntries(filteredSearchParams.entries());
+  const validSearchParams = validateSearchParams(appConfig, searchParamsObj);
+
+  const validSearchParamsObject = Object.fromEntries(
+    Object.entries(validSearchParams).filter(
+      ([_, value]) => value !== undefined,
+    ),
+  );
+
+  const queryParams = new URLSearchParams(validSearchParamsObject);
   const pathname = request.nextUrl.pathname;
   const redirectPath = pathname.replace("/search", "");
 
+  // console.log("Redirecting to:", `${redirectPath}?${queryParams.toString()}`);
   redirect(`${redirectPath}?${queryParams.toString()}`);
 }

--- a/src/app/[council]/[reference]/submit-comment/page.tsx
+++ b/src/app/[council]/[reference]/submit-comment/page.tsx
@@ -33,7 +33,11 @@ import { ContentError } from "@/components/ContentError";
 import { getAppConfigClientSide } from "@/config/getAppConfigClientSide";
 import { AppConfig } from "@/config/types";
 import { BackLink } from "@/components/BackLink/BackLink";
-import { topicLabels, pageTitles, checkCommentsEnabled } from "@/lib/comments";
+import {
+  pageTitles,
+  checkCommentsEnabled,
+  COMMENT_PUBLIC_TOPIC_OPTIONS,
+} from "@/lib/comments";
 import { getPropertyAddress } from "@/lib/planningApplication/application";
 
 type Props = {
@@ -74,7 +78,9 @@ const Comment = ({ params }: Props) => {
 
     if (page === 3 && selectedTopics[currentTopicIndex]) {
       const topicKey = selectedTopics[currentTopicIndex];
-      const overrideTitle = topicLabels[topicKey as keyof typeof topicLabels];
+      const overrideTitle = COMMENT_PUBLIC_TOPIC_OPTIONS.find(
+        (t) => t.value === topicKey,
+      )?.label;
       if (overrideTitle) {
         stepTitle = overrideTitle;
       }

--- a/src/components/FormCommentsSearch/FormCommentsSearch.scss
+++ b/src/components/FormCommentsSearch/FormCommentsSearch.scss
@@ -1,0 +1,24 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+@import "src/styles/component-base";
+
+$selector: "dpr-form-comments-search";
+
+.#{$selector} {
+  @include dpr-form;
+}

--- a/src/components/FormCommentsSearch/FormCommentsSearch.stories.ts
+++ b/src/components/FormCommentsSearch/FormCommentsSearch.stories.ts
@@ -30,8 +30,11 @@ const meta: Meta<typeof FormCommentsSearch> = {
     },
   },
   args: {
-    council: "example-council",
-    reference: "ABC123",
+    searchParams: {
+      page: 1,
+      resultsPerPage: 10,
+      type: "public",
+    },
   },
 };
 

--- a/src/components/FormCommentsSearch/FormCommentsSearch.tsx
+++ b/src/components/FormCommentsSearch/FormCommentsSearch.tsx
@@ -102,7 +102,7 @@ export const FormCommentsSearch = ({
           commentSearchFields.includes("sentimentSpecialist") &&
           sentimentFields()}
 
-        {commentSearchFields.includes("topic") && (
+        {type === "public" && commentSearchFields.includes("topic") && (
           <div className="dpr-form-comments-search__column-one-third">
             <div className="govuk-form-group">
               <label className="govuk-label" htmlFor="topic">

--- a/src/components/FormCommentsSearch/FormCommentsSearch.tsx
+++ b/src/components/FormCommentsSearch/FormCommentsSearch.tsx
@@ -14,47 +14,78 @@
  * You should have received a copy of the GNU General Public License
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
-"use client";
-import { COMMENT_RESULTSPERPAGE_OPTIONS } from "@/lib/comments";
-import { createPathFromParams } from "@/lib/navigation";
+import {
+  COMMENT_PUBLIC_SENTIMENT_OPTIONS,
+  COMMENT_PUBLIC_TOPIC_OPTIONS,
+  COMMENT_RESULTSPERPAGE_OPTIONS,
+  COMMENT_SPECIALIST_SENTIMENT_OPTIONS,
+} from "@/lib/comments";
 import { SearchParamsComments } from "@/types";
 import { commentSearchFields } from "@/util/featureFlag";
-import { useSearchParams } from "next/navigation";
+import "./FormCommentsSearch.scss";
+import { FormFieldFromTo } from "../FormFieldFromTo";
+import { Button } from "../button";
 
 export interface FormCommentsSearchProps {
-  council: string;
-  reference: string;
   searchParams: SearchParamsComments;
   action?: string;
 }
 
 export const FormCommentsSearch = ({
-  council,
-  reference,
   searchParams,
   action,
 }: FormCommentsSearchProps) => {
-  const urlSearchParams = useSearchParams() || new URLSearchParams();
+  const { type } = searchParams;
 
-  const clearFormQueryParams = new URLSearchParams(
-    Array.from(urlSearchParams.entries()).filter(
-      ([key]) => !commentSearchFields.includes(key),
-    ),
+  const sentimentFields = () => (
+    <div className="dpr-form-comments-search__column-one-third">
+      <div className="govuk-form-group">
+        <label className="govuk-label" htmlFor="sentiment">
+          Sentiment
+        </label>
+        <select
+          className="govuk-select govuk-!-width-full"
+          id="sentiment"
+          name="sentiment"
+          defaultValue={searchParams?.sentiment ?? ""}
+        >
+          <option value="">All</option>
+          {type === "public" && (
+            <>
+              {COMMENT_PUBLIC_SENTIMENT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </>
+          )}
+          {type === "specialist" && (
+            <>
+              {COMMENT_SPECIALIST_SENTIMENT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </>
+          )}
+        </select>
+      </div>
+    </div>
   );
 
   const renderFormContent = () => (
-    <>
-      <h2 className="govuk-heading-m">Search comments</h2>
-      <div className="govuk-grid-row">
+    <div className="dpr-form-comments-search">
+      <h2 className="dpr-form-comments-search__title">Search comments</h2>
+      <div className="dpr-form-comments-search__row">
         {commentSearchFields.includes("query") && (
-          <div className="govuk-grid-column-one-third">
+          <div className="dpr-form-comments-search__column-one-third">
             <div className="govuk-form-group">
               <label htmlFor="query" className="govuk-label">
                 Contents
               </label>
               <input
                 name="query"
-                className="govuk-input"
+                className="govuk-input govuk-!-width-full"
                 id="query"
                 type="text"
                 defaultValue={searchParams?.query ?? ""}
@@ -62,48 +93,92 @@ export const FormCommentsSearch = ({
             </div>
           </div>
         )}
-        <div className="govuk-grid-row">
-          {commentSearchFields.includes("query") && (
-            <div className="govuk-grid-column-one-third">
-              <div className="govuk-form-group">
-                <label htmlFor="resultsPerPage" className="govuk-label">
-                  Comments per page
-                </label>
-                <select
-                  id="resultsPerPage"
-                  name="resultsPerPage"
-                  defaultValue={searchParams.resultsPerPage}
-                  className="govuk-select drp-dropdown__select"
-                >
-                  {COMMENT_RESULTSPERPAGE_OPTIONS.map((option) => (
-                    <option key={option} value={option}>
-                      {option}
-                    </option>
-                  ))}
-                </select>
-              </div>
+
+        {/* @TODO get rid of this when both sentimentsare done  */}
+        {type === "public" &&
+          commentSearchFields.includes("sentiment") &&
+          sentimentFields()}
+        {type === "specialist" &&
+          commentSearchFields.includes("sentimentSpecialist") &&
+          sentimentFields()}
+
+        {commentSearchFields.includes("topic") && (
+          <div className="dpr-form-comments-search__column-one-third">
+            <div className="govuk-form-group">
+              <label className="govuk-label" htmlFor="topic">
+                Topic
+              </label>
+
+              <select
+                className="govuk-select govuk-!-width-full"
+                id="topic"
+                name="topic"
+                defaultValue={searchParams?.topic ?? ""}
+              >
+                <option value="">All</option>
+
+                {COMMENT_PUBLIC_TOPIC_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        )}
+      </div>
+      <div className="dpr-form-comments-search__row">
+        {commentSearchFields.includes("publishedAtFrom") &&
+          commentSearchFields.includes("publishedAtTo") && (
+            <div className="dpr-form-comments-search__column-one-third">
+              <FormFieldFromTo
+                title="Published date"
+                from={{
+                  label: "Published from date",
+                  name: "publishedAtFrom",
+                  value: searchParams?.publishedAtFrom,
+                }}
+                to={{
+                  label: "Published to date",
+                  name: "publishedAtTo",
+                  value: searchParams?.publishedAtTo,
+                }}
+              />
             </div>
           )}
-        </div>
-        <div className="govuk-grid-row govuk-!-margin-left-0 grid-row-extra-bottom-margin">
-          <div className="govuk-grid-column-full govuk-button-group">
-            <button
-              type="submit"
-              className="govuk-button dpr-comment-filter__button"
-            >
-              Search
-            </button>
-            <a
-              href={`${createPathFromParams({ council, reference }, "comments")}?${clearFormQueryParams.toString()}`}
-              className="govuk-button govuk-button--secondary"
-              role="button"
-            >
-              Clear search
-            </a>
+        {commentSearchFields.includes("query") && (
+          <div className="dpr-form-comments-search__column-one-third">
+            <div className="govuk-form-group">
+              <label htmlFor="resultsPerPage" className="govuk-label">
+                Comments per page
+              </label>
+              <select
+                id="resultsPerPage"
+                name="resultsPerPage"
+                defaultValue={searchParams.resultsPerPage}
+                className="govuk-select govuk-!-width-full"
+              >
+                {COMMENT_RESULTSPERPAGE_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </div>
           </div>
+        )}
+      </div>
+      <div className="dpr-form-comments-search__row grid-row-extra-bottom-margin">
+        <div className="govuk-grid-column-full govuk-button-group">
+          <Button type="submit" variant="primary" name="action" value="submit">
+            Search
+          </Button>
+          <Button type="submit" variant="secondary" name="action" value="clear">
+            Clear search
+          </Button>
         </div>
       </div>
-    </>
+    </div>
   );
 
   return action ? (

--- a/src/components/FormCommentsSort/FormCommentsSort.scss
+++ b/src/components/FormCommentsSort/FormCommentsSort.scss
@@ -1,0 +1,24 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+@import "src/styles/component-base";
+
+$selector: "dpr-form-comments-sort";
+
+.#{$selector} {
+  @include dpr-form;
+}

--- a/src/components/FormCommentsSort/FormCommentsSort.tsx
+++ b/src/components/FormCommentsSort/FormCommentsSort.tsx
@@ -15,7 +15,11 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 "use client";
-import { SearchParamsComments } from "@/types";
+import {
+  DprCommentOrderBy,
+  DprCommentSortBy,
+  SearchParamsComments,
+} from "@/types";
 import { Button } from "../button";
 import {
   COMMENT_ORDERBY_DEFAULT,
@@ -24,6 +28,7 @@ import {
   COMMENT_SORTBY_OPTIONS,
 } from "@/lib/comments";
 import { useState } from "react";
+import "./FormCommentsSort.scss";
 
 export interface FormCommentsSortProps {
   searchParams: SearchParamsComments;
@@ -59,11 +64,11 @@ export const FormCommentsSort = ({
     const [newSortBy, newOrderBy] = e.target.value.split("_");
 
     if (
-      COMMENT_SORTBY_OPTIONS.includes(newSortBy) &&
-      COMMENT_ORDERBY_OPTIONS.includes(newOrderBy)
+      COMMENT_SORTBY_OPTIONS.includes(newSortBy as DprCommentSortBy) &&
+      COMMENT_ORDERBY_OPTIONS.includes(newOrderBy as DprCommentOrderBy)
     ) {
-      setSortBy(newSortBy);
-      setOrderBy(newOrderBy);
+      setSortBy(newSortBy as DprCommentSortBy);
+      setOrderBy(newOrderBy as DprCommentOrderBy);
     } else {
       setSortBy(COMMENT_SORTBY_DEFAULT);
       setOrderBy(COMMENT_ORDERBY_DEFAULT);
@@ -74,35 +79,37 @@ export const FormCommentsSort = ({
 
   const renderFormContent = () => (
     <>
-      <div className="govuk-grid-row dpr-form-comments-sort">
-        <div className="govuk-grid-column-one-third">
-          <div className="govuk-form-group">
-            <label htmlFor="commentSortByorderBy" className="govuk-label">
-              Sort by
-            </label>
-            <select
-              id="commentSortByorderBy"
-              value={sortByOrderBy}
-              onChange={handleChange}
-              className="govuk-select govuk-!-width-full"
-            >
-              {commentSortByOrderByOptions.map((option) => (
-                <option
-                  key={option.label}
-                  value={`${option.sortBy}_${option.orderBy}`}
-                >
-                  {option.label}
-                </option>
-              ))}
-            </select>
+      <div className="dpr-form-comments-sort">
+        <div className="dpr-form-comments-search__row">
+          <div className="dpr-form-comments-sort__column-one-third">
+            <div className="govuk-form-group">
+              <label htmlFor="commentSortByorderBy" className="govuk-label">
+                Sort by
+              </label>
+              <select
+                id="commentSortByorderBy"
+                value={sortByOrderBy}
+                onChange={handleChange}
+                className="govuk-select govuk-!-width-full"
+              >
+                {commentSortByOrderByOptions.map((option) => (
+                  <option
+                    key={option.label}
+                    value={`${option.sortBy}_${option.orderBy}`}
+                  >
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
           </div>
-        </div>
-        <div className="govuk-grid-column-two-thirds govuk-!-padding-top-6">
-          <input type="hidden" name="sortBy" defaultValue={sortBy} />
-          <input type="hidden" name="orderBy" defaultValue={orderBy} />
-          <Button variant="secondary" type="submit">
-            Apply sorting
-          </Button>
+          <div className="dpr-form-comments-sort__column-two-thirds govuk-!-padding-top-6">
+            <input type="hidden" name="sortBy" defaultValue={sortBy} />
+            <input type="hidden" name="orderBy" defaultValue={orderBy} />
+            <Button variant="secondary" type="submit">
+              Apply sorting
+            </Button>
+          </div>
         </div>
       </div>
     </>

--- a/src/components/FormFieldFromTo/FormFieldFromTo.scss
+++ b/src/components/FormFieldFromTo/FormFieldFromTo.scss
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+@import "src/styles/component-base";
+
+$selector: "dpr-form-field-from-to";
+
+.#{$selector} {
+  legend {
+    margin-bottom: govuk-spacing(1);
+  }
+
+  &__fields {
+    display: grid;
+    grid-template-columns: 46% 1fr 46%;
+    align-items: baseline;
+    gap: 0;
+
+    p {
+      text-align: center;
+    }
+  }
+}

--- a/src/components/FormFieldFromTo/FormFieldFromTo.stories.ts
+++ b/src/components/FormFieldFromTo/FormFieldFromTo.stories.ts
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react";
+import { FormFieldFromTo } from "./FormFieldFromTo";
+
+const meta = {
+  title: "Forms/Form field from to date",
+  component: FormFieldFromTo,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  parameters: {
+    // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
+    layout: "fullscreen",
+  },
+  args: {
+    title: "Published date",
+    from: {
+      label: "Published from date",
+      name: "publishedAtFrom",
+    },
+    to: {
+      label: "Published to date",
+      name: "publishedAtTo",
+    },
+  },
+} satisfies Meta<typeof FormFieldFromTo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/FormFieldFromTo/FormFieldFromTo.tsx
+++ b/src/components/FormFieldFromTo/FormFieldFromTo.tsx
@@ -1,0 +1,76 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import "./FormFieldFromTo.scss";
+
+type FieldProps = {
+  label: string;
+  name: string;
+  id?: string;
+  value?: string;
+};
+
+export interface FormFieldFromToProps {
+  title: string;
+  from: FieldProps;
+  to: FieldProps;
+}
+
+export const FormFieldFromTo = ({ title, from, to }: FormFieldFromToProps) => {
+  return (
+    <fieldset className="govuk-fieldset dpr-form-field-from-to">
+      <legend className="govuk-fieldset__legend">{title}</legend>
+      <div className="dpr-form-field-from-to__fields">
+        <div className="govuk-form-group">
+          <label
+            className="govuk-label govuk-visually-hidden"
+            htmlFor={from.id ?? from.name}
+          >
+            {from.label}
+          </label>
+          <input
+            className="govuk-input govuk-!-width-full"
+            step="1"
+            id={from.id ?? from.name}
+            name={from.name}
+            defaultValue={from.value ?? ""}
+            type="date"
+          />
+        </div>
+        <div className="govuk-form-group" aria-hidden="true">
+          <p className="govuk-body">to</p>
+        </div>
+        <div className="govuk-form-group">
+          <label
+            className="govuk-label govuk-visually-hidden"
+            htmlFor={to.id ?? to.name}
+          >
+            {to.label}
+          </label>
+          <input
+            className="govuk-input govuk-!-width-full"
+            step="1"
+            id={to.id ?? to.name}
+            name={to.name}
+            defaultValue={to.value ?? ""}
+            type="date"
+          />
+        </div>
+      </div>
+    </fieldset>
+  );
+};

--- a/src/components/FormFieldFromTo/index.ts
+++ b/src/components/FormFieldFromTo/index.ts
@@ -1,0 +1,18 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export * from "./FormFieldFromTo";

--- a/src/components/PageApplicationComments/PageApplicationComments.tsx
+++ b/src/components/PageApplicationComments/PageApplicationComments.tsx
@@ -85,19 +85,14 @@ export const PageApplicationComments = ({
           <input type="hidden" name="type" value={type} />
           <input type="hidden" name="council" value={councilSlug} />
           <input type="hidden" name="reference" value={reference} />
-          <FormCommentsSearch
-            council={councilSlug}
-            reference={reference}
-            searchParams={searchParams}
-            // type={type}
-          />
+          <FormCommentsSearch searchParams={searchParams} />
           <FormCommentsSort searchParams={searchParams} />
         </form>
         <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible"></hr>
         {comments && comments.length > 0 ? (
           <>
             {comments.map((comment) => (
-              <CommentCard key={comment.receivedDate} comment={comment} />
+              <CommentCard key={comment.id} comment={comment} />
             ))}
           </>
         ) : (

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -47,6 +47,8 @@ interface ButtonProps {
   >;
   ariaLabel?: string;
   variant?: ButtonVariant;
+  value?: string;
+  name?: string;
 }
 
 export const Button = ({
@@ -58,6 +60,8 @@ export const Button = ({
   onClick,
   ariaLabel,
   variant = "default",
+  value,
+  name,
 }: ButtonProps) => {
   const getVariantClass = (variant: ButtonVariant) => {
     switch (variant) {
@@ -82,7 +86,9 @@ export const Button = ({
   } ${getVariantClass(variant)} ${className}`.trim();
 
   const optionalProps = {
-    ...(ariaLabel && { "aria-label": ariaLabel as string }),
+    ...(ariaLabel && { "aria-label": ariaLabel }),
+    ...(value && { value }),
+    ...(name && { name }),
   };
 
   if (element === "link" && href) {

--- a/src/components/comment_check_answer/index.tsx
+++ b/src/components/comment_check_answer/index.tsx
@@ -23,57 +23,15 @@ import { AppConfig } from "@/config/types";
 import "./CommentCheckAnswer.scss";
 import { Details } from "../govukDpr/Details";
 import { TextButton } from "../TextButton";
-import { sentiment_options } from "@/lib/comments";
+import {
+  COMMENT_PUBLIC_SENTIMENT_OPTIONS,
+  COMMENT_PUBLIC_TOPIC_OPTIONS,
+} from "@/lib/comments";
 import { PersonalDetails } from "../comment_personal_details";
 import { DprCommentSubmission } from "@/types";
 import { CommentSentiment } from "@/types/odp-types/schemas/postSubmissionApplication/enums/CommentSentiment";
 import { CommentTopic } from "@/types/odp-types/schemas/postSubmissionApplication/enums/CommentTopic";
 import { trackClient } from "@/lib/dprAnalytics";
-
-const topics_selection = [
-  {
-    label:
-      "Comment on the design, size or height of new buildings or extensions",
-    value: "design",
-    selectedTopicsLabel:
-      "The design, size or height of new buildings or extensions",
-  },
-  {
-    label: "Comment on the use and function of the proposed development",
-    value: "use",
-    selectedTopicsLabel: "The use and function of the proposed development",
-  },
-  {
-    label: "Comment on any impacts on natural light",
-    value: "light",
-    selectedTopicsLabel: "Any impacts on natural light",
-  },
-  {
-    label: "Comment on any impacts on privacy of neighbours",
-    value: "privacy",
-    selectedTopicsLabel: "Impacts to the privacy of neighbours",
-  },
-  {
-    label: "Comment on disabled access",
-    value: "access",
-    selectedTopicsLabel: <>Impacts on disabled persons&apos; access</>,
-  },
-  {
-    label: "Comment on any noise from new uses",
-    value: "noise",
-    selectedTopicsLabel: "Any noise from new uses",
-  },
-  {
-    label: "Comment on traffic, parking or road safety",
-    value: "traffic",
-    selectedTopicsLabel: "Impacts to traffic, parking or road safety",
-  },
-  {
-    label: "Other comments",
-    value: "other",
-    selectedTopicsLabel: "Any other things",
-  },
-];
 
 const CommentCheckAnswer = ({
   councilConfig,
@@ -135,8 +93,10 @@ const CommentCheckAnswer = ({
   const formatSelectedTopics = (topics: string[]) => {
     return topics
       .map((topic) => {
-        const foundTopic = topics_selection.find((t) => t.value === topic);
-        return foundTopic ? foundTopic.selectedTopicsLabel : "";
+        const foundTopic = COMMENT_PUBLIC_TOPIC_OPTIONS.find(
+          (t) => t.value === topic,
+        );
+        return foundTopic ? foundTopic.selectedLabel : "";
       })
       .filter((label) => label !== "");
   };
@@ -158,7 +118,7 @@ const CommentCheckAnswer = ({
       address: `${personalDetails.address}, ${personalDetails.postcode}`,
       response: comments
         .map(({ topic, comment }) => {
-          const topicLabel = topics_selection.find(
+          const topicLabel = COMMENT_PUBLIC_TOPIC_OPTIONS.find(
             (t) => t.value === topic,
           )?.label;
           return `* ${topicLabel}: ${comment} `;
@@ -261,8 +221,9 @@ const CommentCheckAnswer = ({
                 </dt>
                 <dd className="govuk-summary-list__value">
                   {
-                    sentiment_options.find((option) => option.id === sentiment)
-                      ?.label
+                    COMMENT_PUBLIC_SENTIMENT_OPTIONS.find(
+                      (option) => option.value === sentiment,
+                    )?.label
                   }
                 </dd>
                 <dd className="govuk-summary-list__actions">
@@ -306,12 +267,10 @@ const CommentCheckAnswer = ({
             </dl>
 
             {comments.map(({ topic, comment }, index) => {
-              const foundTopic = topics_selection.find(
+              const foundTopic = COMMENT_PUBLIC_TOPIC_OPTIONS.find(
                 (t) => t.value === topic,
               );
-              const topicLabel = foundTopic
-                ? foundTopic.selectedTopicsLabel
-                : "";
+              const topicLabel = foundTopic ? foundTopic.selectedLabel : "";
 
               return (
                 <dl className="govuk-summary-list" key={index}>

--- a/src/components/comment_sentiment/index.tsx
+++ b/src/components/comment_sentiment/index.tsx
@@ -17,7 +17,7 @@
 
 "use client";
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { sentiment_options } from "@/lib/comments";
+import { COMMENT_PUBLIC_SENTIMENT_OPTIONS } from "@/lib/comments";
 import { trackClient } from "@/lib/dprAnalytics";
 
 const CommentSentiment = ({
@@ -124,21 +124,21 @@ const CommentSentiment = ({
           </legend>
 
           <div className="govuk-radios">
-            {sentiment_options.map((option) => (
-              <div className="govuk-radios__item" key={option.id}>
+            {COMMENT_PUBLIC_SENTIMENT_OPTIONS.map((option) => (
+              <div className="govuk-radios__item" key={option.value}>
                 <input
                   className="govuk-radios__input"
-                  id={option.id}
+                  id={option.value}
                   name="sentiment"
                   type="radio"
-                  value={option.id}
-                  checked={sentiment === option.id}
+                  value={option.value}
+                  checked={sentiment === option.value}
                   onChange={(e) => handleSentimentChange(e.target.value)}
                 />
                 <label
                   className="govuk-label govuk-radios__label"
-                  htmlFor={option.id}
-                  data-testid={option.id}
+                  htmlFor={option.value}
+                  data-testid={option.value}
                 >
                   <span className="govuk-body">{option.label}</span>
                 </label>

--- a/src/components/comment_text_entry/index.tsx
+++ b/src/components/comment_text_entry/index.tsx
@@ -18,7 +18,7 @@
 "use client";
 import React, { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/button";
-import { topicLabels, topicLabelsHint } from "@/lib/comments";
+import { COMMENT_PUBLIC_TOPIC_OPTIONS } from "@/lib/comments";
 import { trackClient } from "@/lib/dprAnalytics";
 
 const MAX_COMMENT_LENGTH = 6000;
@@ -151,11 +151,21 @@ const CommentTextEntry = ({
 
             <h2 className="govuk-label-wrapper">
               <label className="govuk-label govuk-label--m" htmlFor="comment">
-                {topicLabels[currentTopic]}
+                {
+                  COMMENT_PUBLIC_TOPIC_OPTIONS.find(
+                    (option) => option.value === currentTopic,
+                  )?.hint
+                }
               </label>
             </h2>
 
-            <p className="govuk-hint">{topicLabelsHint[currentTopic]}</p>
+            <p className="govuk-hint">
+              {
+                COMMENT_PUBLIC_TOPIC_OPTIONS.find(
+                  (option) => option.value === currentTopic,
+                )?.description
+              }
+            </p>
             <p className="govuk-hint">
               {currentTopicIndex + 1} of {totalTopics}
             </p>

--- a/src/components/comment_topic_selection/index.tsx
+++ b/src/components/comment_topic_selection/index.tsx
@@ -20,49 +20,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { Details } from "../govukDpr/Details";
 import { Button } from "@/components/button";
 import { trackClient } from "@/lib/dprAnalytics";
-
-export const topics_selection = [
-  {
-    label: "Design, size or height of new buildings or extensions",
-    value: "design",
-    hint: "Such as if a building is too tall, or does not fit into the surrounding environment.",
-  },
-  {
-    label: "Use and function of the proposed development",
-    value: "use",
-    hint: "Such as a proposed business that would not serve the area well, or could cause problems due to its operation.",
-  },
-  {
-    label: "Impacts on natural light",
-    value: "light",
-    hint: "Such as a building casting a shadow over residential buildings nearby.",
-  },
-  {
-    label: "Privacy of neighbours",
-    value: "privacy",
-    hint: "Such as a large building overlooking houses and gardens next to it, or being too close to prevent viewing into neighbours windows.",
-  },
-  {
-    label: "Disabled persons' access",
-    value: "access",
-    hint: "Such as a development not providing accessible access to it's entrance, or removing a previous accessible route.",
-  },
-  {
-    label: "Noise from new uses",
-    value: "noise",
-    hint: "Such as a new business causing excessive noise in a residential area.",
-  },
-  {
-    label: "Traffic, parking or road safety",
-    value: "traffic",
-    hint: "Such as the parking proposed being inadequate, or important parking provisions being removed.",
-  },
-  {
-    label: "Other",
-    value: "other",
-    hint: "Anything that does not fit into other categories.",
-  },
-];
+import { COMMENT_PUBLIC_TOPIC_OPTIONS } from "@/lib/comments";
 
 const CommentTopicSelection = ({
   reference,
@@ -183,7 +141,7 @@ const CommentTopicSelection = ({
                 }`}
                 data-module="govuk-checkboxes"
               >
-                {topics_selection.map((topic) => (
+                {COMMENT_PUBLIC_TOPIC_OPTIONS.map((topic) => (
                   <div className="govuk-checkboxes__item" key={topic.value}>
                     <input
                       className={`govuk-checkboxes__input ${
@@ -208,7 +166,7 @@ const CommentTopicSelection = ({
                       aria-describedby={`${topic.value}-hint`}
                       className="govuk-hint govuk-checkboxes__hint"
                     >
-                      {topic.hint}
+                      {topic.description}
                     </div>
                   </div>
                 ))}

--- a/src/handlers/bops/v2/publicComments.ts
+++ b/src/handlers/bops/v2/publicComments.ts
@@ -59,6 +59,16 @@ export async function publicComments(
     if (searchParams.orderBy) {
       params.append("orderBy", searchParams.orderBy);
     }
+    if (searchParams.sentiment) {
+      params.append("sentiment", searchParams.sentiment);
+    }
+    if (searchParams.topic) {
+      params.append("topic", searchParams.topic);
+    }
+    if (searchParams.publishedAtFrom && searchParams.publishedAtTo) {
+      params.append("publishedAtFrom", searchParams.publishedAtFrom);
+      params.append("publishedAtTo", searchParams.publishedAtTo);
+    }
     url = `${url}?${params.toString()}`;
   }
 

--- a/src/handlers/bops/v2/specialistComments.ts
+++ b/src/handlers/bops/v2/specialistComments.ts
@@ -62,9 +62,6 @@ export async function specialistComments(
     if (searchParams.sentiment) {
       params.append("sentiment", searchParams.sentiment);
     }
-    if (searchParams.topic) {
-      params.append("topic", searchParams.topic);
-    }
     if (searchParams.publishedAtFrom && searchParams.publishedAtTo) {
       params.append("publishedAtFrom", searchParams.publishedAtFrom);
       params.append("publishedAtTo", searchParams.publishedAtTo);

--- a/src/handlers/bops/v2/specialistComments.ts
+++ b/src/handlers/bops/v2/specialistComments.ts
@@ -59,6 +59,16 @@ export async function specialistComments(
     if (searchParams.orderBy) {
       params.append("orderBy", searchParams.orderBy);
     }
+    if (searchParams.sentiment) {
+      params.append("sentiment", searchParams.sentiment);
+    }
+    if (searchParams.topic) {
+      params.append("topic", searchParams.topic);
+    }
+    if (searchParams.publishedAtFrom && searchParams.publishedAtTo) {
+      params.append("publishedAtFrom", searchParams.publishedAtFrom);
+      params.append("publishedAtTo", searchParams.publishedAtTo);
+    }
     url = `${url}?${params.toString()}`;
   }
 

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,18 @@
+import { UnknownSearchParams } from "@/types";
+
+export const getValueFromUnknownSearchParams = (
+  searchParams: UnknownSearchParams,
+  key: string,
+): string | undefined => {
+  if (!searchParams || !key) {
+    return undefined; // Return undefined if searchParams or key is not provided
+  }
+  // Check if the key exists in the searchParams
+  const value = searchParams[key];
+
+  if (Array.isArray(value)) {
+    return value[0]; // Use the first element if it's an array
+  }
+
+  return value; // Use the value directly if it's a string or undefined
+};

--- a/src/styles/_utils.scss
+++ b/src/styles/_utils.scss
@@ -17,6 +17,8 @@
 
 @import "node_modules/govuk-frontend/dist/govuk/base";
 
+@import "utils/dpr-form";
+
 %visually-hidden {
   position: absolute;
   width: 1px;

--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -15,6 +15,10 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
+$dpr-breakpoints: (
+  laptop: 1024px,
+);
+// $govuk-show-breakpoints: true;
 $govuk-font-family: Arial, Helvetica, sans-serif;
 $govuk-page-width: 1020px;
 // $govuk-assets-path: "/public/govuk-assets/";

--- a/src/styles/utils/_dpr-form.scss
+++ b/src/styles/utils/_dpr-form.scss
@@ -1,0 +1,66 @@
+/*
+  * @file dpr-form.scss
+  * @description This file is a util for forms for the DPR project.
+  * It is used to create a form with a grid layout and responsive design.
+  * It uses the GOV.UK Frontend framework for styling and layout.
+  * It is used in the FormCommentsSearch component.
+  * It also adds in the date-range component
+  * usage:
+  */
+//
+// @import "src/styles/component-base";
+//
+// $selector: "dpr-form-dataType-formType";
+//
+// .#{$selector} {
+//   @include dpr-form;
+// }
+//
+// <div className="dpr-form-dataType-formType">
+//   <div className="dpr-form-dataType-formType__row">
+//     <div className="dpr-form-dataType-formType__column-one-third">
+//       hello
+//     </div>
+//     <div className="dpr-form-dataType-formType__column-one-third">
+//       hello
+//     </div>
+//     <div className="dpr-form-dataType-formType__column-one-third">
+//       hello
+//     </div>
+//   </div>
+//   <div className="dpr-form-dataType-formType__row">
+//     <div className="dpr-form-dataType-formType__column-two-thirds">
+//       hello
+//     </div>
+//     <div className="dpr-form-dataType-formType__column-one-third">
+//       hello
+//     </div>
+//   </div>
+//   <div className="dpr-form-dataType-formType__row">
+//     <div className="dpr-form-dataType-formType__column-full">hello</div>
+//   </div>
+// </div>
+//
+@use "sass:map";
+@import "node_modules/govuk-frontend/dist/govuk/core/index";
+
+@mixin dpr-form {
+  &__title {
+    @extend %govuk-heading-m;
+  }
+
+  &__row {
+    @include govuk-clearfix;
+    margin-right: -($govuk-gutter-half);
+    margin-left: -($govuk-gutter-half);
+  }
+
+  @each $width in map-keys($govuk-grid-widths) {
+    &__column-#{$width} {
+      @include govuk-grid-column(
+        $width,
+        $at: map.get($dpr-breakpoints, "laptop")
+      );
+    }
+  }
+}

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -16,7 +16,9 @@
  */
 
 import { AssessmentDecision } from "@/types/odp-types/schemas/postSubmissionApplication/enums/AssessmentDecision";
+import { CommentSentiment } from "@/types/odp-types/schemas/postSubmissionApplication/enums/CommentSentiment";
 import { DprCommentTypes } from "@/types/definitions";
+import { CommentTopic } from "./odp-types/schemas/postSubmissionApplication/enums/CommentTopic";
 
 /**
  * This file contains the definitions for common objects used accross the application
@@ -73,6 +75,10 @@ export interface SearchParamsComments extends SearchParams {
   type: DprCommentTypes;
   sortBy?: DprCommentSortBy;
   orderBy?: DprCommentOrderBy;
+  sentiment?: CommentSentiment | SpecialistCommentSentiment;
+  topic?: CommentTopic;
+  publishedAtFrom?: string;
+  publishedAtTo?: string;
 }
 export type DprCommentSortBy = "receivedAt";
 export type DprCommentOrderBy = "asc" | "desc";

--- a/src/util/featureFlag.ts
+++ b/src/util/featureFlag.ts
@@ -77,6 +77,8 @@ export const COMMENT_SEARCH_FIELDS = [
   "publishedAtFrom",
   "publishedAtTo",
   "sentiment",
+  "sentimentSpecialist",
+  "topic",
 ] as const;
 
 export const commentSearchFields = handleFeatureFlags(


### PR DESCRIPTION
This PR will allow us to test [DSNPI-1248](https://tpximpact.atlassian.net/browse/DSNPI-1248) and mark [DSNPI-947](https://tpximpact.atlassian.net/browse/DSNPI-947) as ✅

To test this PR you will need to add (then comment out!) these env vars!

`COMMENT_FILTERING_DISABLED=publishedAtFrom,publishedAtTo,sentiment,sentimentSpecialist,topic`

Each commit in this pull request relates to a separate area for easier reviewing if necessary. 

This PR:

* adds in the `sentiment` (public), `sentiment` (specialist), `topic`, `publishedAtFrom` & `publishedAtTo` fields  (and then hides them)
  * Adds in validation for these fields
  * Adds the values into the payload to the respective API endpoints (if present & valid)
* there are two different sets of values for `sentiment` for public and private 
  * we manage both of them under the same param name
  * we can hide each one or both with the new values for `COMMENT_FILTERING_DISABLED`, `sentiment` and `sentimentSpecialist`
* adds a new component `FormFieldFromTo` for from/to date fields (theres one more for the documents)
* moved the 'clear search' functionality to the form submission route handler 
  * the `FormCommentsSearch` was a client component but to do the clear form functionality this meant that the `COMMENT_FILTERING_DISABLED` env variable couldn't be used, if we made it `NEXT_PUBLIC_` every time we wanted to make a feature visible we'd need to rebuild the site defeating the point of the feature flags so I've converted it to a server component and we now use submit actions to trigger the clear event on submit in the route handler
* updated the css and styling for our forms 
  * created a new `dpr-form` mixin which is now used by `FormCommentsSearch` and `FormCommentsSort` it redoes the form css entirely for the forms. There was an issue with the responsive breakpoints and the form fields overlapping and breaking at the wrong points so I've added a new laptop size breakpoint.

