### PR TITLE
DSNPI-1354 Fix for date logic missing

### DIFF
--- a/__tests__/lib/planningApplication/search.test.ts
+++ b/__tests__/lib/planningApplication/search.test.ts
@@ -585,7 +585,7 @@ describe("validateSearchParams", () => {
       it.each(APPLICATION_DATETYPE_OPTIONS)(
         "parses valid dateType '%s' from searchParams",
         (dateType) => {
-          const searchParams = { dateType: dateType.value };
+          const searchParams = { dateType: dateType.value, dateRange: "week" };
 
           const result = validateSearchParams(mockAppConfig, searchParams);
 
@@ -594,6 +594,7 @@ describe("validateSearchParams", () => {
             resultsPerPage: 10,
             type: "simple",
             dateType: dateType.value,
+            dateRange: "week",
           });
         },
       );
@@ -620,7 +621,10 @@ describe("validateSearchParams", () => {
       it.each(APPLICATION_DATERANGE_OPTIONS)(
         "parses valid dateRange '%s' from searchParams",
         (dateRange) => {
-          const searchParams = { dateRange: dateRange.value };
+          const searchParams = {
+            dateType: "receivedAt",
+            dateRange: dateRange.value,
+          };
 
           const result = validateSearchParams(mockAppConfig, searchParams);
 
@@ -628,6 +632,7 @@ describe("validateSearchParams", () => {
             page: 1,
             resultsPerPage: 10,
             type: "simple",
+            dateType: "receivedAt",
             dateRange: dateRange.value,
           });
         },
@@ -645,6 +650,201 @@ describe("validateSearchParams", () => {
         page: 1,
         resultsPerPage: 10,
         type: "simple",
+      });
+    });
+  });
+
+  // dateRangeFrom, dateRangeTo
+  describe("dateRangeFrom, dateRangeTo", () => {
+    it("returns valid dateRangeFrom and dateRangeTo when both are valid and in the correct order", () => {
+      const searchParams = {
+        dateType: "receivedAt",
+        dateRange: "fixed",
+        dateRangeFrom: "2025-05-01",
+        dateRangeTo: "2025-05-31",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        dateType: "receivedAt",
+        dateRange: "fixed",
+        dateRangeFrom: "2025-05-01",
+        dateRangeTo: "2025-05-31",
+      });
+    });
+
+    it("returns undefined for both dateRangeFrom and dateRangeTo when they are out of order", () => {
+      const searchParams = {
+        dateType: "receivedAt",
+        dateRange: "fixed",
+        dateRangeFrom: "2025-05-31",
+        dateRangeTo: "2025-05-01",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        dateType: "receivedAt",
+        dateRange: "fixed",
+        dateRangeFrom: undefined,
+        dateRangeTo: undefined,
+      });
+    });
+
+    it("sets dateRangeTo to the same value as dateRangeFrom when only dateRangeFrom is valid", () => {
+      const searchParams = {
+        dateType: "receivedAt",
+        dateRange: "fixed",
+        dateRangeFrom: "2025-05-01",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        dateType: "receivedAt",
+        dateRange: "fixed",
+        dateRangeFrom: "2025-05-01",
+        dateRangeTo: "2025-05-01",
+      });
+    });
+
+    it("sets dateRangeFrom to the same value as dateRangeTo when only dateRangeTo is valid", () => {
+      const searchParams = {
+        dateType: "receivedAt",
+        dateRange: "fixed",
+        dateRangeTo: "2025-05-31",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        dateType: "receivedAt",
+        dateRange: "fixed",
+        dateRangeFrom: "2025-05-31",
+        dateRangeTo: "2025-05-31",
+      });
+    });
+
+    it("returns undefined for both dateRangeFrom and dateRangeTo when neither is valid", () => {
+      const searchParams = {
+        dateType: "receivedAt",
+        dateRange: "fixed",
+        dateRangeFrom: "invalid-date",
+        dateRangeTo: "another-invalid-date",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        dateType: "receivedAt",
+        dateRange: "fixed",
+        dateRangeFrom: undefined,
+        dateRangeTo: undefined,
+      });
+    });
+
+    it("returns undefined for both dateRangeFrom and dateRangeTo when both are missing", () => {
+      const searchParams = {};
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        dateRangeFrom: undefined,
+        dateRangeTo: undefined,
+      });
+    });
+  });
+
+  // dateType, dateRange, dateRangeFrom, dateRangeTo
+  describe("dateType, dateRange, dateRangeFrom, dateRangeTo", () => {
+    it("ignores all if dateType is missing", () => {
+      const searchParams = {
+        dateRange: "week",
+        dateRangeFrom: "2023-01-01",
+        dateRangeTo: "2023-01-07",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+      });
+    });
+
+    it("ignores all if dateRange is missing", () => {
+      const searchParams = {
+        dateType: "receivedAt",
+        dateRangeFrom: "2023-01-01",
+        dateRangeTo: "2023-01-07",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+      });
+    });
+
+    it("ignores dateRangeFrom, dateRangeTo if dateRange is not set to fixed", () => {
+      const searchParams = {
+        dateType: "receivedAt",
+        dateRange: "week",
+        dateRangeFrom: "2023-01-01",
+        dateRangeTo: "2023-01-07",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        dateType: "receivedAt",
+        dateRange: "week",
+      });
+    });
+
+    it("allows dateRangeFrom, dateRangeTo if dateRange is set to fixed", () => {
+      const searchParams = {
+        dateType: "receivedAt",
+        dateRange: "fixed",
+        dateRangeFrom: "2023-01-01",
+        dateRangeTo: "2023-01-07",
+      };
+
+      const result = validateSearchParams(mockAppConfig, searchParams);
+
+      expect(result).toEqual({
+        page: 1,
+        resultsPerPage: 10,
+        type: "simple",
+        dateType: "receivedAt",
+        dateRange: "fixed",
+        dateRangeFrom: "2023-01-01",
+        dateRangeTo: "2023-01-07",
       });
     });
   });

--- a/src/components/FormFieldApplicationDateRange/FormFieldApplicationDateRange.tsx
+++ b/src/components/FormFieldApplicationDateRange/FormFieldApplicationDateRange.tsx
@@ -48,7 +48,7 @@ export const FormFieldApplicationDateRange = ({
           name="dateType"
           defaultValue={searchParams?.dateType ?? ""}
         >
-          <option value="" disabled />
+          <option value=""></option>
           {APPLICATION_DATETYPE_OPTIONS.map(
             (option: { value: string; label: string }) => (
               <option key={option.value} value={option.value}>


### PR DESCRIPTION
This PR fixes the missing date logic for advanced search.

dateType = received, valid etc
dateRange =  week, month, quarter, year and fixed

if the dateRange is fixed then dateRangeFrom and dateRangeTo are set in all other cases they should be undefined.

* If dateType === 'valid option' && dateRange === 'valid option' then
  * dateType = 'valid option'
  * dateRange = 'valid option' 
  * dateRangeFrom = undefined 
  * dateRangeTo = undefined
* If dateType !== 'valid option' && dateRange === 'valid option' then
  * dateType = undefined
  * dateRange = undefined
  * dateRangeFrom = undefined 
  * dateRangeTo = undefined
* If dateType === 'valid option' && dateRange !== 'valid option' then
  * dateType = undefined
  * dateRange = undefined
  * dateRangeFrom = undefined 
  * dateRangeTo = undefined
* If dateType === 'valid option' && dateRange === 'fixed' && dateRangeFrom === 'valid-date' && dateRangeTo === 'valid-date' then
  * dateType = 'valid option'
  * dateRange = 'valid option' 
  * dateRangeFrom = 'valid option' 
  * dateRangeTo = 'valid option' 
* If dateType === 'valid option' && dateRange === 'fixed' && dateRangeFrom !== 'valid-date' && dateRangeTo === 'valid-date' then
  * dateType = 'valid option'
  * dateRange = 'valid option' 
  * dateRangeFrom = undefined 
  * dateRangeTo = undefined
* If dateType === 'valid option' && dateRange === 'fixed' && dateRangeFrom === 'valid-date' && dateRangeTo !== 'valid-date' then
  * dateType = 'valid option'
  * dateRange = 'valid option' 
  * dateRangeFrom = undefined 
  * dateRangeTo = undefined

Then the usual date validation applies:
* if both dates are set make sure they are in the right order, if not set them both to undefined
* if only one is set match the other to the set date




