### PR TITLE
DSNPI-1346 / Remove Pagination Conversion for BOPS Search Endpoint

### DIFF
--- a/__tests__/handlers/bops/v2/search.test.ts
+++ b/__tests__/handlers/bops/v2/search.test.ts
@@ -17,10 +17,7 @@
 
 import { search } from "@/handlers/bops/v2/search";
 import { handleBopsGetRequest } from "@/handlers/bops/requests";
-import {
-  convertBopsToDpr,
-  convertBopsToDprPagination,
-} from "@/handlers/bops/converters/planningApplication";
+import { convertBopsToDpr } from "@/handlers/bops/converters/planningApplication";
 import {
   isDprApplication,
   convertToDprApplication,
@@ -42,7 +39,6 @@ jest.mock("@/handlers/lib", () => ({
 
 const mockHandleBopsGetRequest = handleBopsGetRequest as jest.Mock;
 const mockConvertBopsToDpr = convertBopsToDpr as jest.Mock;
-const mockConvertBopsToDprPagination = convertBopsToDprPagination as jest.Mock;
 const mockIsDprApplication = isDprApplication as unknown as jest.Mock;
 const mockConvertToDprApplication = convertToDprApplication as jest.Mock;
 const logErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
@@ -51,11 +47,6 @@ const logWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
 describe("search", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockConvertBopsToDprPagination.mockReturnValue({
-      page: 1,
-      totalPages: 1,
-      totalAvailableItems: 1,
-    });
   });
 
   it("should return null data if no applications are found", async () => {

--- a/src/components/CommentsSummary/CommentsSummary.tsx
+++ b/src/components/CommentsSummary/CommentsSummary.tsx
@@ -44,7 +44,7 @@ export const CommentsSummary = ({
   type,
   summary,
 }: CommentsSummaryProps) => {
-  if (!type || !summary.sentiment) {
+  if (!type || !summary?.sentiment) {
     return null;
   }
 

--- a/src/components/CommentsSummaryWithSuspense/CommentsSummaryWithSuspense.tsx
+++ b/src/components/CommentsSummaryWithSuspense/CommentsSummaryWithSuspense.tsx
@@ -81,6 +81,6 @@ async function CommentsSummaryLoader({
     type,
   });
 
-  const summary = response.data.summary;
+  const summary = response?.data?.summary;
   return <CommentsSummary params={params} type={type} summary={summary} />;
 }

--- a/src/handlers/bops/types/schemas.d.ts
+++ b/src/handlers/bops/types/schemas.d.ts
@@ -20,7 +20,6 @@ import {
   BopsApplicationOverview,
   BopsNonStandardApplication,
   BopsPlanningApplication,
-  BopsSearchLinks,
   BopsSearchMetadata,
 } from "./definitions/application";
 import { BopsComment } from "./definitions/comment";
@@ -35,8 +34,7 @@ import {
  * #/components/schemas/Search
  */
 export interface BopsV2PublicPlanningApplicationsSearch {
-  metadata: BopsSearchMetadata;
-  links: BopsSearchLinks;
+  pagination: DprPagination;
   data: BopsPlanningApplication[];
 }
 

--- a/src/handlers/bops/v2/search.ts
+++ b/src/handlers/bops/v2/search.ts
@@ -28,10 +28,7 @@ import {
 import { BopsV2PublicPlanningApplicationsSearch } from "@/handlers/bops/types";
 import { handleBopsGetRequest } from "@/handlers/bops/requests";
 import { defaultPagination } from "@/handlers/lib";
-import {
-  convertBopsToDpr,
-  convertBopsToDprPagination,
-} from "@/handlers/bops/converters/planningApplication";
+import { convertBopsToDpr } from "@/handlers/bops/converters/planningApplication";
 import {
   convertToDprApplication,
   isDprApplication,
@@ -173,11 +170,8 @@ export async function search(
   if (errors.length > 0) {
     console.warn("Some applications failed to convert:", errors);
   }
-  const metadata = request.data?.metadata;
   const pagination: DprPagination =
-    metadata && "results" in metadata
-      ? convertBopsToDprPagination(metadata)
-      : defaultPagination;
+    request.data?.pagination || defaultPagination;
 
   return {
     ...request,


### PR DESCRIPTION
[Ticket 1346](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?jql=assignee%20%3D%2062a6f3cb6085950068acebf7&selectedIssue=DSNPI-1346)

This PR removes the conversion from the search handler. 
This can only work when the [the equivalent BOPS ticket](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?jql=assignee%20%3D%2062a6f3cb6085950068acebf7&selectedIssue=DSNPI-1262) updates the public search endpoint to use the postsubmission pagination schema has been deployed. For now, you can use the main branch of BOPS locally.

nb: also some changes to unrelated files that were causing errors due to not checking for presence.