### PR TITLE
DSNPI-1066 / Search page- Info icons added to the various groups by search

### DIFF
--- a/__tests__/components/DetailsCheckboxAccordion.test.tsx
+++ b/__tests__/components/DetailsCheckboxAccordion.test.tsx
@@ -18,6 +18,7 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { DetailsCheckboxAccordion } from "@/components/DetailsCheckboxAccordion";
+import { InfoIcon } from "@/components/InfoIcon";
 
 // Helper for a simple string option type
 const OPTIONS = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"];
@@ -111,5 +112,28 @@ describe("DetailsCheckboxAccordion", () => {
       />,
     );
     expect(container.firstChild).toBeNull();
+  });
+  it("shows the content prop if provided", () => {
+    const content = (
+      <InfoIcon
+        href={`/council/help/application-statuses`}
+        title="Get help understanding what application statuses mean"
+        ariaLabel="Get help understanding what application statuses mean"
+      />
+    );
+    render(
+      <DetailsCheckboxAccordion
+        title="With Content"
+        name="with-content"
+        options={OPTIONS}
+        checkedOptions={[]}
+        content={content}
+      />,
+    );
+    expect(
+      screen.queryByTitle(
+        "Get help understanding what application statuses mean",
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/DetailsCheckboxAccordion/DetailsCheckboxAccordion.stories.tsx
+++ b/src/components/DetailsCheckboxAccordion/DetailsCheckboxAccordion.stories.tsx
@@ -18,6 +18,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { DetailsCheckboxAccordion } from "./DetailsCheckboxAccordion";
 import { validApplicationTypes } from "@/lib/planningApplication";
+import { InfoIcon } from "@/components/InfoIcon";
 
 const flatApplicationTypes = Object.values(validApplicationTypes).flat();
 const meta = {
@@ -33,6 +34,13 @@ const meta = {
     title: "public-council-1",
     name: "applicationType",
     options: flatApplicationTypes,
+    content: (
+      <InfoIcon
+        href={`/public-council-1/help/application-types`}
+        title="Get help understanding what application types mean"
+        ariaLabel="Get help understanding what application types mean"
+      />
+    ),
   },
 } satisfies Meta<typeof DetailsCheckboxAccordion>;
 
@@ -43,5 +51,29 @@ export const Default: Story = {};
 export const Checked: Story = {
   args: {
     checkedOptions: flatApplicationTypes.slice(10, 15),
+  },
+};
+
+export const WithStringContent: Story = {
+  args: {
+    content: "This is a string content example for the accordion.",
+  },
+};
+
+export const WithReactNodeContent: Story = {
+  args: {
+    content: (
+      <InfoIcon
+        href={`/public-council-1/help/decisions#council-decisions`}
+        title="Get help understanding what council decisions mean"
+        ariaLabel="Get help understanding what council decisions mean"
+      />
+    ),
+  },
+};
+
+export const WithoutContent: Story = {
+  args: {
+    content: undefined,
   },
 };

--- a/src/components/DetailsCheckboxAccordion/DetailsCheckboxAccordion.tsx
+++ b/src/components/DetailsCheckboxAccordion/DetailsCheckboxAccordion.tsx
@@ -23,6 +23,7 @@ export interface DetailsCheckboxAccordionProps<T> {
   name: string;
   options: T[];
   checkedOptions?: T[];
+  content?: string | React.ReactNode;
 }
 
 export function DetailsCheckboxAccordion<T>({
@@ -30,6 +31,7 @@ export function DetailsCheckboxAccordion<T>({
   name,
   options,
   checkedOptions,
+  content,
 }: DetailsCheckboxAccordionProps<T>) {
   const [checked, setChecked] = useState<T[]>(checkedOptions ?? []);
 
@@ -78,6 +80,7 @@ export function DetailsCheckboxAccordion<T>({
         </div>
       </summary>
       <fieldset className="govuk-fieldset dpr-details-checkbox-accordion__content">
+        {content && content}
         <legend className="govuk-fieldset__legend govuk-fieldset__legend--m govuk-visually-hidden">
           {title}
         </legend>

--- a/src/components/FormSearchFull/FormSearchFull.scss
+++ b/src/components/FormSearchFull/FormSearchFull.scss
@@ -19,7 +19,7 @@
 
 .dpr-form-search-full {
   position: relative;
-  .info-icon {
+  & > .info-icon.dpr-form-search-full__info-icon {
     position: absolute;
     top: 0;
     right: 0;

--- a/src/components/FormSearchFull/FormSearchFull.tsx
+++ b/src/components/FormSearchFull/FormSearchFull.tsx
@@ -116,6 +116,13 @@ export const FormSearchFull = ({
           name="applicationType"
           options={flatApplicationTypes}
           checkedOptions={searchParams?.applicationType?.split(",") ?? []}
+          content={
+            <InfoIcon
+              href={`/${councilSlug}/help/application-types`}
+              title="Get help understanding what application types mean"
+              ariaLabel="Get help understanding what application types mean"
+            />
+          }
         />
       )}
 
@@ -125,6 +132,13 @@ export const FormSearchFull = ({
           name="applicationStatus"
           options={validPublicApplicationStatusSummaries}
           checkedOptions={searchParams?.applicationStatus?.split(",") ?? []}
+          content={
+            <InfoIcon
+              href={`/${councilSlug}/help/application-statuses`}
+              title="Get help understanding what application statuses mean"
+              ariaLabel="Get help understanding what application statuses mean"
+            />
+          }
         />
       )}
 
@@ -136,6 +150,13 @@ export const FormSearchFull = ({
             capitalizeFirstLetter(option),
           )}
           checkedOptions={searchParams?.councilDecision?.split(",") ?? []}
+          content={
+            <InfoIcon
+              href={`/${councilSlug}/help/decisions#council-decisions`}
+              title="Get help understanding what council decisions mean"
+              ariaLabel="Get help understanding what council decisions mean"
+            />
+          }
         />
       )}
 


### PR DESCRIPTION
[Ticket 1066](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-1066)

This PR adds the info icons to the advanced search page. Icons are passed as content props from the parent component (`<FormSearchFull />`) to the `<DetailsCheckboxAccordion />` component which accepts either `string | React.ReactNode`. 
Icons correspond to correct fields and link to the relevant help page. They are keyboard accessible with aria labels. There was initially some overriding styling happening due to the pre-existing info icon at the top of the page, but this has been mitigated with more targeted class names.

Additional storybook stories and test coverage included.