### PR TITLE
BUG: Forgot to disable the rebrand toggle - dont want blue yet!

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -56,7 +56,7 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="govuk-template govuk-template--rebranded ">
+    <html lang="en" className="govuk-template">
       <body className={`govuk-template__body`}>
         <DprAnalytics />
         <noscript>


### PR DESCRIPTION
Forgot I'd left the `govuk-template--rebranded` in for the example screenshots of the new ui I took! 🤦‍♀️ 

It doesn't do much rn it just makes the cookies blue not grey but still we don't want it yet!