### PR TITLE
Exclude folders called types from coverage

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -49,6 +49,7 @@ const config = {
     "!src/**/index.(ts|tsx)",
     "!src/**/*.stories.(ts|tsx)",
     "!src/types/odp-types/**/*",
+    "!**/types/**", // Exclude all 'types' folders from coverage
   ],
 
   // The directory where Jest should output its coverage files


### PR DESCRIPTION
theres a few `/types` folders that were messing with our coverage %'ages

**before**
```sh
Jest: "global" coverage threshold for statements (80%) not met: 58.85%
Jest: "global" coverage threshold for lines (80%) not met: 58.85%
Jest: "global" coverage threshold for functions (80%) not met: 51.28%
```

**after**
```sh
Jest: "global" coverage threshold for statements (80%) not met: 65.11%
Jest: "global" coverage threshold for lines (80%) not met: 65.11%
Jest: "global" coverage threshold for functions (80%) not met: 53.05%
```