### PR TITLE
DprPagination totalResults & totalAvailableItems

### DIFF
--- a/__mocks__/dprApplicationFactory.ts
+++ b/__mocks__/dprApplicationFactory.ts
@@ -108,6 +108,7 @@ export const generateDocument = (): DprDocument => {
 export const generatePagination = (
   currentPage: number,
   totalResults: number,
+  totalAvailableItems: number = totalResults,
   resultsPerPage: number = 10,
 ): DprPagination => {
   const totalPages = Math.ceil(totalResults / resultsPerPage);
@@ -116,7 +117,8 @@ export const generatePagination = (
     resultsPerPage,
     currentPage: Number(currentPage),
     totalPages,
-    totalItems: totalResults,
+    totalResults,
+    totalAvailableItems,
   };
 };
 

--- a/__tests__/components/PageSearch.test.tsx
+++ b/__tests__/components/PageSearch.test.tsx
@@ -80,7 +80,7 @@ describe("PageSearch Component", () => {
       <PageSearch
         appConfig={getAppConfig("public-council-1")}
         applications={exampleApplications}
-        pagination={generatePagination(0, 100)}
+        pagination={generatePagination(0, 100, 200)}
         searchParams={{ page: 1, resultsPerPage: 10, query: "search" }}
       />,
     );

--- a/__tests__/components/govuk/Pagination/Pagination.test.tsx
+++ b/__tests__/components/govuk/Pagination/Pagination.test.tsx
@@ -38,7 +38,8 @@ describe("Pagination", () => {
       currentPage: 1,
       resultsPerPage: 10,
       totalPages: 100,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -110,7 +111,8 @@ describe("Pagination", () => {
       currentPage: 2,
       resultsPerPage: 10,
       totalPages: 100,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -200,7 +202,8 @@ describe("Pagination", () => {
       currentPage: 3,
       resultsPerPage: 10,
       totalPages: 100,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -298,7 +301,8 @@ describe("Pagination", () => {
       currentPage: 4,
       resultsPerPage: 10,
       totalPages: 100,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -404,7 +408,8 @@ describe("Pagination", () => {
       currentPage: 5,
       resultsPerPage: 10,
       totalPages: 100,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -510,7 +515,8 @@ describe("Pagination", () => {
       currentPage: 98,
       resultsPerPage: 10,
       totalPages: 100,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -608,7 +614,8 @@ describe("Pagination", () => {
       currentPage: 99,
       resultsPerPage: 10,
       totalPages: 100,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -698,7 +705,8 @@ describe("Pagination", () => {
       currentPage: 100,
       resultsPerPage: 10,
       totalPages: 100,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,
@@ -768,7 +776,8 @@ describe("Pagination", () => {
       currentPage: 0,
       resultsPerPage: 10,
       totalPages: 100,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     };
     const searchParams = {
       resultsPerPage: 10,

--- a/__tests__/mocks/dprApplicationFactory.test.ts
+++ b/__tests__/mocks/dprApplicationFactory.test.ts
@@ -110,7 +110,8 @@ describe("generatePagination", () => {
     expect(pagination).toHaveProperty("resultsPerPage");
     expect(pagination).toHaveProperty("currentPage");
     expect(pagination).toHaveProperty("totalPages");
-    expect(pagination).toHaveProperty("totalItems");
+    expect(pagination).toHaveProperty("totalResults");
+    expect(pagination).toHaveProperty("totalAvailableItems");
   });
 
   it("should generate pagination data with the correct values when current page provided", () => {
@@ -122,6 +123,11 @@ describe("generatePagination", () => {
     const pagination1 = generatePagination(1, 100);
     const pagination2 = generatePagination(2, 100);
     expect(pagination1).not.toEqual(pagination2);
+  });
+
+  it("should generate pagination data with the correct values when totalAvailableItems provided", () => {
+    const pagination = generatePagination(1, 100, 200);
+    expect(pagination.totalAvailableItems).toBe(200);
   });
 });
 

--- a/src/components/PageApplicationDocuments/PageApplicationDocuments.tsx
+++ b/src/components/PageApplicationDocuments/PageApplicationDocuments.tsx
@@ -61,7 +61,8 @@ export const PageApplicationDocuments = ({
     currentPage: 1,
     resultsPerPage: searchParams?.resultsPerPage ?? 9,
     totalPages: 1,
-    totalItems: documents?.length ?? 0,
+    totalResults: documents?.length ?? 0,
+    totalAvailableItems: documents?.length ?? 0,
   };
 
   const { currentPage, resultsPerPage } = documentsPagination;

--- a/src/components/PageSearch/PageSearch.stories.tsx
+++ b/src/components/PageSearch/PageSearch.stories.tsx
@@ -98,6 +98,7 @@ export const DefaultWithEmailAlerts: Story = {
 };
 export const SearchResults: Story = {
   args: {
+    pagination: generatePagination(1, 100, 200),
     searchParams: {
       page: 1,
       resultsPerPage: 10,

--- a/src/components/govuk/Pagination/Pagination.stories.ts
+++ b/src/components/govuk/Pagination/Pagination.stories.ts
@@ -29,7 +29,8 @@ const meta = {
       currentPage: 50,
       totalPages: 100,
       resultsPerPage: 10,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     },
     baseUrl: "search",
     searchParams: {
@@ -67,7 +68,8 @@ export const FirstPage: Story = {
       currentPage: 1,
       totalPages: 100,
       resultsPerPage: 10,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     },
   },
 };
@@ -78,7 +80,8 @@ export const SecondPage: Story = {
       currentPage: 2,
       totalPages: 100,
       resultsPerPage: 10,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     },
   },
 };
@@ -89,7 +92,8 @@ export const ThirdPage: Story = {
       currentPage: 3,
       totalPages: 100,
       resultsPerPage: 10,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     },
   },
 };
@@ -100,7 +104,8 @@ export const FourthPage: Story = {
       currentPage: 4,
       totalPages: 100,
       resultsPerPage: 10,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     },
   },
 };
@@ -111,7 +116,8 @@ export const FifthPage: Story = {
       currentPage: 5,
       totalPages: 100,
       resultsPerPage: 10,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     },
   },
 };
@@ -122,7 +128,8 @@ export const NinetyEighthPage: Story = {
       currentPage: 98,
       totalPages: 100,
       resultsPerPage: 10,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     },
   },
 };
@@ -133,7 +140,8 @@ export const NinetyNinthPage: Story = {
       currentPage: 99,
       totalPages: 100,
       resultsPerPage: 10,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     },
   },
 };
@@ -144,7 +152,8 @@ export const LastPage: Story = {
       currentPage: 100,
       totalPages: 100,
       resultsPerPage: 10,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     },
   },
 };
@@ -155,7 +164,8 @@ export const HigherThanPossiblePage: Story = {
       currentPage: 101,
       totalPages: 100,
       resultsPerPage: 10,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     },
   },
 };
@@ -166,7 +176,8 @@ export const LowerThanPossiblePage: Story = {
       currentPage: 0,
       totalPages: 100,
       resultsPerPage: 10,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     },
   },
 };
@@ -177,7 +188,8 @@ export const EvenLowerThanPossiblePage: Story = {
       currentPage: -1,
       totalPages: 100,
       resultsPerPage: 10,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     },
   },
 };
@@ -188,7 +200,8 @@ export const MoreItemsThanPages: Story = {
       currentPage: 101,
       totalPages: 100,
       resultsPerPage: 10,
-      totalItems: 1000,
+      totalResults: 1000,
+      totalAvailableItems: 1000,
     },
   },
 };

--- a/src/components/govuk/Pagination/Pagination.tsx
+++ b/src/components/govuk/Pagination/Pagination.tsx
@@ -62,7 +62,8 @@ export interface Page {
  * @param {number} pagination.currentPage - The current page number.
  * @param {number} pagination.totalPages - The total number of pages.
  * @param {number} pagination.itemsPerPage - The number of items per page.
- * @param {number} pagination.totalItems - The total number of items.
+ * @param {number} pagination.totalResults - The total number of items for this request.
+ * @param {number} pagination.totalAvailableItems - The total number of items available overall.
  * @param {Object} [prev] - Previous page link.
  * @param {Object} [next] - Next page link.
  * @returns {JSX.Element} The Pagination component.

--- a/src/handlers/bops/converters/planningApplication.ts
+++ b/src/handlers/bops/converters/planningApplication.ts
@@ -91,7 +91,8 @@ export const convertBopsToDprPagination = (
     resultsPerPage: bopsPagination.results,
     currentPage: bopsPagination.page,
     totalPages: bopsPagination.total_pages,
-    totalItems: bopsPagination.total_results,
+    totalResults: bopsPagination.total_results,
+    totalAvailableItems: bopsPagination.total_results,
   };
 };
 

--- a/src/handlers/lib/api.ts
+++ b/src/handlers/lib/api.ts
@@ -35,5 +35,6 @@ export const defaultPagination = {
   resultsPerPage: 0,
   currentPage: 1,
   totalPages: 1,
-  totalItems: 0,
+  totalResults: 0,
+  totalAvailableItems: 0,
 };

--- a/src/handlers/local/v1/publicComments.ts
+++ b/src/handlers/local/v1/publicComments.ts
@@ -73,7 +73,8 @@ const response = (
       resultsPerPage: resultsPerPage,
       currentPage: currentPage,
       totalPages: totalPages,
-      totalItems: exampleComments.length,
+      totalResults: exampleComments.length,
+      totalAvailableItems: exampleComments.length,
     },
   };
 };

--- a/src/handlers/local/v1/specialistComments.ts
+++ b/src/handlers/local/v1/specialistComments.ts
@@ -74,7 +74,8 @@ const response = (
       resultsPerPage: resultsPerPage,
       currentPage: currentPage,
       totalPages: totalPages,
-      totalItems: exampleComments.length,
+      totalResults: exampleComments.length,
+      totalAvailableItems: exampleComments.length,
     },
   };
 };

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -26,17 +26,18 @@ import { DprPagination } from "@/types";
  */
 
 export const createItemPagination = (
-  totalItems: number = 0,
+  totalResults: number = 0,
   paramsPage: number = 1,
   maxDisplayItems: number = 10,
 ): DprPagination => {
   const currentPage = Number(paramsPage);
-  const totalPages = Math.ceil(totalItems / maxDisplayItems);
+  const totalPages = Math.ceil(totalResults / maxDisplayItems);
 
   return {
     resultsPerPage: maxDisplayItems,
     currentPage: currentPage,
     totalPages: totalPages,
-    totalItems: totalItems,
+    totalResults,
+    totalAvailableItems: totalResults,
   };
 };

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -82,28 +82,33 @@ export type DprCommentOrderBy = "asc" | "desc";
  *
  * DprPagination
  * the object that describes the pagination of a list of objects
- * @todo rename these to PascalCase
+ * @todo export type DprPagination = Pagination (from odp-types)
  *
  *
  *
  */
+// export type DprPagination = Pagination;
 export interface DprPagination {
   /**
-   * Number of results per page (e.g., 10)
+   * Number of results per page eg 10
    */
   resultsPerPage: number;
   /**
-   * Current page number (e.g., 1)
+   * Current page number eg 1
    */
   currentPage: number;
   /**
-   * Total number of pages (e.g., 10)
+   * Total number of pages eg 10
    */
   totalPages: number;
   /**
-   * Total number of items (e.g., 100)
+   * Represents the total number of results returned by current query
    */
-  totalItems: number;
+  totalResults: number;
+  /**
+   * Represents the total number of items available in the database (#nofilter)
+   */
+  totalAvailableItems?: number;
 }
 
 /**


### PR DESCRIPTION
This PR updates our internal DprPagination type to match the new naming structure from BOPS. 

This PR goes along with https://github.com/unboxed/bops/pull/2298 and https://github.com/theopensystemslab/digital-planning-data-schemas/pull/346 

We're either converting the default BOPS pagination to our own structure or not yet using the `totalResults`/`totalAvailableItems` values (see [DSNPI-1250](https://tpximpact.atlassian.net/browse/DSNPI-1250)) so this PR can be safely merged at any time ignoring the relating PR's



