### PR TITLE
Bug Fix for chromatic build failing

### DIFF
--- a/__tests__/components/ApplicationDetails.test.tsx
+++ b/__tests__/components/ApplicationDetails.test.tsx
@@ -20,6 +20,7 @@ import React from "react";
 import { ApplicationDetails } from "@/components/ApplicationDetails";
 import { AppConfig } from "@/config/types";
 import { generateExampleApplications } from "@mocks/dprNewApplicationFactory";
+import { CommentsSummaryWithSuspense } from "@/components/CommentsSummaryWithSuspense";
 
 // Mock child components
 jest.mock("@/components/ApplicationHero", () => ({
@@ -54,9 +55,9 @@ jest.mock("@/components/ApplicationPeople", () => ({
   ApplicationPeople: () => <div data-testid="application-people" />,
 }));
 jest.mock("@/components/CommentsSummaryWithSuspense", () => ({
-  CommentsSummaryWithSuspense: (props: any) => (
+  CommentsSummaryWithSuspense: jest.fn((props) => (
     <div data-testid={`comments-summary-with-suspense-${props.type}`} />
-  ),
+  )),
 }));
 jest.mock("@/components/ContentError", () => ({
   ContentError: () => <div data-testid="content-error" />,
@@ -198,5 +199,67 @@ describe.only("ApplicationDetails", () => {
     expect(
       screen.queryByTestId("comments-summary-with-suspense-public"),
     ).not.toBeInTheDocument();
+  });
+
+  it("Passes public comments summary to CommentsSummaryWithSuspense", () => {
+    const publicCommentSummary = {
+      sentiment: {
+        supportive: 2,
+        neutral: 0,
+        objection: 0,
+      },
+      totalComments: 2,
+    };
+
+    render(
+      <ApplicationDetails
+        {...baseProps}
+        application={planningOfficerDetermined}
+        publicCommentSummary={publicCommentSummary}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("comments-summary-with-suspense-public"),
+    ).toBeInTheDocument();
+    expect(CommentsSummaryWithSuspense).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { council: "public-council-1", reference: "APP-123" },
+        type: "public",
+        summary: publicCommentSummary,
+      }),
+      expect.anything(),
+    );
+  });
+  it("Passes specialist comments summary to CommentsSummaryWithSuspense", () => {
+    const specialistCommentSummary = {
+      sentiment: {
+        approved: 2,
+        amendmentsNeeded: 0,
+        objected: 0,
+      },
+      totalConsulted: 2,
+      totalComments: 2,
+    };
+
+    render(
+      <ApplicationDetails
+        {...baseProps}
+        application={planningOfficerDetermined}
+        specialistCommentSummary={specialistCommentSummary}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("comments-summary-with-suspense-specialist"),
+    ).toBeInTheDocument();
+    expect(CommentsSummaryWithSuspense).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { council: "public-council-1", reference: "APP-123" },
+        type: "specialist",
+        summary: specialistCommentSummary,
+      }),
+      expect.anything(),
+    );
   });
 });

--- a/__tests__/components/PageShow.test.tsx
+++ b/__tests__/components/PageShow.test.tsx
@@ -1,0 +1,124 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { PageShow } from "@/components/PageShow/PageShow";
+import { AppConfig } from "@/config/types";
+import { DprApplication, DprDocument } from "@/types";
+import {
+  PublicCommentSummary,
+  SpecialistCommentSummary,
+} from "@/types/odp-types/schemas/postSubmissionApplication/data/CommentSummary";
+
+// Mock child components to isolate PageShow
+jest.mock("@/components/BackButton", () => ({
+  BackButton: ({ baseUrl }: any) => <div data-testid="back-btn">{baseUrl}</div>,
+}));
+jest.mock("@/components/PageMain", () => ({
+  PageMain: ({ children }: any) => (
+    <main data-testid="page-main">{children}</main>
+  ),
+}));
+jest.mock("@/components/ContentNotFound", () => ({
+  ContentNotFound: ({ councilConfig }: any) => (
+    <div data-testid="not-found">{councilConfig?.slug}</div>
+  ),
+}));
+jest.mock("@/components/ApplicationDetails", () => ({
+  ApplicationDetails: (props: any) => (
+    <div data-testid="application-details">{JSON.stringify(props)}</div>
+  ),
+}));
+
+const baseAppConfig: AppConfig = {
+  council: { slug: "camden", dataSource: "test" },
+  // ...other required config fields
+} as any;
+
+const baseApplication: DprApplication = {
+  submission: { data: { applicant: "Test Applicant" } },
+  data: { caseOfficer: "Test Officer" },
+  // ...other required fields
+} as any;
+
+const baseParams = { council: "camden", reference: "APP-123" };
+
+describe("PageShow", () => {
+  it("renders ContentNotFound if application is null", () => {
+    render(
+      <PageShow
+        appConfig={baseAppConfig}
+        application={null}
+        params={baseParams}
+      />,
+    );
+    expect(screen.getByTestId("not-found")).toBeInTheDocument();
+    expect(screen.queryByTestId("application-details")).not.toBeInTheDocument();
+  });
+
+  it("renders ApplicationDetails with required props", () => {
+    render(
+      <PageShow
+        appConfig={baseAppConfig}
+        application={baseApplication}
+        params={baseParams}
+      />,
+    );
+    expect(screen.getByTestId("application-details")).toBeInTheDocument();
+    expect(screen.getByTestId("back-btn")).toHaveTextContent("/camden");
+    expect(screen.getByTestId("page-main")).toBeInTheDocument();
+  });
+
+  it("passes documents, publicCommentSummary, and specialistCommentSummary if provided", () => {
+    const documents: DprDocument[] = [{ id: "1", title: "Doc" } as any];
+    const publicCommentSummary: PublicCommentSummary = {
+      sentiment: {
+        supportive: 1,
+        neutral: 0,
+        objection: 0,
+      },
+      totalComments: 1,
+    };
+    const specialistCommentSummary: SpecialistCommentSummary = {
+      sentiment: {
+        approved: 2,
+        amendmentsNeeded: 0,
+        objected: 0,
+      },
+      totalConsulted: 1,
+      totalComments: 1,
+    };
+
+    render(
+      <PageShow
+        appConfig={baseAppConfig}
+        application={baseApplication}
+        params={baseParams}
+        documents={documents}
+        publicCommentSummary={publicCommentSummary}
+        specialistCommentSummary={specialistCommentSummary}
+      />,
+    );
+    const details = JSON.parse(
+      screen.getByTestId("application-details").textContent!,
+    );
+    expect(details.documents).toEqual(documents);
+    expect(details.publicCommentSummary).toEqual(publicCommentSummary);
+    expect(details.specialistCommentSummary).toEqual(specialistCommentSummary);
+  });
+});

--- a/src/components/ApplicationDetails/ApplicationDetails.stories.tsx
+++ b/src/components/ApplicationDetails/ApplicationDetails.stories.tsx
@@ -42,6 +42,23 @@ const meta = {
     appConfig: baseAppConfig,
     application: committeeDetermined,
     documents: generateNResults<DprDocument>(3, generateDocument),
+    publicCommentSummary: {
+      sentiment: {
+        supportive: 0,
+        neutral: 0,
+        objection: 0,
+      },
+      totalComments: 0,
+    },
+    specialistCommentSummary: {
+      sentiment: {
+        approved: 0,
+        amendmentsNeeded: 0,
+        objected: 0,
+      },
+      totalConsulted: 0,
+      totalComments: 0,
+    },
   },
 } satisfies Meta<typeof ApplicationDetails>;
 

--- a/src/components/ApplicationDetails/ApplicationDetails.tsx
+++ b/src/components/ApplicationDetails/ApplicationDetails.tsx
@@ -32,12 +32,18 @@ import { ApplicationAppeals } from "@/components/ApplicationAppeals";
 import { checkCommentsEnabled } from "@/lib/comments";
 import { getDescription } from "@/lib/planningApplication/application";
 import { CommentsSummaryWithSuspense } from "@/components/CommentsSummaryWithSuspense";
+import {
+  PublicCommentSummary,
+  SpecialistCommentSummary,
+} from "@/types/odp-types/schemas/postSubmissionApplication/data/CommentSummary";
 
 export interface ApplicationDetailsProps {
   reference: string;
   appConfig: AppConfig;
   application: DprApplication;
   documents?: DprDocument[];
+  publicCommentSummary?: PublicCommentSummary;
+  specialistCommentSummary?: SpecialistCommentSummary;
 }
 
 export const ApplicationDetails = ({
@@ -45,6 +51,8 @@ export const ApplicationDetails = ({
   appConfig,
   application,
   documents,
+  publicCommentSummary,
+  specialistCommentSummary,
 }: ApplicationDetailsProps) => {
   if (!appConfig.council) {
     return <ContentError />;
@@ -172,6 +180,10 @@ export const ApplicationDetails = ({
             councilSlug={appConfig?.council?.slug}
             reference={reference}
             documentsToShow={6}
+            // this enables us to show this component in storybook without needing to fetch documents
+            {...(documents !== undefined
+              ? { documents, totalDocuments: documents.length }
+              : {})}
           />
           <ApplicationPeople
             applicant={application.submission.data.applicant}
@@ -182,12 +194,20 @@ export const ApplicationDetails = ({
             <CommentsSummaryWithSuspense
               params={{ council: councilSlug, reference: reference }}
               type="specialist"
+              // this enables us to show this component in storybook without needing to fetch comments
+              {...(specialistCommentSummary !== undefined
+                ? { summary: specialistCommentSummary }
+                : {})}
             />
           )}
           {appConfig.council?.publicComments && (
             <CommentsSummaryWithSuspense
               params={{ council: councilSlug, reference: reference }}
               type="public"
+              // this enables us to show this component in storybook without needing to fetch comments
+              {...(publicCommentSummary !== undefined
+                ? { summary: publicCommentSummary }
+                : {})}
             />
           )}
         </div>

--- a/src/components/PageShow/PageShow.stories.tsx
+++ b/src/components/PageShow/PageShow.stories.tsx
@@ -69,6 +69,23 @@ const meta = {
     appConfig: createAppConfig("public-council-1"),
     application: committeeDetermined,
     documents: generateNResults(10, generateDocument),
+    publicCommentSummary: {
+      sentiment: {
+        supportive: 0,
+        neutral: 0,
+        objection: 0,
+      },
+      totalComments: 0,
+    },
+    specialistCommentSummary: {
+      sentiment: {
+        approved: 0,
+        amendmentsNeeded: 0,
+        objected: 0,
+      },
+      totalConsulted: 0,
+      totalComments: 0,
+    },
     params: {
       council: "public-council-1",
       reference: "123456",

--- a/src/components/PageShow/PageShow.tsx
+++ b/src/components/PageShow/PageShow.tsx
@@ -21,11 +21,17 @@ import { AppConfig } from "@/config/types";
 import { ApplicationDetails } from "../ApplicationDetails";
 import { PageMain } from "../PageMain";
 import { ContentNotFound } from "../ContentNotFound";
+import {
+  PublicCommentSummary,
+  SpecialistCommentSummary,
+} from "@/types/odp-types/schemas/postSubmissionApplication/data/CommentSummary";
 
 export interface PageShowProps {
   appConfig: AppConfig;
   application: DprApplication | null;
   documents?: DprDocument[];
+  publicCommentSummary?: PublicCommentSummary;
+  specialistCommentSummary?: SpecialistCommentSummary;
   params: {
     council: string;
     reference: string;
@@ -37,6 +43,8 @@ export const PageShow = ({
   application,
   params,
   documents,
+  publicCommentSummary,
+  specialistCommentSummary,
 }: PageShowProps) => {
   const { council, reference } = params;
 
@@ -55,8 +63,17 @@ export const PageShow = ({
         <ApplicationDetails
           reference={reference}
           application={application}
-          documents={documents}
           appConfig={appConfig}
+          // this enables us to show this component in storybook without needing to fetch documents
+          {...(documents !== undefined ? { documents } : {})}
+          // this enables us to show this component in storybook without needing to fetch comments
+          {...(specialistCommentSummary !== undefined
+            ? { specialistCommentSummary: specialistCommentSummary }
+            : {})}
+          // this enables us to show this component in storybook without needing to fetch comments
+          {...(publicCommentSummary !== undefined
+            ? { publicCommentSummary: publicCommentSummary }
+            : {})}
         />
       </PageMain>
     </>


### PR DESCRIPTION
Currently storybook is failing when building to main,looks like its [this issue](https://github.com/storybookjs/storybook/issues/30317) it is also giving an infinite loop when viewing the affected stories:

* http://localhost:6006/?path=/story/council-pages-show--default
* http://localhost:6006/?path=/docs/dpr-components-applicationdetails--docs

<img width="1004" alt="image" src="https://github.com/user-attachments/assets/2dd6675e-d52a-4619-888b-a038ef8bf809" />

The reason is that our version of storybook (8) doesn't have the best support for react server components. There are a few solutions but the simplest one and the one that we've already been doing elsewhere is to simply pass the *WithSuspense component what it wants so that it doesn't even try to load the async server component. 

This PR adds three new optional props to `ApplicationDetails` and `PageShow` components