### PR TITLE
DSNPI - 1345 / Add support for mime types to Attachment component

### DIFF
--- a/__tests__/components/Attachment.test.tsx
+++ b/__tests__/components/Attachment.test.tsx
@@ -95,3 +95,135 @@ describe("Attachment Component", () => {
     ).not.toBeInTheDocument();
   });
 });
+
+describe("MIME-type icon rendering", () => {
+  it('renders the PDF icon for shorthand "pdf"', () => {
+    const { container } = render(<Attachment contentType="pdf" />);
+    const icon = container.querySelector(
+      ".dpr-attachment__thumbnail-image--pdf",
+    );
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('renders the PDF icon for "application/pdf"', () => {
+    const { container } = render(<Attachment contentType="application/pdf" />);
+    const icon = container.querySelector(
+      ".dpr-attachment__thumbnail-image--pdf",
+    );
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('renders the Document icon for shorthand "doc"', () => {
+    const { container } = render(<Attachment contentType="doc" />);
+    const icon = container.querySelector(
+      ".dpr-attachment__thumbnail-image--document",
+    );
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('renders the Document icon for "application/msword"', () => {
+    const { container } = render(
+      <Attachment contentType="application/msword" />,
+    );
+    const icon = container.querySelector(
+      ".dpr-attachment__thumbnail-image--document",
+    );
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('renders the Document icon for shorthand "docx"', () => {
+    const { container } = render(<Attachment contentType="docx" />);
+    const icon = container.querySelector(
+      ".dpr-attachment__thumbnail-image--document",
+    );
+    expect(icon).toBeInTheDocument();
+  });
+
+  it("renders the Document icon for the full DOCX MIME type", () => {
+    const { container } = render(
+      <Attachment contentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />,
+    );
+    const icon = container.querySelector(
+      ".dpr-attachment__thumbnail-image--document",
+    );
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('renders the Spreadsheet icon for shorthand "xls"', () => {
+    const { container } = render(<Attachment contentType="xls" />);
+    const icon = container.querySelector(
+      ".dpr-attachment__thumbnail-image--spreadsheet",
+    );
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('renders the Spreadsheet icon for "application/vnd.ms-excel"', () => {
+    const { container } = render(
+      <Attachment contentType="application/vnd.ms-excel" />,
+    );
+    const icon = container.querySelector(
+      ".dpr-attachment__thumbnail-image--spreadsheet",
+    );
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('renders the Spreadsheet icon for shorthand "xlsx"', () => {
+    const { container } = render(<Attachment contentType="xlsx" />);
+    const icon = container.querySelector(
+      ".dpr-attachment__thumbnail-image--spreadsheet",
+    );
+    expect(icon).toBeInTheDocument();
+  });
+
+  it("renders the Spreadsheet icon for the full XLSX MIME type", () => {
+    const { container } = render(
+      <Attachment contentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" />,
+    );
+    const icon = container.querySelector(
+      ".dpr-attachment__thumbnail-image--spreadsheet",
+    );
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('renders the Spreadsheet icon for shorthand "spreadsheet"', () => {
+    const { container } = render(<Attachment contentType="spreadsheet" />);
+    const icon = container.querySelector(
+      ".dpr-attachment__thumbnail-image--spreadsheet",
+    );
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('renders the HTML icon for shorthand "html"', () => {
+    const { container } = render(<Attachment contentType="html" />);
+    const icon = container.querySelector(
+      ".dpr-attachment__thumbnail-image--html",
+    );
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('renders the HTML icon for "text/html"', () => {
+    const { container } = render(<Attachment contentType="text/html" />);
+    const icon = container.querySelector(
+      ".dpr-attachment__thumbnail-image--html",
+    );
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('renders the HTML icon for "application/xhtml+xml"', () => {
+    const { container } = render(
+      <Attachment contentType="application/xhtml+xml" />,
+    );
+    const icon = container.querySelector(
+      ".dpr-attachment__thumbnail-image--html",
+    );
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('renders the External icon for "external"', () => {
+    const { container } = render(<Attachment contentType="external" />);
+    const icon = container.querySelector(
+      ".dpr-attachment__thumbnail-image--external",
+    );
+    expect(icon).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/Attachment.test.tsx
+++ b/__tests__/components/Attachment.test.tsx
@@ -97,133 +97,34 @@ describe("Attachment Component", () => {
 });
 
 describe("MIME-type icon rendering", () => {
-  it('renders the PDF icon for shorthand "pdf"', () => {
-    const { container } = render(<Attachment contentType="pdf" />);
-    const icon = container.querySelector(
-      ".dpr-attachment__thumbnail-image--pdf",
-    );
-    expect(icon).toBeInTheDocument();
-  });
-
-  it('renders the PDF icon for "application/pdf"', () => {
-    const { container } = render(<Attachment contentType="application/pdf" />);
-    const icon = container.querySelector(
-      ".dpr-attachment__thumbnail-image--pdf",
-    );
-    expect(icon).toBeInTheDocument();
-  });
-
-  it('renders the Document icon for shorthand "doc"', () => {
-    const { container } = render(<Attachment contentType="doc" />);
-    const icon = container.querySelector(
-      ".dpr-attachment__thumbnail-image--document",
-    );
-    expect(icon).toBeInTheDocument();
-  });
-
-  it('renders the Document icon for "application/msword"', () => {
-    const { container } = render(
-      <Attachment contentType="application/msword" />,
-    );
-    const icon = container.querySelector(
-      ".dpr-attachment__thumbnail-image--document",
-    );
-    expect(icon).toBeInTheDocument();
-  });
-
-  it('renders the Document icon for shorthand "docx"', () => {
-    const { container } = render(<Attachment contentType="docx" />);
-    const icon = container.querySelector(
-      ".dpr-attachment__thumbnail-image--document",
-    );
-    expect(icon).toBeInTheDocument();
-  });
-
-  it("renders the Document icon for the full DOCX MIME type", () => {
-    const { container } = render(
-      <Attachment contentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />,
-    );
-    const icon = container.querySelector(
-      ".dpr-attachment__thumbnail-image--document",
-    );
-    expect(icon).toBeInTheDocument();
-  });
-
-  it('renders the Spreadsheet icon for shorthand "xls"', () => {
-    const { container } = render(<Attachment contentType="xls" />);
-    const icon = container.querySelector(
-      ".dpr-attachment__thumbnail-image--spreadsheet",
-    );
-    expect(icon).toBeInTheDocument();
-  });
-
-  it('renders the Spreadsheet icon for "application/vnd.ms-excel"', () => {
-    const { container } = render(
-      <Attachment contentType="application/vnd.ms-excel" />,
-    );
-    const icon = container.querySelector(
-      ".dpr-attachment__thumbnail-image--spreadsheet",
-    );
-    expect(icon).toBeInTheDocument();
-  });
-
-  it('renders the Spreadsheet icon for shorthand "xlsx"', () => {
-    const { container } = render(<Attachment contentType="xlsx" />);
-    const icon = container.querySelector(
-      ".dpr-attachment__thumbnail-image--spreadsheet",
-    );
-    expect(icon).toBeInTheDocument();
-  });
-
-  it("renders the Spreadsheet icon for the full XLSX MIME type", () => {
-    const { container } = render(
-      <Attachment contentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" />,
-    );
-    const icon = container.querySelector(
-      ".dpr-attachment__thumbnail-image--spreadsheet",
-    );
-    expect(icon).toBeInTheDocument();
-  });
-
-  it('renders the Spreadsheet icon for shorthand "spreadsheet"', () => {
-    const { container } = render(<Attachment contentType="spreadsheet" />);
-    const icon = container.querySelector(
-      ".dpr-attachment__thumbnail-image--spreadsheet",
-    );
-    expect(icon).toBeInTheDocument();
-  });
-
-  it('renders the HTML icon for shorthand "html"', () => {
-    const { container } = render(<Attachment contentType="html" />);
-    const icon = container.querySelector(
-      ".dpr-attachment__thumbnail-image--html",
-    );
-    expect(icon).toBeInTheDocument();
-  });
-
-  it('renders the HTML icon for "text/html"', () => {
-    const { container } = render(<Attachment contentType="text/html" />);
-    const icon = container.querySelector(
-      ".dpr-attachment__thumbnail-image--html",
-    );
-    expect(icon).toBeInTheDocument();
-  });
-
-  it('renders the HTML icon for "application/xhtml+xml"', () => {
-    const { container } = render(
-      <Attachment contentType="application/xhtml+xml" />,
-    );
-    const icon = container.querySelector(
-      ".dpr-attachment__thumbnail-image--html",
-    );
-    expect(icon).toBeInTheDocument();
-  });
-
-  it('renders the External icon for "external"', () => {
-    const { container } = render(<Attachment contentType="external" />);
-    const icon = container.querySelector(
-      ".dpr-attachment__thumbnail-image--external",
-    );
+  it.each([
+    ["pdf", "pdf"],
+    ["pdf", "application/pdf"],
+    ["document", "doc"],
+    ["document", "docx"],
+    ["document", "application/msword"],
+    [
+      "document",
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ],
+    ["spreadsheet", "xls"],
+    ["spreadsheet", "xlsx"],
+    ["spreadsheet", "spreadsheet"],
+    ["spreadsheet", "application/vnd.ms-excel"],
+    [
+      "spreadsheet",
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ],
+    ["html", "html"],
+    ["html", "text/html"],
+    ["html", "application/xhtml+xml"],
+    ["external", "external"],
+    ["generic", "some/unknown-type"],
+    ["generic", "invalid/type"],
+  ])("renders the %s icon for contentType '%s'", (expectedType, mimeType) => {
+    const { container } = render(<Attachment contentType={mimeType} />);
+    const expectedSelector = `.dpr-attachment__thumbnail-image--${expectedType}`;
+    const icon = container.querySelector(expectedSelector);
     expect(icon).toBeInTheDocument();
   });
 });

--- a/src/components/govukDpr/Attachment/Attachment.stories.ts
+++ b/src/components/govukDpr/Attachment/Attachment.stories.ts
@@ -119,7 +119,7 @@ export const WithThumbnail: Story = {
   args: {
     title: "Attachment with Thumbnail",
     url: "#",
-    thumbnailUrl: "/images/file.jpg",
+    thumbnailUrl: "/govuk/assets/images/govuk-crest.svg",
     contentType: "pdf",
     fileSize: 1234567,
     numberOfPages: 5,

--- a/src/components/govukDpr/Attachment/Attachment.tsx
+++ b/src/components/govukDpr/Attachment/Attachment.tsx
@@ -26,6 +26,7 @@ import {
 } from "./Thumbnails";
 import { formatDateTimeToDprDate, formatFileSize } from "@/util";
 import { Details } from "../Details";
+import { mapMimeToAttachmentContentType } from "@/util/convertAttachmentContentType";
 
 export interface AttachmentProps {
   title?: string;
@@ -50,43 +51,23 @@ export const Attachment = ({
   alternativeFormatContactEmail,
   createdDate,
 }: AttachmentProps) => {
-  function pickGOVUKIcon(contentType?: string): JSX.Element {
-    const type = contentType?.toLowerCase();
+  function renderIcon(contentType?: string): JSX.Element {
+    const type = mapMimeToAttachmentContentType(contentType);
 
-    // PDFs
-    if (type?.includes("pdf")) {
-      return <ThumbnailPdf />;
+    switch (type) {
+      case "pdf":
+        return <ThumbnailPdf />;
+      case "document":
+        return <ThumbnailDocument />;
+      case "spreadsheet":
+        return <ThumbnailSpreadsheet />;
+      case "html":
+        return <ThumbnailHtml />;
+      case "external":
+        return <ThumbnailExternal />;
+      default:
+        return <ThumbnailGeneric />;
     }
-
-    // Word documents
-    if (
-      type?.endsWith("doc") ||
-      type?.endsWith("docx") ||
-      type?.includes("msword") ||
-      type?.includes("wordprocessingml")
-    ) {
-      return <ThumbnailDocument />;
-    }
-
-    // Spreadsheets
-    if (
-      type?.endsWith("xls") ||
-      type?.endsWith("xlsx") ||
-      type?.includes("excel") ||
-      type?.includes("spreadsheet")
-    ) {
-      return <ThumbnailSpreadsheet />;
-    }
-
-    // HTML pages
-    if (type?.includes("html")) {
-      return <ThumbnailHtml />;
-    }
-
-    if (type === "external") {
-      return <ThumbnailExternal />;
-    }
-    return <ThumbnailGeneric />;
   }
 
   const formattedFileSize =
@@ -119,7 +100,7 @@ export const Attachment = ({
       className="dpr-attachment__thumbnail-image"
     />
   ) : (
-    pickGOVUKIcon(contentType)
+    renderIcon(contentType)
   );
 
   return (

--- a/src/components/govukDpr/Attachment/Attachment.tsx
+++ b/src/components/govukDpr/Attachment/Attachment.tsx
@@ -50,40 +50,40 @@ export const Attachment = ({
   alternativeFormatContactEmail,
   createdDate,
 }: AttachmentProps) => {
-  function pickGOVUKIcon(type?: string): JSX.Element {
-    const lowercaseType = type?.toLowerCase();
+  function pickGOVUKIcon(contentType?: string): JSX.Element {
+    const type = contentType?.toLowerCase();
 
     // PDFs
-    if (lowercaseType?.includes("pdf")) {
+    if (type?.includes("pdf")) {
       return <ThumbnailPdf />;
     }
 
     // Word documents
     if (
-      lowercaseType?.endsWith("doc") ||
-      lowercaseType?.endsWith("docx") ||
-      lowercaseType?.includes("msword") ||
-      lowercaseType?.includes("wordprocessingml")
+      type?.endsWith("doc") ||
+      type?.endsWith("docx") ||
+      type?.includes("msword") ||
+      type?.includes("wordprocessingml")
     ) {
       return <ThumbnailDocument />;
     }
 
     // Spreadsheets
     if (
-      lowercaseType?.endsWith("xls") ||
-      lowercaseType?.endsWith("xlsx") ||
-      lowercaseType?.includes("excel") ||
-      lowercaseType?.includes("spreadsheet")
+      type?.endsWith("xls") ||
+      type?.endsWith("xlsx") ||
+      type?.includes("excel") ||
+      type?.includes("spreadsheet")
     ) {
       return <ThumbnailSpreadsheet />;
     }
 
     // HTML pages
-    if (lowercaseType?.includes("html")) {
+    if (type?.includes("html")) {
       return <ThumbnailHtml />;
     }
 
-    if (lowercaseType === "external") {
+    if (type === "external") {
       return <ThumbnailExternal />;
     }
     return <ThumbnailGeneric />;

--- a/src/components/govukDpr/Attachment/Attachment.tsx
+++ b/src/components/govukDpr/Attachment/Attachment.tsx
@@ -51,24 +51,42 @@ export const Attachment = ({
   createdDate,
 }: AttachmentProps) => {
   function pickGOVUKIcon(type?: string): JSX.Element {
-    switch (type?.toLowerCase()) {
-      case "application/pdf":
-      case "pdf":
-        return <ThumbnailPdf />;
-      case "doc":
-      case "docx":
-        return <ThumbnailDocument />;
-      case "xls":
-      case "xlsx":
-      case "spreadsheet":
-        return <ThumbnailSpreadsheet />;
-      case "html":
-        return <ThumbnailHtml />;
-      case "external":
-        return <ThumbnailExternal />;
-      default:
-        return <ThumbnailGeneric />;
+    const lowercaseType = type?.toLowerCase();
+
+    // PDFs
+    if (lowercaseType?.includes("pdf")) {
+      return <ThumbnailPdf />;
     }
+
+    // Word documents
+    if (
+      lowercaseType?.endsWith("doc") ||
+      lowercaseType?.endsWith("docx") ||
+      lowercaseType?.includes("msword") ||
+      lowercaseType?.includes("wordprocessingml")
+    ) {
+      return <ThumbnailDocument />;
+    }
+
+    // Spreadsheets
+    if (
+      lowercaseType?.endsWith("xls") ||
+      lowercaseType?.endsWith("xlsx") ||
+      lowercaseType?.includes("excel") ||
+      lowercaseType?.includes("spreadsheet")
+    ) {
+      return <ThumbnailSpreadsheet />;
+    }
+
+    // HTML pages
+    if (lowercaseType?.includes("html")) {
+      return <ThumbnailHtml />;
+    }
+
+    if (lowercaseType === "external") {
+      return <ThumbnailExternal />;
+    }
+    return <ThumbnailGeneric />;
   }
 
   const formattedFileSize =

--- a/src/util/convertAttachmentContentType.ts
+++ b/src/util/convertAttachmentContentType.ts
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export type AttachmentContentType =
+  | "pdf"
+  | "document"
+  | "spreadsheet"
+  | "html"
+  | "external"
+  | "generic";
+
+export function mapMimeToAttachmentContentType(
+  mime?: string,
+): AttachmentContentType {
+  const type = mime?.toLowerCase() || "";
+
+  if (type.includes("pdf")) return "pdf";
+
+  if (
+    type.endsWith("doc") ||
+    type.endsWith("docx") ||
+    type.includes("msword") ||
+    type.includes("wordprocessingml")
+  ) {
+    return "document";
+  }
+
+  if (
+    type.endsWith("xls") ||
+    type.endsWith("xlsx") ||
+    type.includes("excel") ||
+    type.includes("spreadsheet")
+  ) {
+    return "spreadsheet";
+  }
+
+  if (type.includes("html")) return "html";
+
+  if (type === "external") return "external";
+
+  return "generic";
+}


### PR DESCRIPTION
[Ticket 1345](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?jql=assignee%20%3D%2062a6f3cb6085950068acebf7&selectedIssue=DSNPI-1345)

This PR enhances the `<Attachment />` component to support MIME types. It updates the `pickGOVUKIcon` function so that it lower-cases the incoming contentType and uses .includes() to catch any full MIME strings (like application/pdf, text/html) and .endsWith() to match file extensions (doc, xlsx), which then maps to the correct GOV.UK thumbnail.