### PR TITLE
util for pascalToSentenceCase (also test for codecov)

### DIFF
--- a/__tests__/util/pascalToSentenceCase.test.ts
+++ b/__tests__/util/pascalToSentenceCase.test.ts
@@ -1,0 +1,29 @@
+import { pascalToSentenceCase } from "@/util/pascalToSentenceCase";
+
+describe("pascalToSentenceCase", () => {
+  it("converts PascalCase to sentence case", () => {
+    expect(pascalToSentenceCase("PascalCaseString")).toBe("pascal case string");
+    expect(pascalToSentenceCase("AnotherExampleHere")).toBe(
+      "another example here",
+    );
+    expect(pascalToSentenceCase("SingleWord")).toBe("single word");
+    expect(pascalToSentenceCase("Test")).toBe("test");
+  });
+
+  it("handles strings with no uppercase letters", () => {
+    expect(pascalToSentenceCase("lowercase")).toBe("lowercase");
+  });
+
+  it("handles strings with consecutive uppercase letters", () => {
+    expect(pascalToSentenceCase("XMLParser")).toBe("xml parser");
+    expect(pascalToSentenceCase("HTTPRequest")).toBe("http request");
+  });
+
+  it("handles empty strings", () => {
+    expect(pascalToSentenceCase("")).toBe("");
+  });
+
+  it("handles strings with only one word", () => {
+    expect(pascalToSentenceCase("Word")).toBe("word");
+  });
+});

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -27,3 +27,4 @@ export * from "./flattenObject";
 export * from "./findItemByKey";
 export * from "./addCouncilToName";
 export * from "./splitStringOnOrBeforeMaxChars";
+export * from "./pascalToSentenceCase";

--- a/src/util/pascalToSentenceCase.ts
+++ b/src/util/pascalToSentenceCase.ts
@@ -1,0 +1,10 @@
+/**
+ * Converts a PascalCase string to a normal sentence case (all lowercase).
+ * Example: "PascalCaseString" -> "pascal case string"
+ */
+export function pascalToSentenceCase(input: string): string {
+  return input
+    .replace(/([a-z])([A-Z])/g, "$1 $2") // Add a space between lowercase and uppercase letters
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2") // Handle consecutive uppercase letters followed by lowercase
+    .toLowerCase(); // Convert the entire string to lowercase
+}


### PR DESCRIPTION
Needed something to test codecov changes with so pinched this util from a comment [here](https://github.com/tpximpact/digital-planning-register/pull/327#discussion_r2098913866) 

Since this is made from the main branch which now has a base coverage it should show an increase in coverage from code cov 🤞

