### PR TITLE
DSNPI-1130 / update ContentNoResult component to show more text when it has a councilConfig

### DIFF
--- a/__mocks__/appConfigFactory.ts
+++ b/__mocks__/appConfigFactory.ts
@@ -138,6 +138,7 @@ export const createCouncilConfig = ({
   specialistComments = true,
   pageContent,
   features,
+  contact,
 }: {
   councilName: string;
   visibility?: Council["visibility"];
@@ -146,6 +147,7 @@ export const createCouncilConfig = ({
   specialistComments?: Council["specialistComments"];
   pageContent?: Council["pageContent"];
   features?: Council["features"];
+  contact?: Council["contact"];
 }): Council => {
   const slug = slugify(councilName);
   const defaultPageContent = {
@@ -162,6 +164,7 @@ export const createCouncilConfig = ({
     specialistComments,
     pageContent: pageContent ?? defaultPageContent,
     features,
+    contact,
   };
 };
 

--- a/src/components/ContentNoResult/ContentNoResult.stories.ts
+++ b/src/components/ContentNoResult/ContentNoResult.stories.ts
@@ -17,9 +17,13 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 import { ContentNoResult } from "./ContentNoResult";
-import { getAppConfig } from "@/config";
+import { createCouncilConfig } from "@mocks/appConfigFactory";
 
-const appConfig = getAppConfig("public-council-1");
+const baseCouncilConfig = createCouncilConfig({
+  councilName: "Public Council 1",
+  contact: "https://planningregister.org/",
+});
+
 const meta = {
   title: "Content/No result",
   component: ContentNoResult,
@@ -39,6 +43,6 @@ export const Default: Story = {};
 
 export const WithCouncilConfig: Story = {
   args: {
-    councilConfig: appConfig.council,
+    councilConfig: baseCouncilConfig,
   },
 };


### PR DESCRIPTION
[Ticket 1130](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?selectedIssue=DSNPI-1130)

This PR ensures that the storybook story for `<ContentNoResult />` shows the contact your council link when the councilConfig is provided.
The mock function `createCouncilConfig` has been updated to support adding contact information for mock councils.

![image](https://github.com/user-attachments/assets/5bd4531b-1084-44e7-9607-dfef336c8125)
