### PR TITLE
Advanced search under feature flags

### DIFF
--- a/__tests__/app/council/reference/comments/search.test.tsx
+++ b/__tests__/app/council/reference/comments/search.test.tsx
@@ -1,0 +1,116 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @jest-environment node
+ */
+import { GET } from "@/app/[council]/[reference]/comments/search/route";
+import { redirect } from "next/navigation";
+import { NextRequest } from "next/server";
+
+// Mock dependencies
+jest.mock("next/navigation", () => ({
+  redirect: jest.fn(),
+}));
+jest.mock("@/config", () => ({
+  getAppConfig: jest.fn(() => ({})),
+}));
+jest.mock("@/lib/comments", () => ({
+  validateSearchParams: jest.fn((_, params) => params),
+}));
+jest.mock("@/lib/search", () => ({
+  filterSearchParams: jest.fn((params) => params),
+}));
+jest.mock("@/util/featureFlag", () => ({
+  commentSearchFields: ["field1", "field2"],
+}));
+
+const getMockRequest = (params: Record<string, string>) => {
+  const searchParams = new URLSearchParams(params);
+  return {
+    nextUrl: {
+      searchParams,
+      pathname: "/council/reference/comments/search",
+    },
+  } as unknown as NextRequest;
+};
+
+describe("GET route", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("redirects to /not-found if council param is missing", async () => {
+    await GET(getMockRequest({}));
+    expect(redirect).toHaveBeenCalledWith("/not-found");
+  });
+
+  it("filters search params if action is 'clear'", async () => {
+    const req = getMockRequest({
+      council: "test-council-1",
+      action: "clear",
+      foo: "bar",
+      field1: "shouldRemove",
+      field2: "shouldRemove",
+    });
+    await GET(req);
+    // Should call filterSearchParams with correct excluded keys
+    const { filterSearchParams } = require("@/lib/search");
+    expect(filterSearchParams).toHaveBeenCalledWith(
+      expect.any(URLSearchParams),
+      expect.arrayContaining(["field1", "field2", "action"]),
+    );
+    // Should redirect to correct path (removes /search)
+    expect(redirect).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/council\/reference\/comments\?/),
+    );
+  });
+
+  it("does not filter search params if action is not 'clear'", async () => {
+    const req = getMockRequest({
+      council: "test-council-1",
+      foo: "bar",
+    });
+    await GET(req);
+    // Should not call filterSearchParams
+    const { filterSearchParams } = require("@/lib/search");
+    expect(filterSearchParams).not.toHaveBeenCalled();
+    // Should redirect to correct path (removes /search)
+    expect(redirect).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/council\/reference\/comments\?/),
+    );
+  });
+
+  it("removes undefined values from query params", async () => {
+    // Mock validateSearchParams to return an object with undefined values
+    const { validateSearchParams } = require("@/lib/comments");
+    validateSearchParams.mockReturnValue({
+      foo: "bar",
+      baz: undefined,
+      council: "test-council-1",
+    });
+    const req = getMockRequest({
+      council: "test-council-1",
+      foo: "bar",
+      baz: "",
+    });
+    await GET(req);
+    // Should not include 'baz' in the query string
+    expect(redirect).toHaveBeenCalledWith(expect.stringContaining("foo=bar"));
+    expect(redirect).toHaveBeenCalledWith(expect.not.stringContaining("baz"));
+  });
+});

--- a/__tests__/app/council/search-form.test.tsx
+++ b/__tests__/app/council/search-form.test.tsx
@@ -1,0 +1,142 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @jest-environment node
+ */
+import { GET } from "@/app/[council]/search-form/route";
+import { redirect } from "next/navigation";
+import { NextRequest } from "next/server";
+
+// Mocks
+jest.mock("next/navigation", () => ({
+  redirect: jest.fn(),
+}));
+jest.mock("@/config", () => ({
+  getAppConfig: jest.fn(() => ({})),
+}));
+jest.mock("@/lib/planningApplication/search", () => ({
+  validateSearchParams: jest.fn((_, params) => params),
+}));
+jest.mock("@/lib/search", () => ({
+  filterSearchParams: jest.fn((params) => params),
+}));
+jest.mock("@/util/featureFlag", () => ({
+  applicationSearchFields: ["foo", "bar"],
+}));
+
+const getMockRequest = (
+  params: Record<string, string> | URLSearchParams,
+  pathname = "/council/search-form",
+) => {
+  const searchParams = new URLSearchParams(params);
+  return {
+    nextUrl: {
+      searchParams,
+      pathname,
+    },
+  } as unknown as NextRequest;
+};
+
+describe("GET /search-form route", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("redirects to /not-found if council param is missing", async () => {
+    await GET(getMockRequest({}));
+    expect(redirect).toHaveBeenCalledWith("/not-found");
+  });
+
+  it("filters search params if action is 'clear'", async () => {
+    const req = getMockRequest({
+      council: "test-council-1",
+      action: "clear",
+      foo: "removeMe",
+      bar: "removeMeToo",
+      keep: "yes",
+    });
+    await GET(req);
+    const { filterSearchParams } = require("@/lib/search");
+    expect(filterSearchParams).toHaveBeenCalledWith(
+      expect.any(URLSearchParams),
+      expect.arrayContaining(["foo", "bar", "action"]),
+    );
+  });
+
+  it("removes resultsPerPage from query params", async () => {
+    const {
+      validateSearchParams,
+    } = require("@/lib/planningApplication/search");
+    validateSearchParams.mockReturnValue({
+      council: "test-council-1",
+      keep: "yes",
+      resultsPerPage: 25,
+      another: "ok",
+    });
+    const req = getMockRequest({
+      council: "test-council-1",
+      keep: "yes",
+      resultsPerPage: "25",
+      another: "ok",
+    });
+    await GET(req);
+    // Should not include resultsPerPage in the query string
+    expect(redirect).toHaveBeenCalledWith(expect.stringContaining("keep=yes"));
+    expect(redirect).toHaveBeenCalledWith(
+      expect.stringContaining("another=ok"),
+    );
+    expect(redirect).not.toHaveBeenCalledWith(
+      expect.stringContaining("resultsPerPage"),
+    );
+  });
+
+  it("redirects to correct path with filtered query params", async () => {
+    const req = getMockRequest(
+      {
+        council: "test-council-1",
+        keep: "yes",
+        another: "ok",
+      },
+      "/council/search-form",
+    );
+    await GET(req);
+    expect(redirect).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/council\?(.+&)?keep=yes(&.+)?/),
+    );
+  });
+
+  it.skip("combines duplicate searchParams into unique comma separated list", async () => {
+    const req = getMockRequest(
+      new URLSearchParams([
+        ["council", "test-council-1"],
+        ["keep", "yes"],
+        ["another", "ok"],
+        ["keep", "bar"],
+        ["keep", "bar"],
+        ["keep", "baz"],
+      ]),
+      "/council/search-form",
+    );
+    await GET(req);
+
+    expect(redirect).toHaveBeenCalledWith(
+      expect.stringMatching(/\/council\?(?:.*&)?keep=yes%2Cbar%2Cbaz(?:&.*)?/),
+    );
+  });
+});

--- a/__tests__/app/council/search.test.tsx
+++ b/__tests__/app/council/search.test.tsx
@@ -1,0 +1,102 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import Page from "@/app/[council]/search/page";
+
+// Mock dependencies
+jest.mock("@/config", () => ({
+  getAppConfig: jest.fn(() => ({ council: "test-council-1" })),
+}));
+jest.mock("@/lib/planningApplication/search", () => ({
+  validateSearchParams: jest.fn((_, params) => params),
+}));
+jest.mock("@/components/PageMain", () => ({
+  PageMain: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="page-main">{children}</div>
+  ),
+}));
+jest.mock("@/components/FormSearchFull", () => ({
+  FormSearchFull: (props: any) => {
+    // Only pass valid HTML attributes to the div
+    const { councilSlug, action, children } = props;
+    return (
+      <div
+        data-testid="form-search-full"
+        data-council-slug={councilSlug}
+        data-action={action}
+        data-search-params={JSON.stringify(props.searchParams)}
+      >
+        {JSON.stringify(props.searchParams)}
+        FormSearchFullMock
+        {children}
+      </div>
+    );
+  },
+}));
+jest.mock("@/lib/navigation", () => ({
+  createPathFromParams: jest.fn(() => "/test-council-1/search-form"),
+}));
+
+describe("Page /[council]/search", () => {
+  it("renders PageMain and FormSearchFull with correct props", async () => {
+    const params = { council: "test-council-1" };
+    const searchParams = { foo: "bar" };
+
+    // @ts-ignore
+    render(await Page({ params, searchParams }));
+
+    expect(screen.getByTestId("page-main")).toBeInTheDocument();
+    const form = screen.getByTestId("form-search-full");
+    expect(form).toBeInTheDocument();
+    expect(form).toHaveAttribute("data-council-slug", "test-council-1");
+    expect(form).toHaveAttribute("data-action", "/test-council-1/search-form");
+    expect(form).toHaveAttribute(
+      "data-search-params",
+      JSON.stringify(searchParams),
+    );
+  });
+
+  it("calls getAppConfig and validateSearchParams with correct arguments", async () => {
+    const { getAppConfig } = require("@/config");
+    const {
+      validateSearchParams,
+    } = require("@/lib/planningApplication/search");
+    const params = { council: "test-council-1" };
+    const searchParams = { foo: "bar" };
+
+    // @ts-ignore
+    await Page({ params, searchParams });
+
+    expect(getAppConfig).toHaveBeenCalledWith("test-council-1");
+    expect(validateSearchParams).toHaveBeenCalledWith(
+      expect.any(Object),
+      searchParams,
+    );
+  });
+
+  it("uses default searchParams if not provided", async () => {
+    // @ts-ignore
+    render(await Page({ params: { council: "test-council-1" } }));
+
+    const form = screen.getByTestId("form-search-full");
+    expect(form).toBeInTheDocument();
+    expect(form).not.toHaveAttribute("data-search-params");
+  });
+});

--- a/__tests__/components/DetailsCheckboxAccordion.test.tsx
+++ b/__tests__/components/DetailsCheckboxAccordion.test.tsx
@@ -1,0 +1,115 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { DetailsCheckboxAccordion } from "@/components/DetailsCheckboxAccordion";
+
+// Helper for a simple string option type
+const OPTIONS = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"];
+
+describe("DetailsCheckboxAccordion", () => {
+  it("renders the title and correct number of checkboxes", () => {
+    render(
+      <DetailsCheckboxAccordion
+        title="My Title"
+        name="test"
+        options={OPTIONS}
+        checkedOptions={["A", "C"]}
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { level: 2, name: /My Title/i }),
+    ).toBeInTheDocument();
+    // Should render all options as checkboxes
+    expect(screen.getAllByRole("checkbox")).toHaveLength(OPTIONS.length);
+  });
+
+  it("shows the correct number of selected checkboxes", () => {
+    render(
+      <DetailsCheckboxAccordion
+        title="My Title"
+        name="test"
+        options={OPTIONS}
+        checkedOptions={["A", "C"]}
+      />,
+    );
+    expect(screen.getByText("2 selected")).toBeInTheDocument();
+  });
+
+  it("splits options into two columns if more than 10", () => {
+    const { container } = render(
+      <DetailsCheckboxAccordion
+        title="My Title"
+        name="test"
+        options={OPTIONS}
+        checkedOptions={[]}
+      />,
+    );
+    // Should have two columns
+    const columns = container.querySelectorAll(".govuk-grid-column-one-half");
+    expect(columns.length).toBe(2);
+    // Each column should have roughly half the checkboxes
+    const col1Checkboxes = columns[0].querySelectorAll("input[type=checkbox]");
+    const col2Checkboxes = columns[1].querySelectorAll("input[type=checkbox]");
+    expect(col1Checkboxes.length + col2Checkboxes.length).toBe(OPTIONS.length);
+  });
+
+  it("checks the correct checkboxes based on checkedOptions", () => {
+    render(
+      <DetailsCheckboxAccordion
+        title="My Title"
+        name="test"
+        options={OPTIONS}
+        checkedOptions={["B", "D"]}
+      />,
+    );
+    expect(screen.getByLabelText("B")).toBeChecked();
+    expect(screen.getByLabelText("D")).toBeChecked();
+    expect(screen.getByLabelText("A")).not.toBeChecked();
+  });
+
+  it("updates checked state when a checkbox is clicked", () => {
+    render(
+      <DetailsCheckboxAccordion
+        title="My Title"
+        name="test"
+        options={OPTIONS}
+        checkedOptions={["A"]}
+      />,
+    );
+    const checkboxB = screen.getByLabelText("B");
+    expect(checkboxB).not.toBeChecked();
+    fireEvent.click(checkboxB);
+    expect(checkboxB).toBeChecked();
+    // Clicking again should uncheck
+    fireEvent.click(checkboxB);
+    expect(checkboxB).not.toBeChecked();
+  });
+
+  it("returns null if options is empty", () => {
+    const { container } = render(
+      <DetailsCheckboxAccordion
+        title="Empty"
+        name="empty"
+        options={[]}
+        checkedOptions={[]}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/__tests__/components/FormApplicationsSort.test.tsx
+++ b/__tests__/components/FormApplicationsSort.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  FormApplicationsSort,
+  FormApplicationsSortProps,
+} from "@/components/FormApplicationsSort";
+import {
+  APPLICATION_ORDERBY_DEFAULT,
+  APPLICATION_SORTBY_DEFAULT,
+} from "@/lib/planningApplication/search";
+
+describe("FormApplicationsSort", () => {
+  const defaultProps: FormApplicationsSortProps = {
+    searchParams: {
+      page: 1,
+      resultsPerPage: 10,
+      type: "simple",
+    },
+    action: "/test-action",
+  };
+
+  it("renders the form correctly", () => {
+    render(<FormApplicationsSort {...defaultProps} />);
+
+    // Check if the form is rendered
+    const form = screen.getByRole("form", { name: /Sort applications/i });
+    expect(form).toBeInTheDocument();
+
+    // Check if the select element has the correct default value
+    expect(form).toHaveAttribute("action", "/test-action");
+
+    // shows the correct default sort order
+    const select = screen.getByLabelText(/Sort by/i);
+    expect(select).toHaveValue(
+      `${APPLICATION_SORTBY_DEFAULT}_${APPLICATION_ORDERBY_DEFAULT}`,
+    );
+
+    // renders the Apply sorting button
+    const button = screen.getByRole("button", { name: /apply sorting/i });
+    expect(button).toBeInTheDocument();
+
+    // renders the hidden input for sortBy
+    const hiddenSortBy = screen.getByDisplayValue(APPLICATION_SORTBY_DEFAULT);
+    expect(hiddenSortBy).toHaveAttribute("type", "hidden");
+    expect(hiddenSortBy).toHaveAttribute("name", "sortBy");
+
+    // renders the hidden input for orderBy
+    const hiddenOrderBy = screen.getByDisplayValue(APPLICATION_ORDERBY_DEFAULT);
+    expect(hiddenOrderBy).toHaveAttribute("type", "hidden");
+    expect(hiddenOrderBy).toHaveAttribute("name", "orderBy");
+  });
+
+  it("renders without the form tag when action is not provided", () => {
+    render(<FormApplicationsSort searchParams={defaultProps.searchParams} />);
+
+    // Check that the form is not rendered
+    const form = screen.queryByRole("form", { name: /Sort comments/i });
+    expect(form).not.toBeInTheDocument();
+
+    // Check that the select element is still rendered
+    const select = screen.getByLabelText(/Sort by/i);
+    expect(select).toBeInTheDocument();
+  });
+
+  it("updates the state when a new sorting option is selected", () => {
+    render(<FormApplicationsSort {...defaultProps} />);
+
+    // Select a new sorting option
+    const select = screen.getByLabelText(/Sort by/i);
+    fireEvent.change(select, { target: { value: "receivedAt_asc" } });
+
+    // Check if the select value is updated
+    expect(select).toHaveValue("receivedAt_asc");
+  });
+
+  it("includes hidden inputs for sortBy and orderBy in the form", () => {
+    render(<FormApplicationsSort {...defaultProps} />);
+
+    // Check if the hidden inputs are rendered with the correct values
+    const sortByInput = screen.getByDisplayValue(APPLICATION_SORTBY_DEFAULT);
+    const orderByInput = screen.getByDisplayValue(APPLICATION_ORDERBY_DEFAULT);
+
+    expect(sortByInput).toHaveAttribute("name", "sortBy");
+    expect(orderByInput).toHaveAttribute("name", "orderBy");
+  });
+
+  it("calls the handleChange function when a new option is selected", () => {
+    render(<FormApplicationsSort {...defaultProps} />);
+
+    // Select a new sorting option
+    const select = screen.getByLabelText(/Sort by/i);
+    fireEvent.change(select, { target: { value: "receivedAt_asc" } });
+
+    // Check if the hidden inputs are updated
+    const sortByInput = screen.getByDisplayValue("receivedAt");
+    const orderByInput = screen.getByDisplayValue("asc");
+
+    expect(sortByInput).toHaveAttribute("name", "sortBy");
+    expect(orderByInput).toHaveAttribute("name", "orderBy");
+  });
+});

--- a/__tests__/components/FormFieldApplicationDateRange.test.tsx
+++ b/__tests__/components/FormFieldApplicationDateRange.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FormFieldApplicationDateRange } from "@/components/FormFieldApplicationDateRange";
+import {
+  APPLICATION_DATERANGE_OPTIONS,
+  APPLICATION_DATETYPE_OPTIONS,
+} from "@/lib/planningApplication/search";
+import { SearchParamsApplication } from "@/types";
+
+const defaultSearchParams: SearchParamsApplication = {
+  page: 1,
+  resultsPerPage: 10,
+  type: "simple",
+  dateRange: undefined,
+  dateType: undefined,
+  dateRangeFrom: undefined,
+  dateRangeTo: undefined,
+};
+
+describe("FormFieldApplicationDateRange", () => {
+  it("renders all date type options", () => {
+    render(
+      <FormFieldApplicationDateRange searchParams={defaultSearchParams} />,
+    );
+    APPLICATION_DATETYPE_OPTIONS.forEach((option) => {
+      expect(
+        screen.getByRole("option", { name: option.label }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders all date range radio options", () => {
+    render(
+      <FormFieldApplicationDateRange searchParams={defaultSearchParams} />,
+    );
+    APPLICATION_DATERANGE_OPTIONS.forEach((option) => {
+      expect(screen.getByLabelText(option.label)).toBeInTheDocument();
+    });
+  });
+
+  it("checks the correct radio when dateRange is set", () => {
+    render(
+      <FormFieldApplicationDateRange
+        searchParams={{ ...defaultSearchParams, dateRange: "fixed" }}
+      />,
+    );
+    expect(screen.getByLabelText(/fixed/i)).toBeChecked();
+  });
+
+  it("shows the conditional date range fields when 'fixed' is selected", () => {
+    render(
+      <FormFieldApplicationDateRange
+        searchParams={{ ...defaultSearchParams, dateRange: "fixed" }}
+      />,
+    );
+    expect(screen.getByLabelText("From date")).toBeInTheDocument();
+    expect(screen.getByLabelText("To date")).toBeInTheDocument();
+  });
+
+  it("hides the conditional date range fields when not 'fixed'", () => {
+    render(
+      <FormFieldApplicationDateRange
+        searchParams={{ ...defaultSearchParams, dateRange: "month" }}
+      />,
+    );
+    const conditionalDiv = document.getElementById("conditional-fixed");
+    expect(conditionalDiv?.className).toMatch(
+      /govuk-radios__conditional--hidden/,
+    );
+  });
+
+  it("calls setShow when a radio is changed", () => {
+    // Since setShow is internal, we test the visible effect
+    render(
+      <FormFieldApplicationDateRange searchParams={defaultSearchParams} />,
+    );
+    const fixedRadio = screen.getByLabelText(/fixed/i);
+    fireEvent.click(fixedRadio);
+    // The conditional should now be visible
+    const conditionalDiv = document.getElementById("conditional-fixed");
+    expect(conditionalDiv?.className).not.toMatch(
+      /govuk-radios__conditional--hidden/,
+    );
+  });
+});

--- a/__tests__/components/FormSearch.test.tsx
+++ b/__tests__/components/FormSearch.test.tsx
@@ -1,0 +1,139 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { FormSearch } from "@/components/FormSearch";
+
+// Mocks
+jest.mock("@/components/button", () => ({
+  Button: ({ children, element, href, ...props }: any) =>
+    element === "link" ? (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    ) : (
+      <button {...props}>{children}</button>
+    ),
+}));
+jest.mock("@/lib/navigation", () => ({
+  createPathFromParams: jest.fn((params, suffix) =>
+    params && params.council ? `/${params.council}/${suffix || ""}` : "/",
+  ),
+}));
+jest.mock("@/components/govukDpr/Details", () => ({
+  Details: ({ summaryText, text, open }: any) => (
+    <details open={open} data-testid="details">
+      <summary>{summaryText}</summary>
+      {text}
+    </details>
+  ),
+}));
+jest.mock("@/util/featureFlag", () => ({
+  applicationSearchFields: ["advancedSearch", "quickFilters"],
+}));
+jest.mock("@/lib/planningApplication/search", () => ({
+  APPLICATION_DPR_FILTER_OPTIONS: ["inConsultation", "decided"],
+}));
+jest.mock("@/util", () => ({
+  capitalizeFirstLetter: (s: string) => s.charAt(0).toUpperCase() + s.slice(1),
+  pascalToSentenceCase: (s: string) =>
+    s.replace(/([A-Z])/g, " $1").toLowerCase(),
+}));
+
+describe("FormSearch", () => {
+  it("renders the form", () => {
+    render(<FormSearch params={{ council: "test-council-1" }} />);
+    expect(
+      screen.getByLabelText(/Search by application reference/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: /search by application reference/i }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: /search/i })).toBeInTheDocument();
+  });
+
+  it("renders as a <form> if action is provided", () => {
+    render(
+      <FormSearch
+        params={{ council: "test-council-1" }}
+        action="/test-council-1/search-form"
+      />,
+    );
+    expect(screen.getByRole("form")).toBeInTheDocument();
+    expect(screen.getByRole("form")).toHaveAttribute(
+      "action",
+      "/test-council-1/search-form",
+    );
+
+    const input = screen
+      .getByRole("form")
+      .querySelector('input[type="hidden"][name="council"]');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute("value", "test-council-1");
+  });
+
+  it("renders as a fragment if action is not provided", () => {
+    render(<FormSearch params={{ council: "test-council-1" }} />);
+    // Should not find a form element
+    expect(screen.queryByRole("form")).not.toBeInTheDocument();
+  });
+
+  it("sets the input defaultValue from searchParams", () => {
+    render(
+      <FormSearch
+        params={{ council: "test-council-1" }}
+        searchParams={{ query: "foo" } as any}
+      />,
+    );
+    expect(screen.getByRole("textbox")).toHaveValue("foo");
+  });
+
+  it("renders Advanced search button if advancedSearch is enabled", () => {
+    render(<FormSearch params={{ council: "test-council-1" }} />);
+    expect(
+      screen.getByRole("link", { name: /advanced search/i }),
+    ).toBeInTheDocument();
+  });
+
+  describe("quickFilters", () => {
+    it("renders quick filters details if quickFilters is enabled", () => {
+      render(<FormSearch params={{ council: "test-council-1" }} />);
+      const details = screen.getByTestId("details");
+      expect(details).toBeInTheDocument();
+      expect(details).not.toHaveAttribute("open");
+      expect(screen.getByText(/quick filters/i)).toBeInTheDocument();
+      expect(screen.getByText(/in consultation/i)).toBeInTheDocument();
+      expect(screen.getByText(/decided/i)).toBeInTheDocument();
+    });
+
+    it("shows checkmark for active quick filter and clear link and details box is open", () => {
+      render(
+        <FormSearch
+          params={{ council: "test-council-1" }}
+          searchParams={{ dprFilter: "inConsultation" } as any}
+        />,
+      );
+      expect(screen.getByText(/✔/)).toBeInTheDocument();
+      expect(screen.getByText(/clear quick filters/i)).toBeInTheDocument();
+      const details = screen.getByTestId("details");
+      expect(details).toBeInTheDocument();
+      expect(details).toHaveAttribute("open");
+    });
+  });
+});

--- a/__tests__/components/FormSearchFull.test.tsx
+++ b/__tests__/components/FormSearchFull.test.tsx
@@ -1,0 +1,396 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { FormSearchFull } from "@/components/FormSearchFull";
+import { SearchParamsApplication } from "@/types";
+
+// Mocks
+jest.mock("@/components/button", () => ({
+  Button: ({ children, element, href, ...props }: Record<string, unknown>) =>
+    element === "link" ? (
+      <a href={href as string} {...props}>
+        {children as React.ReactNode}
+      </a>
+    ) : (
+      <button {...props}>{children as React.ReactNode}</button>
+    ),
+}));
+
+jest.mock("@/components/InfoIcon", () => ({
+  InfoIcon: ({
+    href,
+    ariaLabel,
+    title,
+  }: {
+    href: string;
+    ariaLabel: string;
+    title: string;
+  }) => (
+    <a data-testid="info-icon" href={href} aria-label={ariaLabel}>
+      {title}
+    </a>
+  ),
+}));
+
+jest.mock("@/util", () => ({
+  capitalizeFirstLetter: (s: string) => s.charAt(0).toUpperCase() + s.slice(1),
+}));
+
+jest.mock("@/components/FormFieldApplicationDateRange", () => ({
+  FormFieldApplicationDateRange: () => (
+    <div data-testid="FormFieldApplicationDateRange"></div>
+  ),
+}));
+
+jest.mock("@/components/DetailsCheckboxAccordion", () => ({
+  DetailsCheckboxAccordion: ({
+    title,
+    name,
+  }: {
+    title: string;
+    name: string;
+  }) => (
+    <div data-testid="DetailsCheckboxAccordion">
+      <label htmlFor={name}>{title}</label>
+      <input type="checkbox" id={name} name={name} />
+    </div>
+  ),
+}));
+
+const defaultSearchParams: SearchParamsApplication = {
+  page: 1,
+  resultsPerPage: 10,
+  type: "full",
+};
+
+describe("FormSearchFull", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  describe("Navigation", () => {
+    it("renders 'Back to simple search' link", () => {
+      render(
+        <FormSearchFull
+          councilSlug="test-council-1"
+          searchParams={defaultSearchParams}
+        />,
+      );
+      const link = screen.getByRole("link", { name: /back to simple search/i });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "/test-council-1");
+    });
+
+    it("renders infoIcon with link to help page", () => {
+      render(
+        <FormSearchFull
+          councilSlug="test-council-1"
+          searchParams={defaultSearchParams}
+        />,
+      );
+      const infoIcon = screen.getByTestId("info-icon");
+      expect(infoIcon).toBeInTheDocument();
+      expect(infoIcon).toHaveAttribute("href", "/test-council-1/help");
+      expect(infoIcon).toHaveAttribute(
+        "aria-label",
+        "Get help understanding what everything here means",
+      );
+      expect(infoIcon).toHaveTextContent(
+        "Get help understanding what everything here means",
+      );
+    });
+  });
+
+  describe("Form structure", () => {
+    it("renders hidden type input ", () => {
+      const { container } = render(
+        <FormSearchFull
+          councilSlug="test-council-1"
+          searchParams={defaultSearchParams}
+        />,
+      );
+      const input = container.querySelector(
+        'input[type="hidden"][name="type"]',
+      );
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute("value", "full");
+    });
+
+    it("renders as a form with hidden council input when action is set", () => {
+      render(
+        <FormSearchFull
+          councilSlug="test-council-1"
+          action="/test-council-1/search-form"
+          searchParams={defaultSearchParams}
+        />,
+      );
+      const form = screen.getByRole("form");
+      expect(form).toBeInTheDocument();
+      expect(form).toHaveAttribute("action", "/test-council-1/search-form");
+
+      const input = screen
+        .getByRole("form")
+        .querySelector('input[type="hidden"][name="council"]');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute("value", "test-council-1");
+
+      expect(
+        screen.getByRole("button", { name: "Search" }),
+      ).toBeInTheDocument();
+      // Clear button should not be present when action is set
+      expect(
+        screen.queryByRole("button", { name: "Clear search" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders submit and clear buttons when action is not set", () => {
+      render(
+        <FormSearchFull
+          councilSlug="test-council-1"
+          searchParams={defaultSearchParams}
+        />,
+      );
+      expect(
+        screen.getByRole("button", { name: "Search" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Clear search" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Search fields", () => {
+    describe("reference and description", () => {
+      it("renders reference and description fields if enabled", () => {
+        // Mock applicationSearchFields to include both
+        jest.doMock("@/util/featureFlag", () => ({
+          applicationSearchFields: ["reference", "description"],
+        }));
+        const {
+          FormSearchFull: ReloadedFormSearchFull,
+        } = require("@/components/FormSearchFull");
+        render(
+          <ReloadedFormSearchFull
+            councilSlug="test-council-1"
+            searchParams={defaultSearchParams}
+          />,
+        );
+        expect(
+          screen.getByLabelText(/application reference/i),
+        ).toBeInTheDocument();
+        expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+      });
+
+      it("does not render reference/description fields if not enabled", () => {
+        jest.doMock("@/util/featureFlag", () => ({
+          applicationSearchFields: [],
+        }));
+        const {
+          FormSearchFull: ReloadedFormSearchFull,
+        } = require("@/components/FormSearchFull");
+        render(
+          <ReloadedFormSearchFull
+            councilSlug="test-council-1"
+            searchParams={defaultSearchParams}
+          />,
+        );
+        expect(
+          screen.queryByLabelText(/application reference/i),
+        ).not.toBeInTheDocument();
+        expect(screen.queryByLabelText(/description/i)).not.toBeInTheDocument();
+      });
+
+      it("populates reference and description fields if in searchParams", () => {
+        const searchParams: SearchParamsApplication = {
+          page: 1,
+          resultsPerPage: 10,
+          type: "full",
+          reference: "12345",
+          description: "Test description",
+        };
+        render(
+          <FormSearchFull
+            councilSlug="test-council-1"
+            searchParams={searchParams}
+          />,
+        );
+        const referenceInput = screen.getByLabelText(/application reference/i);
+        const descriptionInput = screen.getByLabelText(/description/i);
+        expect(referenceInput).toBeInTheDocument();
+        expect(descriptionInput).toBeInTheDocument();
+        expect(referenceInput).toHaveValue("12345");
+        expect(descriptionInput).toHaveValue("Test description");
+      });
+    });
+
+    describe("applicationType", () => {
+      it("renders applicationType fields if enabled", () => {
+        // Mock applicationSearchFields to include both
+        jest.doMock("@/util/featureFlag", () => ({
+          applicationSearchFields: ["applicationType"],
+        }));
+        const {
+          FormSearchFull: ReloadedFormSearchFull,
+        } = require("@/components/FormSearchFull");
+        render(
+          <ReloadedFormSearchFull
+            councilSlug="test-council-1"
+            searchParams={defaultSearchParams}
+          />,
+        );
+        expect(screen.getByLabelText(/application type/i)).toBeInTheDocument();
+      });
+
+      it("does not render applicationType field if not enabled", () => {
+        jest.doMock("@/util/featureFlag", () => ({
+          applicationSearchFields: [],
+        }));
+        const {
+          FormSearchFull: ReloadedFormSearchFull,
+        } = require("@/components/FormSearchFull");
+        render(
+          <ReloadedFormSearchFull
+            councilSlug="test-council-1"
+            searchParams={defaultSearchParams}
+          />,
+        );
+        expect(
+          screen.queryByLabelText(/application type/i),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    describe("applicationStatus", () => {
+      it("renders applicationStatus fields if enabled", () => {
+        // Mock applicationSearchFields to include both
+        jest.doMock("@/util/featureFlag", () => ({
+          applicationSearchFields: ["applicationStatus"],
+        }));
+        const {
+          FormSearchFull: ReloadedFormSearchFull,
+        } = require("@/components/FormSearchFull");
+        render(
+          <ReloadedFormSearchFull
+            councilSlug="test-council-1"
+            searchParams={defaultSearchParams}
+          />,
+        );
+        expect(
+          screen.getByLabelText(/application status/i),
+        ).toBeInTheDocument();
+      });
+
+      it("does not render applicationStatus field if not enabled", () => {
+        jest.doMock("@/util/featureFlag", () => ({
+          applicationSearchFields: [],
+        }));
+        const {
+          FormSearchFull: ReloadedFormSearchFull,
+        } = require("@/components/FormSearchFull");
+        render(
+          <ReloadedFormSearchFull
+            councilSlug="test-council-1"
+            searchParams={defaultSearchParams}
+          />,
+        );
+        expect(
+          screen.queryByLabelText(/application status/i),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    describe("councilDecision", () => {
+      it("renders councilDecision fields if enabled", () => {
+        // Mock applicationSearchFields to include both
+        jest.doMock("@/util/featureFlag", () => ({
+          applicationSearchFields: ["councilDecision"],
+        }));
+        const {
+          FormSearchFull: ReloadedFormSearchFull,
+        } = require("@/components/FormSearchFull");
+        render(
+          <ReloadedFormSearchFull
+            councilSlug="test-council-1"
+            searchParams={defaultSearchParams}
+          />,
+        );
+        expect(screen.getByLabelText(/council decision/i)).toBeInTheDocument();
+      });
+
+      it("does not render councilDecision field if not enabled", () => {
+        jest.doMock("@/util/featureFlag", () => ({
+          applicationSearchFields: [],
+        }));
+        const {
+          FormSearchFull: ReloadedFormSearchFull,
+        } = require("@/components/FormSearchFull");
+        render(
+          <ReloadedFormSearchFull
+            councilSlug="test-council-1"
+            searchParams={defaultSearchParams}
+          />,
+        );
+        expect(
+          screen.queryByLabelText(/council decision/i),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    describe("dateRange", () => {
+      it("renders dateRange fields if enabled", () => {
+        // Mock applicationSearchFields to include both
+        jest.doMock("@/util/featureFlag", () => ({
+          applicationSearchFields: ["dateRange"],
+        }));
+        const {
+          FormSearchFull: ReloadedFormSearchFull,
+        } = require("@/components/FormSearchFull");
+        render(
+          <ReloadedFormSearchFull
+            councilSlug="test-council-1"
+            searchParams={defaultSearchParams}
+          />,
+        );
+        expect(
+          screen.getByTestId("FormFieldApplicationDateRange"),
+        ).toBeInTheDocument();
+      });
+
+      it("does not render dateRange field if not enabled", () => {
+        jest.doMock("@/util/featureFlag", () => ({
+          applicationSearchFields: [],
+        }));
+        const {
+          FormSearchFull: ReloadedFormSearchFull,
+        } = require("@/components/FormSearchFull");
+        render(
+          <ReloadedFormSearchFull
+            councilSlug="test-council-1"
+            searchParams={defaultSearchParams}
+          />,
+        );
+        expect(
+          screen.queryByTestId("FormFieldApplicationDateRange"),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/__tests__/components/govuk/Details.test.tsx
+++ b/__tests__/components/govuk/Details.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Details } from "@/components/govukDpr/Details";
+
+describe("Details", () => {
+  it("renders summary and text", () => {
+    render(<Details summaryText="Summary" text="Details content" />);
+    expect(screen.getByText("Summary")).toBeInTheDocument();
+    expect(screen.getByText("Details content")).toBeInTheDocument();
+  });
+
+  it("applies inverted class when isInverted is true", () => {
+    render(<Details summaryText="Summary" text="Details content" isInverted />);
+    const details =
+      screen.getByRole("group", { hidden: true }) ||
+      screen.getByText("Summary").closest("details");
+    expect(details).toHaveClass("govuk-details--inverted");
+  });
+
+  it("sets open attribute when open is true", () => {
+    render(<Details summaryText="Summary" text="Details content" open />);
+    const details = screen.getByText("Summary").closest("details");
+    expect(details).toHaveAttribute("open");
+  });
+
+  it("does not set open attribute when open is false", () => {
+    render(<Details summaryText="Summary" text="Details content" />);
+    const details = screen.getByText("Summary").closest("details");
+    expect(details).not.toHaveAttribute("open");
+  });
+
+  it("sets name attribute when name is provided", () => {
+    render(
+      <Details
+        summaryText="Summary"
+        text="Details content"
+        name="my-details"
+      />,
+    );
+    const details = screen.getByText("Summary").closest("details");
+    expect(details).toHaveAttribute("name", "my-details");
+  });
+
+  it("renders JSX elements for summaryText and text", () => {
+    render(
+      <Details
+        summaryText={<span data-testid="custom-summary">Custom Summary</span>}
+        text={<div data-testid="custom-text">Custom Text</div>}
+      />,
+    );
+    expect(screen.getByTestId("custom-summary")).toBeInTheDocument();
+    expect(screen.getByTestId("custom-text")).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/planningApplication/search.test.ts
+++ b/__tests__/lib/planningApplication/search.test.ts
@@ -1,0 +1,651 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { AppConfig } from "@/config/types";
+import {
+  validApplicationStatusSummaries,
+  validApplicationTypes,
+  validDprDecisionSummaries,
+  validPublicApplicationStatusSummaries,
+} from "@/lib/planningApplication";
+import {
+  APPLICATION_DATERANGE_OPTIONS,
+  APPLICATION_DATETYPE_OPTIONS,
+  APPLICATION_DPR_FILTER_OPTIONS,
+  APPLICATION_ORDERBY_OPTIONS,
+  APPLICATION_SORTBY_OPTIONS,
+  checkSearchPerformed,
+  validateSearchParams,
+} from "@/lib/planningApplication/search";
+import { SearchParamsApplication } from "@/types";
+
+describe("checkSearchPerformed", () => {
+  it("returns false if only page, resultsPerPage, or type are set", () => {
+    expect(
+      checkSearchPerformed({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+      }),
+    ).toBe(false);
+
+    expect(
+      checkSearchPerformed({
+        page: 2,
+        resultsPerPage: 25,
+        type: "full",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true if any other param is set with a non-empty value", () => {
+    expect(
+      checkSearchPerformed({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        query: "test",
+      }),
+    ).toBe(true);
+
+    expect(
+      checkSearchPerformed({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        reference: "ABC123",
+      }),
+    ).toBe(true);
+
+    expect(
+      checkSearchPerformed({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        orderBy: "desc",
+      }),
+    ).toBe(true);
+
+    expect(
+      checkSearchPerformed({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        dprFilter: "inConsultation",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false if extra params are set but empty/undefined/null", () => {
+    expect(
+      checkSearchPerformed({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        query: "",
+        reference: undefined,
+        orderBy: null as unknown as SearchParamsApplication["orderBy"],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for an empty object", () => {
+    expect(checkSearchPerformed({} as unknown as SearchParamsApplication)).toBe(
+      false,
+    );
+  });
+});
+
+describe("validateSearchParams", () => {
+  const mockAppConfig: AppConfig = {
+    defaults: {
+      resultsPerPage: 10,
+    },
+  } as unknown as AppConfig;
+
+  describe("required fields: page, resultsPerPage, type", () => {
+    it("returns default values when searchParams is undefined", () => {
+      const result = validateSearchParams(mockAppConfig, undefined);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+      });
+    });
+
+    it("parses valid page and resultsPerPage values", () => {
+      const searchParams = {
+        page: "2",
+        resultsPerPage: "25",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 2,
+        resultsPerPage: 25,
+        type: "simple",
+      });
+    });
+
+    it("defaults to page 1 and resultsPerPage from appConfig when invalid values are provided", () => {
+      const searchParams = {
+        page: "invalid",
+        resultsPerPage: "invalid",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+      });
+    });
+
+    it("validates resultsPerPage against COMMENT_RESULTSPERPAGE_OPTIONS", () => {
+      const searchParams = {
+        resultsPerPage: "100", // Invalid value
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10, // Defaults to appConfig value
+        type: "simple",
+      });
+    });
+  });
+
+  // sortby, orderBy
+  describe("sortBy, orderBy", () => {
+    describe("parses valid sortBy and orderBy values", () => {
+      it.each(
+        APPLICATION_SORTBY_OPTIONS.flatMap((sortBy) =>
+          APPLICATION_ORDERBY_OPTIONS.map((orderBy) => [sortBy, orderBy]),
+        ),
+      )("parses valid sortBy=%s and orderBy=%s values", (sortBy, orderBy) => {
+        const searchParams = { sortBy, orderBy };
+        const result = validateSearchParams(mockAppConfig, searchParams);
+
+        expect(result).toEqual({
+          page: 1,
+          resultsPerPage: 10,
+          type: "simple",
+          sortBy,
+          orderBy,
+        });
+      });
+    });
+
+    it("ignores invalid sortBy and orderBy values", () => {
+      const searchParams = {
+        sortBy: "invalid",
+        orderBy: "invalid",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+      });
+    });
+  });
+
+  // query
+  describe("query", () => {
+    it("parses valid query value", () => {
+      const searchParams = {
+        query: "test-query",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        query: "test-query",
+      });
+    });
+
+    it("handles query as an array and uses the first value", () => {
+      const searchParams = {
+        query: ["test-query", "another-query"],
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        query: "test-query",
+      });
+    });
+  });
+
+  // type
+  describe("type", () => {
+    describe("parses valid types from searchParams", () => {
+      it.each(["simple", "full"])(
+        "parses valid type '%s' from searchParams",
+        (type) => {
+          const searchParams = { type };
+
+          const result = validateSearchParams(mockAppConfig, searchParams);
+
+          expect(result).toEqual({
+            page: 1,
+            resultsPerPage: 10,
+            type,
+          });
+        },
+      );
+    });
+
+    it("defaults to 'simple' type when type is invalid", () => {
+      const searchParams = {
+        type: "invalid",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+      });
+    });
+  });
+
+  // dprFilter
+  describe("dprFilter", () => {
+    describe("parses valid dprFilter's from searchParams", () => {
+      it.each(APPLICATION_DPR_FILTER_OPTIONS)(
+        "parses valid type '%s' from searchParams",
+        (dprFilter) => {
+          const searchParams = { dprFilter };
+
+          const result = validateSearchParams(mockAppConfig, searchParams);
+
+          expect(result).toEqual({
+            page: 1,
+            resultsPerPage: 10,
+            type: "simple",
+            dprFilter,
+          });
+        },
+      );
+    });
+
+    it("ignores invalid dprFilter values", () => {
+      const searchParams = {
+        dprFilter: "invalid",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+      });
+    });
+  });
+
+  // reference
+  describe("reference", () => {
+    it("parses valid reference value", () => {
+      const searchParams = {
+        reference: "test-reference",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        reference: "test-reference",
+      });
+    });
+
+    it("handles reference as an array and uses the first value", () => {
+      const searchParams = {
+        reference: ["test-reference", "another-reference"],
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        reference: "test-reference",
+      });
+    });
+  });
+
+  // description
+  describe("description", () => {
+    it("parses valid description value", () => {
+      const searchParams = {
+        description: "test-description",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        description: "test-description",
+      });
+    });
+
+    it("handles description as an array and uses the first value", () => {
+      const searchParams = {
+        description: ["test-description", "another-description"],
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        description: "test-description",
+      });
+    });
+  });
+
+  // applicationType
+  describe("applicationType", () => {
+    const flatApplicationTypes = Object.values(validApplicationTypes).flat();
+
+    it("allows all valid applicationType values", () => {
+      const searchParams = {
+        applicationType: flatApplicationTypes.join(","),
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        applicationType: flatApplicationTypes.join(","),
+      });
+    });
+
+    it("ignores an invalid applicationType for multiple values", () => {
+      const searchParams = {
+        applicationType: [...flatApplicationTypes, "invalid"].join(","),
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        applicationType: flatApplicationTypes.join(","),
+      });
+    });
+
+    describe("parses valid applicationType's from searchParams", () => {
+      it.each(flatApplicationTypes)(
+        "parses valid type '%s' from searchParams",
+        (applicationType) => {
+          const searchParams = { applicationType };
+
+          const result = validateSearchParams(mockAppConfig, searchParams);
+
+          expect(result).toEqual({
+            page: 1,
+            resultsPerPage: 10,
+            type: "simple",
+            applicationType,
+          });
+        },
+      );
+    });
+
+    it("ignores invalid applicationType values", () => {
+      const searchParams = {
+        applicationType: "invalid",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+      });
+    });
+  });
+
+  // applicationStatus
+  describe("applicationStatus", () => {
+    it("allows all valid public application status summary values", () => {
+      const searchParams = {
+        applicationStatus: validPublicApplicationStatusSummaries.join(","),
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        applicationStatus: validPublicApplicationStatusSummaries.join(","),
+      });
+    });
+
+    it("ignores an invalid application status summaries for multiple values", () => {
+      const searchParams = {
+        applicationStatus: [
+          ...validPublicApplicationStatusSummaries,
+          ...validApplicationStatusSummaries,
+          "invalid",
+        ].join(","),
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        applicationStatus: validPublicApplicationStatusSummaries.join(","),
+      });
+    });
+
+    describe("parses valid application status summaries from searchParams", () => {
+      it.each(validPublicApplicationStatusSummaries)(
+        "parses valid applicationStatusSummary '%s' from searchParams",
+        (applicationStatusSummary) => {
+          const searchParams = { applicationStatus: applicationStatusSummary };
+
+          const result = validateSearchParams(mockAppConfig, searchParams);
+
+          expect(result).toEqual({
+            page: 1,
+            resultsPerPage: 10,
+            type: "simple",
+            applicationStatus: applicationStatusSummary,
+          });
+        },
+      );
+    });
+
+    it("ignores invalid application status summary values", () => {
+      const searchParams = {
+        applicationStatus: "invalid",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+      });
+    });
+  });
+
+  // councilDecision
+  describe("councilDecision", () => {
+    it("allows all valid councilDecision values", () => {
+      const searchParams = {
+        councilDecision: validDprDecisionSummaries.join(","),
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        councilDecision: validDprDecisionSummaries.join(","),
+      });
+    });
+
+    it("ignores an invalid councilDecision for multiple values", () => {
+      const searchParams = {
+        councilDecision: [...validDprDecisionSummaries, "invalid"].join(","),
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        councilDecision: validDprDecisionSummaries.join(","),
+      });
+    });
+
+    describe("parses valid councilDecision from searchParams", () => {
+      it.each(validDprDecisionSummaries)(
+        "parses valid councilDecision '%s' from searchParams",
+        (councilDecision) => {
+          const searchParams = { councilDecision };
+
+          const result = validateSearchParams(mockAppConfig, searchParams);
+
+          expect(result).toEqual({
+            page: 1,
+            resultsPerPage: 10,
+            type: "simple",
+            councilDecision,
+          });
+        },
+      );
+    });
+
+    it("ignores invalid councilDecision values", () => {
+      const searchParams = {
+        applicationStatus: "invalid",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+      });
+    });
+  });
+
+  // dateType
+  describe("dateType", () => {
+    describe("parses valid dateType's from searchParams", () => {
+      it.each(APPLICATION_DATETYPE_OPTIONS)(
+        "parses valid dateType '%s' from searchParams",
+        (dateType) => {
+          const searchParams = { dateType: dateType.value };
+
+          const result = validateSearchParams(mockAppConfig, searchParams);
+
+          expect(result).toEqual({
+            page: 1,
+            resultsPerPage: 10,
+            type: "simple",
+            dateType: dateType.value,
+          });
+        },
+      );
+    });
+
+    it("ignores invalid dateType values", () => {
+      const searchParams = {
+        dateType: "invalid",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+      });
+    });
+  });
+
+  // dateRange
+  describe("dateRange", () => {
+    describe("parses valid dateRange's from searchParams", () => {
+      it.each(APPLICATION_DATERANGE_OPTIONS)(
+        "parses valid dateRange '%s' from searchParams",
+        (dateRange) => {
+          const searchParams = { dateRange: dateRange.value };
+
+          const result = validateSearchParams(mockAppConfig, searchParams);
+
+          expect(result).toEqual({
+            page: 1,
+            resultsPerPage: 10,
+            type: "simple",
+            dateRange: dateRange.value,
+          });
+        },
+      );
+    });
+
+    it("ignores invalid dateRange values", () => {
+      const searchParams = {
+        dateRange: "invalid",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+      });
+    });
+  });
+});

--- a/__tests__/lib/search.test.ts
+++ b/__tests__/lib/search.test.ts
@@ -1,5 +1,25 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import "@testing-library/jest-dom";
-import { getValueFromUnknownSearchParams } from "@/lib/search";
+import {
+  getValueFromUnknownSearchParams,
+  filterSearchParams,
+} from "@/lib/search";
 import { UnknownSearchParams } from "@/types";
 
 describe("getValueFromUnknownSearchParams", () => {
@@ -40,5 +60,42 @@ describe("getValueFromUnknownSearchParams", () => {
       "key1",
     );
     expect(result).toBeNull();
+  });
+});
+
+describe("filterSearchParams", () => {
+  it("removes excluded keys from URLSearchParams", () => {
+    const params = new URLSearchParams({
+      foo: "1",
+      bar: "2",
+      baz: "3",
+    });
+    const filtered = filterSearchParams(params, ["bar"]);
+    expect(filtered.get("foo")).toBe("1");
+    expect(filtered.get("bar")).toBeNull();
+    expect(filtered.get("baz")).toBe("3");
+  });
+
+  it("returns all params if excludedKeys is empty", () => {
+    const params = new URLSearchParams({ a: "x", b: "y" });
+    const filtered = filterSearchParams(params, []);
+    expect(filtered.get("a")).toBe("x");
+    expect(filtered.get("b")).toBe("y");
+  });
+
+  it("returns empty params if all keys are excluded", () => {
+    const params = new URLSearchParams({ a: "1", b: "2" });
+    const filtered = filterSearchParams(params, ["a", "b"]);
+    expect(Array.from(filtered.keys())).toHaveLength(0);
+  });
+
+  it("handles multiple values for the same key", () => {
+    const params = new URLSearchParams();
+    params.append("foo", "1");
+    params.append("foo", "2");
+    params.append("bar", "3");
+    const filtered = filterSearchParams(params, ["bar"]);
+    expect(filtered.getAll("foo")).toEqual(["1", "2"]);
+    expect(filtered.get("bar")).toBeNull();
   });
 });

--- a/src/app/[council]/search/page.tsx
+++ b/src/app/[council]/search/page.tsx
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { UnknownSearchParams } from "@/types";
+import { getAppConfig } from "@/config";
+import { PageMain } from "@/components/PageMain";
+import { validateSearchParams } from "@/lib/planningApplication/search";
+import { FormSearchFull } from "@/components/FormSearchFull";
+import { createPathFromParams } from "@/lib/navigation";
+
+interface PageProps {
+  params: {
+    council: string;
+  };
+  searchParams?: UnknownSearchParams;
+}
+
+export default async function Page({ params, searchParams }: PageProps) {
+  const { council } = params;
+  const appConfig = getAppConfig(council);
+  const validSearchParams = validateSearchParams(appConfig, searchParams);
+  return (
+    <PageMain>
+      <FormSearchFull
+        action={createPathFromParams(params, "/search-form")}
+        councilSlug={council}
+        searchParams={validSearchParams}
+      />
+    </PageMain>
+  );
+}

--- a/src/components/DetailsCheckboxAccordion/DetailsCheckboxAccordion.scss
+++ b/src/components/DetailsCheckboxAccordion/DetailsCheckboxAccordion.scss
@@ -1,0 +1,156 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+@import "src/styles/component-base";
+
+$selector: "dpr-details-checkbox-accordion";
+
+.#{$selector} {
+  $govuk-accordion-base-colour: govuk-colour("black");
+  $govuk-accordion-hover-colour: govuk-colour("light-grey");
+  $govuk-accordion-icon-focus-colour: $govuk-focus-colour;
+  $govuk-accordion-bottom-border-width: 1px;
+
+  &__content {
+    padding-bottom: govuk-spacing(5);
+    @include govuk-media-query($from: tablet) {
+      padding-bottom: govuk-spacing(7);
+    }
+  }
+
+  // sort out the header
+
+  summary {
+    border-top: $govuk-accordion-bottom-border-width solid $govuk-border-colour;
+    padding-top: govuk-spacing(3);
+    padding-bottom: govuk-spacing(5);
+
+    @include govuk-media-query($from: tablet) {
+      padding-bottom: govuk-spacing(7);
+    }
+
+    &:focus {
+      outline: none;
+    }
+    &:hover {
+      cursor: pointer;
+      color: $govuk-accordion-base-colour;
+      background: $govuk-accordion-hover-colour;
+      // The focus state adds a box-shadow to the top and bottom of the
+      // button. We add a grey box-shadow on hover too, to make the height of
+      // the hover state match the height of the focus state.
+      box-shadow:
+        0 -2px $govuk-accordion-hover-colour,
+        0 4px $govuk-accordion-hover-colour;
+
+      .#{$selector}__chevron {
+        &::after {
+          color: $govuk-accordion-base-colour;
+        }
+        span {
+          color: $govuk-accordion-hover-colour;
+          background: $govuk-accordion-base-colour;
+        }
+      }
+    }
+
+    &:focus-within {
+      > p > span {
+        @include govuk-focused-text;
+      }
+      .#{$selector}__chevron,
+      &::after {
+        @include govuk-focused-text;
+      }
+      .#{$selector}__chevron {
+        &::after {
+          color: $govuk-accordion-base-colour;
+        }
+        span {
+          color: $govuk-accordion-icon-focus-colour;
+          background: $govuk-accordion-base-colour;
+        }
+      }
+    }
+  }
+
+  // hide the marker
+  summary {
+    &::marker {
+      content: "";
+    }
+  }
+
+  // fake the show/hide text and chevron
+  &[open] {
+    .#{$selector}__chevron {
+      &::after {
+        content: "Hide";
+      }
+      span {
+        transform: rotate(180deg);
+      }
+    }
+  }
+
+  &__chevron {
+    display: inline-block;
+    @include govuk-font-size($size: 19);
+    &::after {
+      content: "Show";
+      @include govuk-font-size($size: 19);
+      @include govuk-typography-weight-regular;
+      color: $govuk-link-colour;
+    }
+    span {
+      color: $govuk-link-colour;
+      margin: 0 govuk-spacing(1) 0 0;
+      box-sizing: border-box;
+      display: inline-block;
+
+      position: relative;
+
+      // Set size using rems so icon scales with text
+      width: govuk-px-to-rem(20px);
+      height: govuk-px-to-rem(20px);
+
+      border: govuk-px-to-rem(1px) solid;
+      border-radius: 50%;
+
+      vertical-align: middle;
+
+      // Create inner chevron arrow
+      &::after {
+        content: "";
+        box-sizing: border-box;
+        display: block;
+
+        position: absolute;
+        top: govuk-px-to-rem(5px);
+        left: govuk-px-to-rem(6px);
+
+        width: govuk-px-to-rem(6px);
+        height: govuk-px-to-rem(6px);
+
+        transform: rotate(135deg);
+
+        border-top: govuk-px-to-rem(2px) solid;
+        border-right: govuk-px-to-rem(2px) solid;
+      }
+    }
+  }
+}

--- a/src/components/DetailsCheckboxAccordion/DetailsCheckboxAccordion.stories.ts
+++ b/src/components/DetailsCheckboxAccordion/DetailsCheckboxAccordion.stories.ts
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react";
+import { DetailsCheckboxAccordion } from "./DetailsCheckboxAccordion";
+import { validApplicationTypes } from "@/lib/planningApplication";
+
+const flatApplicationTypes = Object.values(validApplicationTypes).flat();
+const meta = {
+  title: "Forms/DetailsCheckboxAccordion",
+  component: DetailsCheckboxAccordion,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  parameters: {
+    // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
+    layout: "fullscreen",
+  },
+  args: {
+    title: "public-council-1",
+    name: "applicationType",
+    options: flatApplicationTypes,
+  },
+} satisfies Meta<typeof DetailsCheckboxAccordion>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Checked: Story = {
+  args: {
+    checkedOptions: flatApplicationTypes.slice(10, 15),
+  },
+};

--- a/src/components/DetailsCheckboxAccordion/DetailsCheckboxAccordion.tsx
+++ b/src/components/DetailsCheckboxAccordion/DetailsCheckboxAccordion.tsx
@@ -1,0 +1,142 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+"use client";
+import React, { useState } from "react";
+import "./DetailsCheckboxAccordion.scss";
+
+export interface DetailsCheckboxAccordionProps<T> {
+  title: string;
+  name: string;
+  options: T[];
+  checkedOptions?: T[];
+}
+
+export function DetailsCheckboxAccordion<T>({
+  title,
+  name,
+  options,
+  checkedOptions,
+}: DetailsCheckboxAccordionProps<T>) {
+  const [checked, setChecked] = useState<T[]>(checkedOptions ?? []);
+
+  if (!options || options.length === 0) {
+    return null;
+  }
+
+  const handleCheckboxChange = (option: T, isChecked: boolean) => {
+    if (isChecked) {
+      setChecked([...checked, option]);
+    } else {
+      setChecked(checked.filter((v) => v !== option));
+    }
+  };
+
+  let col1: T[] = options;
+  let col2: T[] = [];
+
+  if (options.length > 10) {
+    const mid = Math.ceil(options.length / 2);
+    col1 = options.slice(0, mid);
+    col2 = options.slice(mid);
+  }
+  return (
+    <details
+      className="dpr-details-checkbox-accordion"
+      //  useful for debugging
+      // {...(checkedOptions ? { open: true } : {})}
+      name={name}
+    >
+      <summary>
+        <p className="govuk-heading-m" role="heading" aria-level={2}>
+          <span>
+            <span className="govuk-visually-hidden">Open section: </span>
+            {title}
+          </span>
+        </p>
+        <p className="govuk-hint">
+          <span>{checked.length} selected</span>
+        </p>
+        <div
+          className="dpr-details-checkbox-accordion__chevron"
+          aria-hidden={true}
+        >
+          <span></span>
+        </div>
+      </summary>
+      <fieldset className="govuk-fieldset dpr-details-checkbox-accordion__content">
+        <legend className="govuk-fieldset__legend govuk-fieldset__legend--m govuk-visually-hidden">
+          {title}
+        </legend>
+        <div className="govuk-checkboxes govuk-checkboxes--small">
+          <div className="govuk-grid-row">
+            <div className="govuk-grid-column-one-half">
+              {col1.map((option, index) => (
+                <Checkbox<T>
+                  key={`col1-${index}`}
+                  name={name}
+                  option={option}
+                  checked={checked.includes(option)}
+                  onChange={handleCheckboxChange}
+                />
+              ))}
+            </div>
+            <div className="govuk-grid-column-one-half">
+              {col2.map((option, index) => (
+                <Checkbox<T>
+                  key={`col2-${index}`}
+                  name={name}
+                  option={option}
+                  checked={checked.includes(option)}
+                  onChange={handleCheckboxChange}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </details>
+  );
+}
+
+type CheckboxProps<T> = {
+  name: string;
+  option: T;
+  checked: boolean;
+  onChange: (option: T, isChecked: boolean) => void;
+};
+
+function Checkbox<T>({ name, option, checked, onChange }: CheckboxProps<T>) {
+  return (
+    <div className="govuk-checkboxes__item">
+      <input
+        className="govuk-checkboxes__input"
+        id={`${name}-${String(option)}`}
+        name={name}
+        type="checkbox"
+        value={String(option)}
+        checked={checked}
+        onChange={(e) => onChange(option, e.target.checked)}
+      />
+      <label
+        className="govuk-label govuk-checkboxes__label"
+        htmlFor={`${name}-${String(option)}`}
+      >
+        {String(option)}
+      </label>
+    </div>
+  );
+}

--- a/src/components/DetailsCheckboxAccordion/index.ts
+++ b/src/components/DetailsCheckboxAccordion/index.ts
@@ -1,0 +1,18 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export * from "./DetailsCheckboxAccordion";

--- a/src/components/FormApplicationsSort/FormApplicationsSort.scss
+++ b/src/components/FormApplicationsSort/FormApplicationsSort.scss
@@ -1,0 +1,24 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+@import "src/styles/component-base";
+
+$selector: "dpr-form-applications-sort";
+
+.#{$selector} {
+  @include dpr-form;
+}

--- a/src/components/FormApplicationsSort/FormApplicationsSort.stories.ts
+++ b/src/components/FormApplicationsSort/FormApplicationsSort.stories.ts
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Meta, StoryObj } from "@storybook/react";
+import { FormApplicationsSort } from "./FormApplicationsSort";
+
+const meta: Meta<typeof FormApplicationsSort> = {
+  title: "Forms/Applications Sort",
+  component: FormApplicationsSort,
+  tags: ["autodocs"],
+  args: {
+    searchParams: {
+      type: "simple",
+      resultsPerPage: 10,
+      page: 1,
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FormApplicationsSort>;
+
+export const Default: Story = {};
+
+export const OldestFirst: Story = {
+  args: {
+    searchParams: {
+      type: "simple",
+      sortBy: "receivedAt",
+      orderBy: "asc",
+      resultsPerPage: 10,
+      page: 1,
+    },
+  },
+};
+
+export const WithForm: Story = {
+  args: {
+    action: "/comments",
+    searchParams: {
+      type: "simple",
+      resultsPerPage: 10,
+      page: 1,
+    },
+  },
+};

--- a/src/components/FormApplicationsSort/FormApplicationsSort.tsx
+++ b/src/components/FormApplicationsSort/FormApplicationsSort.tsx
@@ -1,0 +1,154 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+"use client";
+import {
+  DprApplicationOrderBy,
+  DprApplicationSortBy,
+  SearchParamsApplication,
+} from "@/types";
+import { Button } from "../button";
+import { useState } from "react";
+import "./FormApplicationsSort.scss";
+import {
+  APPLICATION_ORDERBY_DEFAULT,
+  APPLICATION_ORDERBY_OPTIONS,
+  APPLICATION_SORTBY_DEFAULT,
+  APPLICATION_SORTBY_OPTIONS,
+} from "@/lib/planningApplication/search";
+
+export interface FormApplicationsSortProps {
+  searchParams: SearchParamsApplication;
+  action?: string;
+}
+
+export const FormApplicationsSort = ({
+  searchParams,
+  action,
+}: FormApplicationsSortProps) => {
+  const [sortBy, setSortBy] = useState(
+    searchParams?.sortBy ?? APPLICATION_SORTBY_DEFAULT,
+  );
+  const [orderBy, setOrderBy] = useState(
+    searchParams?.orderBy ?? APPLICATION_ORDERBY_DEFAULT,
+  );
+  const [sortByOrderBy, setSortByOrderBy] = useState(`${sortBy}_${orderBy}`);
+
+  const applicationSortByOrderByOptions = [
+    {
+      label: "By received date",
+      options: [
+        {
+          label: "Newest to oldest",
+          sortBy: "receivedAt",
+          orderBy: "desc",
+        },
+        {
+          label: "Oldest to newest",
+          sortBy: "receivedAt",
+          orderBy: "asc",
+        },
+      ],
+    },
+    {
+      label: "By council decision date",
+      options: [
+        {
+          label: "Newest to oldest",
+          sortBy: "councilDecisionDate",
+          orderBy: "desc",
+        },
+        {
+          label: "Oldest to newest",
+          sortBy: "councilDecisionDate",
+          orderBy: "asc",
+        },
+      ],
+    },
+  ];
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const [newSortBy, newOrderBy] = e.target.value.split("_");
+
+    if (
+      APPLICATION_SORTBY_OPTIONS.includes(newSortBy as DprApplicationSortBy) &&
+      APPLICATION_ORDERBY_OPTIONS.includes(newOrderBy as DprApplicationOrderBy)
+    ) {
+      setSortBy(newSortBy as DprApplicationSortBy);
+      setOrderBy(newOrderBy as DprApplicationOrderBy);
+    } else {
+      setSortBy(APPLICATION_SORTBY_DEFAULT);
+      setOrderBy(APPLICATION_ORDERBY_DEFAULT);
+    }
+
+    setSortByOrderBy(`${newSortBy}_${newOrderBy}`);
+  };
+
+  const renderFormContent = () => (
+    <>
+      <div className="dpr-form-applications-sort">
+        <div className="dpr-form-applications-sort__row">
+          <div className="dpr-form-applications-sort__column-one-third">
+            <div className="govuk-form-group">
+              <label htmlFor="applicationSortByorderBy" className="govuk-label">
+                Sort by
+              </label>
+              <select
+                id="applicationSortByorderBy"
+                value={sortByOrderBy}
+                onChange={handleChange}
+                className="govuk-select govuk-!-width-full"
+              >
+                {applicationSortByOrderByOptions.map((option) => (
+                  <optgroup label={option.label} key={option.label}>
+                    {option.options.map((opt) => (
+                      <option
+                        key={opt.label}
+                        value={`${opt.sortBy}_${opt.orderBy}`}
+                      >
+                        {opt.label}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className="dpr-form-applications-sort__column-two-thirds govuk-!-padding-top-6">
+            <input type="hidden" name="sortBy" defaultValue={sortBy} />
+            <input type="hidden" name="orderBy" defaultValue={orderBy} />
+            <Button variant="secondary" type="submit">
+              Apply sorting
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+
+  return action ? (
+    <form
+      className="govuk-form"
+      method="get"
+      action={action}
+      aria-label="Sort applications"
+    >
+      {renderFormContent()}
+    </form>
+  ) : (
+    renderFormContent()
+  );
+};

--- a/src/components/FormApplicationsSort/index.tsx
+++ b/src/components/FormApplicationsSort/index.tsx
@@ -1,0 +1,18 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export * from "./FormApplicationsSort";

--- a/src/components/FormFieldApplicationDateRange/FormFieldApplicationDateRange.scss
+++ b/src/components/FormFieldApplicationDateRange/FormFieldApplicationDateRange.scss
@@ -1,0 +1,18 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+@import "src/styles/component-base";

--- a/src/components/FormFieldApplicationDateRange/FormFieldApplicationDateRange.stories.ts
+++ b/src/components/FormFieldApplicationDateRange/FormFieldApplicationDateRange.stories.ts
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react";
+import { FormFieldApplicationDateRange } from "./FormFieldApplicationDateRange";
+
+const meta = {
+  title: "Forms/FormFieldApplicationDateRange",
+  component: FormFieldApplicationDateRange,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  parameters: {
+    // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
+    layout: "fullscreen",
+  },
+  args: {
+    searchParams: {
+      page: 1,
+      resultsPerPage: 10,
+      type: "simple",
+    },
+  },
+} satisfies Meta<typeof FormFieldApplicationDateRange>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const WithData: Story = {
+  args: {
+    searchParams: {
+      page: 1,
+      resultsPerPage: 10,
+      type: "simple",
+      dateType: "publishedAt",
+      dateRange: "month",
+    },
+  },
+};
+export const Fixed: Story = {
+  args: {
+    searchParams: {
+      page: 1,
+      resultsPerPage: 10,
+      type: "simple",
+      dateType: "publishedAt",
+      dateRange: "fixed",
+      dateRangeFrom: "2023-01-01",
+      dateRangeTo: "2023-01-31",
+    },
+  },
+};

--- a/src/components/FormFieldApplicationDateRange/FormFieldApplicationDateRange.tsx
+++ b/src/components/FormFieldApplicationDateRange/FormFieldApplicationDateRange.tsx
@@ -1,0 +1,109 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+"use client";
+import { SearchParamsApplication } from "@/types";
+import "./FormFieldApplicationDateRange.scss";
+import {
+  APPLICATION_DATERANGE_OPTIONS,
+  APPLICATION_DATETYPE_OPTIONS,
+} from "@/lib/planningApplication/search";
+import { FormFieldFromTo } from "@/components/FormFieldFromTo";
+import { useState } from "react";
+
+export interface FormFieldApplicationDateRangeProps {
+  searchParams: SearchParamsApplication;
+}
+
+export const FormFieldApplicationDateRange = ({
+  searchParams,
+}: FormFieldApplicationDateRangeProps) => {
+  const [show, setShow] = useState(searchParams?.dateRange === "fixed");
+  return (
+    <fieldset className="govuk-fieldset">
+      <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">
+        Time period
+      </legend>
+
+      <div className="govuk-form-group">
+        <label className="govuk-label" htmlFor="dateType">
+          Date...
+        </label>
+        <select
+          className="govuk-select"
+          id="date"
+          name="dateType"
+          defaultValue={searchParams?.dateType ?? ""}
+        >
+          <option value="" disabled />
+          {APPLICATION_DATETYPE_OPTIONS.map(
+            (option: { value: string; label: string }) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ),
+          )}
+        </select>
+      </div>
+
+      <div className="govuk-form-group govuk-frontend-supported">
+        <label className="govuk-label" htmlFor="dateRange">
+          Date range
+        </label>
+        <div className="govuk-radios">
+          {APPLICATION_DATERANGE_OPTIONS.map((option) => (
+            <div key={option.value} className="govuk-radios__item">
+              <input
+                className="govuk-radios__input"
+                id={option.value}
+                name="dateRange"
+                type="radio"
+                value={option.value}
+                aria-controls={`conditional-${option.value}`}
+                defaultChecked={searchParams?.dateRange === option.value}
+                onChange={() => setShow(option.value === "fixed")}
+              />
+              <label
+                className="govuk-label govuk-radios__label"
+                htmlFor={option.value}
+              >
+                {option.label}
+              </label>
+            </div>
+          ))}
+          <div
+            className={`govuk-radios__conditional${!show ? " govuk-radios__conditional--hidden" : ""}`}
+            id={`conditional-fixed`}
+          >
+            <FormFieldFromTo
+              title="Date range"
+              from={{
+                label: "From date",
+                name: "dateRangeFrom",
+                value: searchParams?.dateRangeFrom,
+              }}
+              to={{
+                label: "To date",
+                name: "dateRangeTo",
+                value: searchParams?.dateRangeTo,
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </fieldset>
+  );
+};

--- a/src/components/FormFieldApplicationDateRange/index.ts
+++ b/src/components/FormFieldApplicationDateRange/index.ts
@@ -1,0 +1,18 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export * from "./FormFieldApplicationDateRange";

--- a/src/components/FormSearch/FormSearch.scss
+++ b/src/components/FormSearch/FormSearch.scss
@@ -15,6 +15,19 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-.search-bar-buttons {
-  margin-top: 30px;
+@import "src/styles/component-base";
+
+.dpr-form-search {
+  &__actions {
+    // this mimics the govuk-label element on the other side of the grid so that the buttons stay aligned regardless of screen size
+    &::before {
+      @include govuk-font($size: 19);
+      content: "Search by application reference, address or description";
+      visibility: hidden;
+      display: block;
+    }
+  }
+  .govuk-button-group {
+    margin-top: govuk-spacing(1);
+  }
 }

--- a/src/components/FormSearch/FormSearch.stories.ts
+++ b/src/components/FormSearch/FormSearch.stories.ts
@@ -28,7 +28,9 @@ const meta = {
     layout: "fullscreen",
   },
   args: {
-    action: "/search",
+    params: {
+      council: "test-council",
+    },
   },
 } satisfies Meta<typeof FormSearch>;
 
@@ -36,3 +38,23 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+export const WithSearchQuery: Story = {
+  args: {
+    searchParams: {
+      page: 1,
+      resultsPerPage: 10,
+      type: "simple",
+      query: "Search query",
+    },
+  },
+};
+export const WithDprFilter: Story = {
+  args: {
+    searchParams: {
+      page: 1,
+      resultsPerPage: 10,
+      type: "simple",
+      dprFilter: "inConsultation",
+    },
+  },
+};

--- a/src/components/FormSearch/FormSearch.tsx
+++ b/src/components/FormSearch/FormSearch.tsx
@@ -15,38 +15,117 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { SearchParams } from "@/types";
+import { SearchParamsApplication } from "@/types";
 import "./FormSearch.scss";
 import { Button } from "@/components/button";
+import { createPathFromParams } from "@/lib/navigation";
+import { Details } from "@/components/govukDpr/Details";
+import { APPLICATION_DPR_FILTER_OPTIONS } from "@/lib/planningApplication/search";
+import { capitalizeFirstLetter, pascalToSentenceCase } from "@/util";
+import Link from "next/link";
+import { applicationSearchFields } from "@/util/featureFlag";
 
 export interface FormSearchProps {
-  action: string;
-  searchParams?: SearchParams;
+  params: {
+    council: string;
+  };
+  action?: string;
+  searchParams?: SearchParamsApplication;
 }
 
-export const FormSearch = ({ action, searchParams }: FormSearchProps) => {
-  return (
-    <form action={action} method="get" className="govuk-grid-row">
-      <div className="govuk-grid-column-one-half">
-        <div className="govuk-form-group">
-          <label className="govuk-label" htmlFor="query">
-            Search by application reference, address or description
-          </label>
-          <input
-            className="govuk-input"
-            id="query"
-            name="query"
-            type="text"
-            defaultValue={searchParams?.query || ""}
-            autoComplete="on"
-          />
+export const FormSearch = ({
+  params,
+  action,
+  searchParams,
+}: FormSearchProps) => {
+  const renderFormContent = () => (
+    <>
+      <div className="govuk-grid-row dpr-form-search">
+        <div className="govuk-grid-column-one-half">
+          <div className="govuk-form-group">
+            <label className="govuk-label" htmlFor="query">
+              Search by application reference, address or description
+            </label>
+            <input
+              className="govuk-input"
+              id="query"
+              name="query"
+              type="text"
+              defaultValue={searchParams?.query || ""}
+              autoComplete="on"
+              required={true}
+            />
+          </div>
+        </div>
+        <div className="govuk-grid-column-one-half dpr-form-search__actions">
+          <div className="govuk-button-group">
+            <Button type="submit" element="button" variant="default">
+              Search
+            </Button>
+            {applicationSearchFields.includes("advancedSearch") && (
+              <Button
+                element="link"
+                href={`${createPathFromParams(params, `search`)}`}
+                variant="secondary"
+              >
+                Advanced search
+              </Button>
+            )}
+          </div>
         </div>
       </div>
-      <div className="govuk-grid-column-one-quarter search-bar-buttons">
-        <Button type="submit" element="button" variant="default">
-          Search
-        </Button>
-      </div>
+      {applicationSearchFields.includes("quickFilters") && (
+        <Details
+          summaryText="Quick filters"
+          text={<QuickFilters params={params} searchParams={searchParams} />}
+          open={!!searchParams?.dprFilter}
+        />
+      )}
+    </>
+  );
+
+  return action ? (
+    <form
+      className="govuk-form"
+      method="get"
+      action={action}
+      aria-label="Sort applications"
+    >
+      <input type="hidden" name="council" value={params.council} />
+      {renderFormContent()}
     </form>
+  ) : (
+    renderFormContent()
+  );
+};
+
+const QuickFilters = ({ params, searchParams }: FormSearchProps) => {
+  const activeFilter = searchParams?.dprFilter;
+  return (
+    <>
+      <div className="govuk-button-group">
+        {APPLICATION_DPR_FILTER_OPTIONS.map((option) => (
+          <Button
+            key={option}
+            element="link"
+            href={`${createPathFromParams(params)}?dprFilter=${option}`}
+            variant={option === activeFilter ? "primary" : "secondary"}
+          >
+            {option === activeFilter && <>&#10004;&nbsp;</>}
+            {capitalizeFirstLetter(pascalToSentenceCase(option))}
+          </Button>
+        ))}
+      </div>
+      {activeFilter && (
+        <p>
+          <Link
+            href={`${createPathFromParams(params)}`}
+            className="govuk-link govuk-link--no-visited-state"
+          >
+            &#10006;&nbsp;Clear quick filters
+          </Link>
+        </p>
+      )}
+    </>
   );
 };

--- a/src/components/FormSearchFull/FormSearchFull.scss
+++ b/src/components/FormSearchFull/FormSearchFull.scss
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+@import "src/styles/component-base";
+
+.dpr-form-search-full {
+  position: relative;
+  .info-icon {
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+}

--- a/src/components/FormSearchFull/FormSearchFull.stories.ts
+++ b/src/components/FormSearchFull/FormSearchFull.stories.ts
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react";
+import { FormSearchFull } from "./FormSearchFull";
+import {
+  validApplicationStatusSummaries,
+  validApplicationTypes,
+  validDprDecisionSummaries,
+} from "@/lib/planningApplication";
+
+const flatApplicationTypes = Object.values(validApplicationTypes).flat();
+
+const meta = {
+  title: "Forms/Search form (full)",
+  component: FormSearchFull,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  parameters: {
+    // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
+    layout: "fullscreen",
+  },
+  args: {
+    councilSlug: "test-council-1",
+    searchParams: {
+      page: 1,
+      resultsPerPage: 10,
+      type: "simple",
+    },
+  },
+} satisfies Meta<typeof FormSearchFull>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const InForm: Story = {
+  args: {
+    action: "search",
+  },
+};
+export const WithSearchParams: Story = {
+  args: {
+    searchParams: {
+      page: 1,
+      resultsPerPage: 10,
+      type: "full",
+      reference: "12345",
+      description: "Test description",
+      applicationType: flatApplicationTypes.splice(0, 10).join(","),
+      applicationStatus: validApplicationStatusSummaries.splice(0, 3).join(","),
+      councilDecision: validDprDecisionSummaries.splice(0, 3).join(","),
+      dateType: "publishedAt",
+      dateRange: "fixed",
+      dateRangeFrom: "2023-01-01",
+      dateRangeTo: "2023-01-31",
+    },
+  },
+};

--- a/src/components/FormSearchFull/FormSearchFull.tsx
+++ b/src/components/FormSearchFull/FormSearchFull.tsx
@@ -1,0 +1,179 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Button } from "@/components/button";
+import "./FormSearchFull.scss";
+import { SearchParamsApplication } from "@/types";
+import { InfoIcon } from "../InfoIcon";
+import { applicationSearchFields } from "@/util/featureFlag";
+import { DetailsCheckboxAccordion } from "@/components/DetailsCheckboxAccordion";
+import {
+  validApplicationTypes,
+  validDprDecisionSummaries,
+  validPublicApplicationStatusSummaries,
+} from "@/lib/planningApplication";
+import { capitalizeFirstLetter } from "@/util";
+import { FormFieldApplicationDateRange } from "@/components/FormFieldApplicationDateRange";
+
+export interface FormSearchFullProps {
+  councilSlug: string;
+  action?: string;
+  searchParams: SearchParamsApplication;
+}
+
+export const FormSearchFull = ({
+  councilSlug,
+  action,
+  searchParams,
+}: FormSearchFullProps) => {
+  const flatApplicationTypes = Object.values(validApplicationTypes).flat();
+
+  const renderFormContent = () => (
+    <div className="dpr-form-search-full">
+      <input type="hidden" name="type" value="full" />
+      <InfoIcon
+        href={`/${councilSlug}/help`}
+        title="Get help understanding what everything here means"
+        ariaLabel="Get help understanding what everything here means"
+        className="dpr-form-search-full__info-icon"
+      />
+      <div className="govuk-button-group">
+        <Button variant="secondary" href={`/${councilSlug}`} element="link">
+          Back to simple search
+        </Button>
+        {/* <Button variant="secondary" href={`/${councilSlug}/map`} element="link">
+          Search an area on a map
+        </Button> */}
+      </div>
+
+      {["reference", "description"].some((field) =>
+        applicationSearchFields.includes(field),
+      ) && (
+        <>
+          <div className="govuk-grid-row grid-row-extra-bottom-margin">
+            <div className="govuk-grid-column-one-half">
+              <fieldset className="govuk-fieldset">
+                <legend className="govuk-fieldset__legend govuk-visually-hidden">
+                  Simple application search
+                </legend>
+
+                {/* application reference */}
+                {applicationSearchFields.includes("reference") && (
+                  <div className="govuk-form-group">
+                    <label className="govuk-label" htmlFor="reference">
+                      Application reference
+                    </label>
+                    <input
+                      className="govuk-input govuk-!-width-full"
+                      id="reference"
+                      name="reference"
+                      type="text"
+                      defaultValue={searchParams?.reference ?? ""}
+                    />
+                  </div>
+                )}
+
+                {/* description */}
+                {applicationSearchFields.includes("description") && (
+                  <div className="govuk-form-group">
+                    <label className="govuk-label" htmlFor="description">
+                      Description
+                    </label>
+                    <input
+                      className="govuk-input govuk-!-width-full"
+                      id="description"
+                      name="description"
+                      type="text"
+                      defaultValue={searchParams?.description ?? ""}
+                    />
+                  </div>
+                )}
+              </fieldset>
+            </div>
+          </div>
+        </>
+      )}
+
+      {applicationSearchFields.includes("applicationType") && (
+        <DetailsCheckboxAccordion
+          title="Application type"
+          name="applicationType"
+          options={flatApplicationTypes}
+          checkedOptions={searchParams?.applicationType?.split(",") ?? []}
+        />
+      )}
+
+      {applicationSearchFields.includes("applicationStatus") && (
+        <DetailsCheckboxAccordion
+          title="Application status"
+          name="applicationStatus"
+          options={validPublicApplicationStatusSummaries}
+          checkedOptions={searchParams?.applicationStatus?.split(",") ?? []}
+        />
+      )}
+
+      {applicationSearchFields.includes("councilDecision") && (
+        <DetailsCheckboxAccordion
+          title="Council decision"
+          name="councilDecision"
+          options={validDprDecisionSummaries.map((option) =>
+            capitalizeFirstLetter(option),
+          )}
+          checkedOptions={searchParams?.councilDecision?.split(",") ?? []}
+        />
+      )}
+
+      {applicationSearchFields.includes("dateRange") && (
+        <>
+          <hr className="govuk-section-break govuk-section-break--visible grid-row-extra-bottom-margin" />
+
+          <div className="govuk-grid-row grid-row-extra-bottom-margin">
+            <div className="govuk-grid-column-one-half">
+              <FormFieldApplicationDateRange searchParams={searchParams} />
+            </div>
+          </div>
+        </>
+      )}
+      <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+
+      <div className="govuk-button-group">
+        <Button type="submit" variant="primary" name="action" value="submit">
+          Search
+        </Button>
+        {!action && (
+          <Button type="submit" variant="secondary" name="action" value="clear">
+            Clear search
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+
+  return action ? (
+    <form
+      className="govuk-form"
+      method="get"
+      action={action}
+      aria-label="Sort comments"
+    >
+      <input type="hidden" name="council" value={councilSlug} />
+      {renderFormContent()}
+    </form>
+  ) : (
+    renderFormContent()
+  );
+};

--- a/src/components/FormSearchFull/index.ts
+++ b/src/components/FormSearchFull/index.ts
@@ -1,0 +1,18 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export * from "./FormSearchFull";

--- a/src/components/PageSearch/PageSearch.stories.tsx
+++ b/src/components/PageSearch/PageSearch.stories.tsx
@@ -59,20 +59,34 @@ const meta = {
     },
   },
   args: {
+    params: {
+      council: "test-council-1",
+    },
     appConfig: defaultAppConfig,
-    applications: [
-      consultation,
-      assessmentInProgress,
-      planningOfficerDetermined,
-      assessmentInCommittee,
-      committeeDetermined,
-      appealLodged,
-      appealValid,
-      appealStarted,
-      appealDetermined,
-      withdrawn,
-    ],
-    pagination: generatePagination(1, 100),
+    searchParams: {
+      page: 1,
+      resultsPerPage: 10,
+      type: "simple",
+    },
+    response: {
+      status: {
+        code: 200,
+        message: "OK",
+      },
+      data: [
+        consultation,
+        assessmentInProgress,
+        planningOfficerDetermined,
+        assessmentInCommittee,
+        committeeDetermined,
+        appealLodged,
+        appealValid,
+        appealStarted,
+        appealDetermined,
+        withdrawn,
+      ],
+      pagination: generatePagination(1, 100),
+    },
   },
 } satisfies Meta<typeof PageSearch>;
 
@@ -80,7 +94,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
-export const DefaultWithEmailAlerts: Story = {
+export const WithEmailAlerts: Story = {
   args: {
     appConfig: {
       ...defaultAppConfig,
@@ -96,23 +110,81 @@ export const DefaultWithEmailAlerts: Story = {
     },
   },
 };
-export const SearchResults: Story = {
+export const SimpleSearchNoResults: Story = {
   args: {
-    pagination: generatePagination(1, 100, 200),
     searchParams: {
       page: 1,
       resultsPerPage: 10,
+      type: "simple",
+      query: "search query",
+    },
+    response: {
+      status: {
+        code: 200,
+        message: "OK",
+      },
+      data: null,
+      pagination: generatePagination(1, 0),
+    },
+  },
+};
+export const SimpleSearchPerformed: Story = {
+  args: {
+    searchParams: {
+      page: 1,
+      resultsPerPage: 10,
+      type: "simple",
       query: "search query",
     },
   },
 };
-export const NoResults: Story = {
+export const SimpleSearchSorted: Story = {
   args: {
-    applications: [],
     searchParams: {
       page: 1,
       resultsPerPage: 10,
-      query: "noresultsplease",
+      type: "simple",
+      query: "search query",
+      sortBy: "receivedAt",
+      orderBy: "asc",
+    },
+  },
+};
+export const QuickFiltered: Story = {
+  args: {
+    searchParams: {
+      page: 1,
+      resultsPerPage: 10,
+      type: "simple",
+      dprFilter: "inConsultation",
+    },
+  },
+};
+export const AdvancedSearchNoResults: Story = {
+  args: {
+    searchParams: {
+      page: 1,
+      resultsPerPage: 10,
+      type: "full",
+      reference: "12345",
+    },
+    response: {
+      status: {
+        code: 200,
+        message: "OK",
+      },
+      data: null,
+      pagination: generatePagination(1, 0),
+    },
+  },
+};
+export const AdvancedSearchPerformed: Story = {
+  args: {
+    searchParams: {
+      page: 1,
+      resultsPerPage: 10,
+      type: "full",
+      reference: "12345",
     },
   },
 };

--- a/src/components/govuk/Pagination/Pagination.tsx
+++ b/src/components/govuk/Pagination/Pagination.tsx
@@ -17,14 +17,24 @@
 
 import React from "react";
 import "./Pagination.scss";
-import { DprPagination, SearchParams } from "@/types";
+import {
+  DprPagination,
+  SearchParams,
+  SearchParamsApplication,
+  SearchParamsComments,
+  SearchParamsDocuments,
+} from "@/types";
 import { ArrowLink } from "./ArrowLink";
 import { PageItem } from "./PageItem";
 import { generatePaginationItems } from "./utils";
 
 interface PaginationProps {
   baseUrl: string;
-  searchParams?: SearchParams;
+  searchParams?:
+    | SearchParams
+    | SearchParamsApplication
+    | SearchParamsComments
+    | SearchParamsDocuments;
   pagination?: DprPagination;
   prev?: PaginationPropsLink;
   next?: PaginationPropsLink;

--- a/src/components/govukDpr/Details/Details.stories.tsx
+++ b/src/components/govukDpr/Details/Details.stories.tsx
@@ -42,6 +42,11 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+export const Open: Story = {
+  args: {
+    open: true,
+  },
+};
 export const White: Story = {
   args: {
     isInverted: true,

--- a/src/components/govukDpr/Details/Details.tsx
+++ b/src/components/govukDpr/Details/Details.tsx
@@ -21,16 +21,22 @@ export interface DetailsProps {
   summaryText: JSX.Element | string;
   text: JSX.Element | string;
   isInverted?: boolean;
+  open?: boolean;
+  name?: string;
 }
 
 export const Details = ({
   summaryText,
   text,
   isInverted = false,
+  open = false,
+  name,
 }: DetailsProps) => {
   return (
     <details
       className={`govuk-details ${isInverted ? "govuk-details--inverted" : ""}`}
+      {...(open ? { open } : {})}
+      {...(name ? { name } : {})}
     >
       <summary className="govuk-details__summary">
         <span className="govuk-details__summary-text">{summaryText}</span>

--- a/src/handlers/bops/v2/search.documentation.tsx
+++ b/src/handlers/bops/v2/search.documentation.tsx
@@ -15,7 +15,7 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Documentation, SearchParams } from "@/types";
+import { Documentation, SearchParamsApplication } from "@/types";
 import { search } from "./search";
 
 export const documentation: Documentation = {
@@ -24,10 +24,11 @@ export const documentation: Documentation = {
   description: "getPlanningApplications",
   arguments: ["council", "page", "resultsPerPage", "searchQuery"],
   run: async (args: [string, number, number, string]) => {
-    const searchObj: SearchParams = {
+    const searchObj: SearchParamsApplication = {
       page: args[1],
       resultsPerPage: args[2],
       query: args[3],
+      type: "simple",
     };
     return await search(args[0], searchObj);
   },

--- a/src/lib/planningApplication/decision.tsx
+++ b/src/lib/planningApplication/decision.tsx
@@ -32,6 +32,18 @@ import {
 import { PostSubmissionApplication } from "@/types/odp-types/schemas/postSubmissionApplication";
 
 /**
+ * Valid decision summaries for DPR applications.
+ * @TODO what happens if we're searching for a decision type that doesn't include prior approval?
+ */
+export const validDprDecisionSummaries: DprDecisionSummary[] = [
+  "granted",
+  "refused",
+  "Prior approval required and approved",
+  "Prior approval not required",
+  "Prior approval required and refused",
+];
+
+/**
  * @deprecated Use getApplicationDprDecisionSummary in future when using PostSubmission schema
  * Returns a formatted decision string based on the application type.
  *

--- a/src/lib/planningApplication/search.tsx
+++ b/src/lib/planningApplication/search.tsx
@@ -1,0 +1,346 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { AppConfig } from "@/config/types";
+import { getValueFromUnknownSearchParams } from "@/lib/search";
+import {
+  DprApplicationDateRange,
+  DprApplicationDateType,
+  DprApplicationOrderBy,
+  DprApplicationSortBy,
+  DprDecisionSummary,
+  DprQuickSearchFilter,
+  DprStatusSummary,
+  SearchParamsApplication,
+  UnknownSearchParams,
+} from "@/types";
+import { validApplicationTypes } from "./type";
+import { ApplicationType } from "@/types/odp-types/schemas/prototypeApplication/enums/ApplicationType";
+import { validPublicApplicationStatusSummaries } from "./status";
+import { validDprDecisionSummaries } from "./decision";
+
+// resultsPerPage
+export const APPLICATION_RESULTSPERPAGE_OPTIONS = [10, 25, 50];
+export const APPLICATION_RESULTSPERPAGE_DEFAULT =
+  APPLICATION_RESULTSPERPAGE_OPTIONS[0];
+
+// sortBy
+export const APPLICATION_SORTBY_OPTIONS: DprApplicationSortBy[] = [
+  "receivedAt",
+  "councilDecisionDate",
+];
+export const APPLICATION_SORTBY_DEFAULT = APPLICATION_SORTBY_OPTIONS[0];
+
+// orderBy
+export const APPLICATION_ORDERBY_OPTIONS = ["desc", "asc"];
+export const APPLICATION_ORDERBY_DEFAULT = APPLICATION_ORDERBY_OPTIONS[0];
+
+// dprFilter
+export const APPLICATION_DPR_FILTER_OPTIONS: DprQuickSearchFilter[] = [
+  "inConsultation",
+  "publishedThisWeek",
+  "publishedThisMonth",
+  "decidedThisWeek",
+  "decidedThisMonth",
+];
+
+// dateType
+export const APPLICATION_DATETYPE_OPTIONS: Array<{
+  label: string;
+  value: DprApplicationDateType;
+}> = [
+  { label: "Received", value: "receivedAt" },
+  { label: "Valid from", value: "validatedAt" },
+  { label: "Published", value: "publishedAt" },
+  { label: "Consultation ended", value: "consultationEndDate" },
+  { label: "Council decision", value: "councilDecisionDate" },
+  { label: "Appeal decision", value: "appealDecisionDate" },
+];
+
+// dateRange
+export const APPLICATION_DATERANGE_OPTIONS: Array<{
+  label: string;
+  value: DprApplicationDateRange;
+}> = [
+  { label: "In the last week", value: "week" },
+  { label: "In the last month", value: "month" },
+  { label: "In the last quarter", value: "quarter" },
+  { label: "In the last year", value: "year" },
+  { label: "A fixed date range", value: "fixed" },
+];
+
+/**
+ * This function checks if a search has been performed based on the provided
+ * search parameters. It returns true if any of the search parameters (except
+ * for "page" "resultsPerPage" or "type") are defined and not null or empty.
+ *
+ * @param validSearchParams - The search parameters to check.
+ * @returns {boolean} - True if a search has been performed, false otherwise.
+ */
+export const checkSearchPerformed = (
+  validSearchParams: SearchParamsApplication,
+) => {
+  const searchPerformed =
+    validSearchParams &&
+    (
+      Object.entries(validSearchParams) as [
+        keyof SearchParamsApplication,
+        unknown,
+      ][]
+    ).some(
+      ([key, value]) =>
+        !["page", "resultsPerPage", "type"].includes(key as string) &&
+        value !== undefined &&
+        value !== null &&
+        value !== "",
+    );
+  return searchPerformed;
+};
+
+export const validateSearchParams = (
+  appConfig: AppConfig,
+  searchParams?: UnknownSearchParams,
+): SearchParamsApplication => {
+  // page
+  const validPage = (() => {
+    // get the value if it exists
+    const pageValue = searchParams
+      ? getValueFromUnknownSearchParams(searchParams, "page")
+      : undefined;
+    // parse it
+    const pageNumber = parseInt(pageValue || "1", 10);
+    // if its not a number or less than or equal to 0, return 1
+    // otherwise return the number
+    return isNaN(pageNumber) || pageNumber <= 0 ? 1 : pageNumber;
+  })();
+
+  // resultsPerPage
+  const resultsPerPage = (() => {
+    if (searchParams?.resultsPerPage) {
+      const workingResultsPerPage = getValueFromUnknownSearchParams(
+        searchParams,
+        "resultsPerPage",
+      );
+      const parsedResultsPerPage = parseInt(workingResultsPerPage || "", 10);
+      if (
+        !isNaN(parsedResultsPerPage) &&
+        APPLICATION_RESULTSPERPAGE_OPTIONS.includes(parsedResultsPerPage)
+      ) {
+        return parsedResultsPerPage;
+      }
+    }
+
+    return appConfig.defaults.resultsPerPage;
+  })();
+
+  // type
+  const type = (() => {
+    const typeValue = searchParams
+      ? getValueFromUnknownSearchParams(searchParams, "type")
+      : undefined;
+    // Only allow "simple" or "full", default to "simple"
+    return typeValue === "simple" || typeValue === "full"
+      ? typeValue
+      : "simple";
+  })();
+
+  // sortBy
+  const sortBy: DprApplicationSortBy | undefined = (() => {
+    const sortByValue = searchParams
+      ? getValueFromUnknownSearchParams(searchParams, "sortBy")
+      : undefined;
+
+    if (
+      sortByValue &&
+      APPLICATION_SORTBY_OPTIONS.includes(sortByValue as DprApplicationSortBy)
+    ) {
+      return sortByValue as DprApplicationSortBy;
+    }
+
+    return undefined;
+  })();
+
+  // orderBy
+  const orderBy: DprApplicationOrderBy | undefined = (() => {
+    const orderByValue = searchParams
+      ? getValueFromUnknownSearchParams(searchParams, "orderBy")
+      : undefined;
+
+    if (
+      orderByValue &&
+      APPLICATION_ORDERBY_OPTIONS.includes(
+        orderByValue as DprApplicationOrderBy,
+      )
+    ) {
+      return orderByValue as DprApplicationOrderBy;
+    }
+
+    return undefined;
+  })();
+
+  // Ensure query is a string
+  const query: string | undefined = searchParams
+    ? getValueFromUnknownSearchParams(searchParams, "query")
+    : undefined;
+
+  // Ensure reference is a string
+  const reference: string | undefined = searchParams
+    ? getValueFromUnknownSearchParams(searchParams, "reference")
+    : undefined;
+
+  // Ensure description is a string
+  const description: string | undefined = searchParams
+    ? getValueFromUnknownSearchParams(searchParams, "description")
+    : undefined;
+
+  // applicationType
+  const applicationType: string | undefined = (() => {
+    const applicationTypeValue = searchParams
+      ? getValueFromUnknownSearchParams(searchParams, "applicationType")
+      : undefined;
+
+    if (!applicationTypeValue) return undefined;
+
+    // Flatten all valid application types
+    const flatApplicationTypes = Object.values(validApplicationTypes).flat();
+
+    // Split, dedupe, and filter only valid types
+    const selectedTypes = Array.from(
+      new Set(applicationTypeValue.split(",").map((v) => v.trim())),
+    ).filter((v): v is ApplicationType =>
+      flatApplicationTypes.includes(v as ApplicationType),
+    );
+
+    return selectedTypes.length > 0 ? selectedTypes.join(",") : undefined;
+  })();
+
+  // applicationStatus
+  const applicationStatus: string | undefined = (() => {
+    const applicationStatusValue = searchParams
+      ? getValueFromUnknownSearchParams(searchParams, "applicationStatus")
+      : undefined;
+
+    if (!applicationStatusValue) return undefined;
+
+    // Split, dedupe, and filter only valid types
+    const selectedStatus = Array.from(
+      new Set(applicationStatusValue.split(",").map((v) => v.trim())),
+    ).filter((v): v is DprStatusSummary =>
+      validPublicApplicationStatusSummaries.includes(v as DprStatusSummary),
+    );
+
+    return selectedStatus.length > 0 ? selectedStatus.join(",") : undefined;
+  })();
+
+  // councilDecision
+  const councilDecision: string | undefined = (() => {
+    const councilDecisionValue = searchParams
+      ? getValueFromUnknownSearchParams(searchParams, "councilDecision")
+      : undefined;
+
+    if (!councilDecisionValue) return undefined;
+
+    // Split, dedupe, and filter only valid types
+    const selectedDecisionSummaries = Array.from(
+      new Set(councilDecisionValue.split(",").map((v) => v.trim())),
+    ).filter((v): v is DprDecisionSummary =>
+      validDprDecisionSummaries.includes(v as DprDecisionSummary),
+    );
+
+    return selectedDecisionSummaries.length > 0
+      ? selectedDecisionSummaries.join(",")
+      : undefined;
+  })();
+
+  // dateType
+  const dateType: DprApplicationDateType | undefined = (() => {
+    const dateTypeValue = searchParams
+      ? getValueFromUnknownSearchParams(searchParams, "dateType")
+      : undefined;
+
+    const validDateTypeValues = APPLICATION_DATETYPE_OPTIONS.map(
+      (option) => option.value,
+    );
+
+    if (
+      dateTypeValue &&
+      validDateTypeValues.includes(dateTypeValue as DprApplicationDateType)
+    ) {
+      return dateTypeValue as DprApplicationDateType;
+    }
+
+    return undefined;
+  })();
+
+  // dateRange
+  const dateRange: DprApplicationDateRange | undefined = (() => {
+    const dateRangeValue = searchParams
+      ? getValueFromUnknownSearchParams(searchParams, "dateRange")
+      : undefined;
+
+    const validDateRangeValues = APPLICATION_DATERANGE_OPTIONS.map(
+      (option) => option.value,
+    );
+
+    if (
+      dateRangeValue &&
+      validDateRangeValues.includes(dateRangeValue as DprApplicationDateRange)
+    ) {
+      return dateRangeValue as DprApplicationDateRange;
+    }
+
+    return undefined;
+  })();
+
+  // dprFilter
+  // @TODO this can only be set if the other values are valid for this filter
+  const dprFilter: DprQuickSearchFilter | undefined = (() => {
+    const dprFilterValue = searchParams
+      ? getValueFromUnknownSearchParams(searchParams, "dprFilter")
+      : undefined;
+
+    if (
+      dprFilterValue &&
+      APPLICATION_DPR_FILTER_OPTIONS.includes(
+        dprFilterValue as DprQuickSearchFilter,
+      )
+    ) {
+      return dprFilterValue as DprQuickSearchFilter;
+    }
+
+    return undefined;
+  })();
+
+  const newSearchParams: SearchParamsApplication = {
+    page: validPage,
+    resultsPerPage,
+    type,
+    ...(query && { query }),
+    ...(sortBy && { sortBy }),
+    ...(orderBy && { orderBy }),
+    ...(dprFilter && { dprFilter }),
+    ...(reference && { reference }),
+    ...(description && { description }),
+    ...(applicationType && { applicationType }),
+    ...(applicationStatus && { applicationStatus }),
+    ...(councilDecision && { councilDecision }),
+    ...(dateType && { dateType }),
+    ...(dateRange && { dateRange }),
+  };
+
+  return newSearchParams;
+};

--- a/src/lib/planningApplication/status.tsx
+++ b/src/lib/planningApplication/status.tsx
@@ -42,6 +42,37 @@ dayjs.extend(isSameOrAfter);
 dayjs.utc().isUTC();
 
 /**
+ * The valid application types
+ */
+export const validApplicationStatusSummaries: DprStatusSummary[] = [
+  "Application submitted",
+  "Application returned",
+  "Consultation in progress",
+  "Assessment in progress",
+  "Determined",
+  "Withdrawn",
+  "Appeal lodged",
+  "Appeal validated",
+  "Appeal in progress",
+  "Appeal decided",
+  "Unknown",
+];
+
+/**
+ * The valid application types that are public and therefor on DPR
+ */
+export const validPublicApplicationStatusSummaries: DprStatusSummary[] = [
+  "Consultation in progress",
+  "Assessment in progress",
+  "Determined",
+  "Withdrawn",
+  "Appeal lodged",
+  "Appeal validated",
+  "Appeal in progress",
+  "Appeal decided",
+];
+
+/**
  *
  * @deprecated Use getApplicationDprStatusSummary in future when using PostSubmission schema
  * Determines the formatted status based on the provided status and consultation start/end date.

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,5 +1,35 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import { UnknownSearchParams } from "@/types";
 
+/**
+ * When using the searchParams object, it can be of type
+ * string | string[] | undefined. This function helps to extract
+ * the value from the searchParams object based on the key.
+ * It handles the case where the value can be an array or a string.
+ * If the value is an array, it returns the first element.
+ * If the value is a string, it returns the string directly.
+ * If the value is undefined, it returns undefined.
+ * If the key is not found, it returns undefined.
+ * @param searchParams
+ * @param key
+ * @returns
+ */
 export const getValueFromUnknownSearchParams = (
   searchParams: UnknownSearchParams,
   key: string,
@@ -15,4 +45,21 @@ export const getValueFromUnknownSearchParams = (
   }
 
   return value; // Use the value directly if it's a string or undefined
+};
+
+/**
+ *
+ * @param searchParams
+ * @param excludedKeys
+ * @returns
+ */
+export const filterSearchParams = (
+  searchParams: URLSearchParams,
+  excludedKeys: string[],
+): URLSearchParams => {
+  return new URLSearchParams(
+    Array.from(searchParams.entries()).filter(
+      ([key]) => !excludedKeys.includes(key),
+    ),
+  );
 };

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -70,7 +70,48 @@ export interface SearchParams {
   resultsPerPage: number;
   query?: string;
 }
+
+// Application specific search params
+export interface SearchParamsApplication extends SearchParams {
+  type: "simple" | "full";
+  sortBy?: DprApplicationSortBy;
+  orderBy?: DprApplicationOrderBy;
+  dprFilter?: DprQuickSearchFilter;
+  reference?: string;
+  description?: string;
+  applicationType?: string;
+  applicationStatus?: string;
+  councilDecision?: string;
+  dateType?: DprApplicationDateType;
+  dateRange?: DprApplicationDateRange;
+  dateRangeFrom?: string;
+  dateRangeTo?: string;
+}
+export type DprApplicationSortBy = "receivedAt" | "councilDecisionDate";
+export type DprApplicationOrderBy = "asc" | "desc";
+export type DprQuickSearchFilter =
+  | "inConsultation"
+  | "publishedThisWeek"
+  | "publishedThisMonth"
+  | "decidedThisWeek"
+  | "decidedThisMonth";
+export type DprApplicationDateType =
+  | "receivedAt"
+  | "validatedAt"
+  | "publishedAt"
+  | "consultationEndDate"
+  | "councilDecisionDate"
+  | "appealDecisionDate";
+export type DprApplicationDateRange =
+  | "week"
+  | "month"
+  | "quarter"
+  | "year"
+  | "fixed";
+// Document specific search params
 export type SearchParamsDocuments = SearchParams;
+
+// Comment specific search params
 export interface SearchParamsComments extends SearchParams {
   type: DprCommentTypes;
   sortBy?: DprCommentSortBy;

--- a/src/util/featureFlag.ts
+++ b/src/util/featureFlag.ts
@@ -107,10 +107,19 @@ export const documentSearchFields = handleFeatureFlags(
  * Application Search Fields
  */
 export const APPLICATION_SEARCH_FIELDS = [
-  "applicationId",
-  "status",
-  "submittedDate",
-  "applicantName",
+  "advancedSearch",
+  "sortBy",
+  "quickFilters",
+  "query",
+  "reference",
+  "description",
+  "applicationType",
+  "applicationStatus",
+  "councilDecision",
+  "dateType",
+  "dateRange",
+  "dateRangeFrom",
+  "dateRangeTo",
 ] as const;
 
 export const applicationSearchFields = handleFeatureFlags(


### PR DESCRIPTION
This PR adds advanced search functionality, quick filters and some new components (all under feature flags) 

![adv-search](https://github.com/user-attachments/assets/2f3b902c-13ee-4b1f-80bd-dee91570b664)

This PR also raised some questions about our backend implementation and model validation 

**New routes**
* `/search` now shows advanced search form - w tests
* `/search-form` is a GET route for processing the search form fields - w tests

**New components**
* `DetailsCheckboxAccordion` - Govuk Accordion using `<detail />` 
* `FormApplicationsSort` - the sort form for applications
* `FormFieldApplicationDateRange` - the date range selector
* `FormSearchFull` - the full search form, w feature flags

**Updates to components**
* `FormSearch` - added quick filters to this and feature flag support for advanced search and quick filters
* `PageSearch` - completely rewritten with more test coverage for the use case
* `Pagination` - added more types to support
* `Details` - added open option to force it to be open if say a field has selected text eg quickFilters

**Other**
* Started adding tests for routes and pages
* Added a whole bunch of reference variables for things as well - these are things that we need to start modelling and validating on in our tickets



**To test**
Add this to env vars to disable the new unsupported functionality
```
APPLICATION_FILTERING_DISABLED=advancedSearch,sortBy,quickFilters,query,reference,description,applicationType,applicationStatus,councilDecision,dateRange
``` 
