### PR TITLE
DSNPI-1351 / Detail component to explain what is on the DPR

### DIFF
--- a/__mocks__/appConfigFactory.ts
+++ b/__mocks__/appConfigFactory.ts
@@ -139,6 +139,7 @@ export const createCouncilConfig = ({
   pageContent,
   features,
   contact,
+  currentLiveRegister,
 }: {
   councilName: string;
   visibility?: Council["visibility"];
@@ -147,6 +148,7 @@ export const createCouncilConfig = ({
   specialistComments?: Council["specialistComments"];
   pageContent?: Council["pageContent"];
   features?: Council["features"];
+  currentLiveRegister?: Council["currentLiveRegister"];
   contact?: Council["contact"];
 }): Council => {
   const slug = slugify(councilName);
@@ -165,6 +167,7 @@ export const createCouncilConfig = ({
     pageContent: pageContent ?? defaultPageContent,
     features,
     contact,
+    currentLiveRegister,
   };
 };
 

--- a/__tests__/components/ContentNotOnDprYet.test.tsx
+++ b/__tests__/components/ContentNotOnDprYet.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { createCouncilConfig } from "@mocks/appConfigFactory";
+import { ContentNotOnDprYet } from "@/components/ContentNotOnDprYet";
+
+const council = createCouncilConfig({
+  councilName: "Public Council 1",
+  currentLiveRegister: "https://example.com",
+});
+
+describe("ContentNotOnDprYet", () => {
+  beforeEach(() => {
+    render(<ContentNotOnDprYet council={council} />);
+  });
+
+  it("renders the ContentNotOnDprYet component", () => {
+    expect(
+      screen.getByText(
+        /Not all planning applications are available on this register/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("displays the pilot scheme information", () => {
+    expect(
+      screen.getByText(/Find out more about this pilot scheme/i),
+    ).toBeInTheDocument();
+  });
+
+  it("mentions the primary planning register in the text", () => {
+    expect(
+      screen.getByText(/visit the primary planning register/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the current live register link", () => {
+    expect(
+      screen.getByRole("link", {
+        name: /visit the primary planning register for\s+Public Council 1\s*\./i,
+      }),
+    ).toHaveAttribute("href", council?.currentLiveRegister || "");
+  });
+});

--- a/__tests__/components/PageSearch.test.tsx
+++ b/__tests__/components/PageSearch.test.tsx
@@ -173,6 +173,38 @@ describe("PageSearch", () => {
     expect(screen.queryByTestId("form-search-full") !== null).toBe(presence);
   };
 
+  const checkForContentNotFoundOnDprYet = (presence: boolean = true) => {
+    expect(screen.queryByTestId("content-not-on-dpr-yet") !== null).toBe(
+      presence,
+    );
+  };
+
+  const checkForContentNoResultAfterApplicationCards = () => {
+    const cards = screen.getAllByTestId("application-card");
+    const allContentNotOnDprYet = screen.getAllByTestId(
+      "content-not-on-dpr-yet",
+    );
+    const pagination = screen.getByTestId("pagination");
+
+    // Use the last ContentNotOnDprYet (the one after the last card)
+    const contentNotOnDprYet =
+      allContentNotOnDprYet[allContentNotOnDprYet.length - 1];
+
+    // All should share the same parent
+    expect(cards[cards.length - 1].parentElement).toBe(
+      contentNotOnDprYet.parentElement,
+    );
+    expect(contentNotOnDprYet.parentElement).toBe(pagination.parentElement);
+
+    const siblings = Array.from(contentNotOnDprYet.parentElement!.children);
+    const lastCardIndex = siblings.indexOf(cards[cards.length - 1]);
+    const contentIndex = siblings.indexOf(contentNotOnDprYet);
+    const paginationIndex = siblings.indexOf(pagination);
+
+    expect(lastCardIndex).toBeLessThan(contentIndex);
+    expect(contentIndex).toBeLessThan(paginationIndex);
+  };
+
   describe("When no actions have been performed", () => {
     it("should show welcome message", () => {
       render(
@@ -243,9 +275,24 @@ describe("PageSearch", () => {
           response={mockResponse}
         />,
       );
-      expect(
-        screen.queryAllByTestId("content-not-on-dpr-yet").length,
-      ).toBeGreaterThan(0);
+      checkForContentNotFoundOnDprYet(true);
+    });
+    describe("and we view the last page of results", () => {
+      const mockResponseLastPage = {
+        ...mockResponse,
+        pagination: generatePagination(10, 100),
+      };
+      it("should render ContentNotOnDprYet component between last ApplicationCard and Pagination", () => {
+        render(
+          <PageSearch
+            params={baseParams}
+            appConfig={mockAppConfig}
+            searchParams={baseSearchParams}
+            response={mockResponseLastPage}
+          />,
+        );
+        checkForContentNoResultAfterApplicationCards();
+      });
     });
   });
 
@@ -311,21 +358,33 @@ describe("PageSearch", () => {
       );
       checkForAdvancedSearchForm(false);
     });
-    it("should not show ContentNotOnDprYet component unless the current page is the last page", () => {
+    it("should not show ContentNotOnDprYet component", () => {
       render(
         <PageSearch
           params={baseParams}
           appConfig={mockAppConfig}
           searchParams={mockSimpleSearchParams}
-          response={{
-            ...mockResponse,
-            pagination: generatePagination(1, 1),
-          }}
+          response={mockResponse}
         />,
       );
-      expect(
-        screen.queryByTestId("content-not-on-dpr-yet"),
-      ).toBeInTheDocument();
+      checkForContentNotFoundOnDprYet(false);
+    });
+    describe("and we view the last page of results", () => {
+      const mockResponseLastPage = {
+        ...mockResponse,
+        pagination: generatePagination(10, 100),
+      };
+      it("should render ContentNotOnDprYet component between last ApplicationCard and Pagination", () => {
+        render(
+          <PageSearch
+            params={baseParams}
+            appConfig={mockAppConfig}
+            searchParams={mockSimpleSearchParams}
+            response={mockResponseLastPage}
+          />,
+        );
+        checkForContentNoResultAfterApplicationCards();
+      });
     });
   });
 
@@ -392,6 +451,34 @@ describe("PageSearch", () => {
       );
       checkForAdvancedSearchForm(false);
     });
+    it("should not show ContentNotOnDprYet component", () => {
+      render(
+        <PageSearch
+          params={baseParams}
+          appConfig={mockAppConfig}
+          searchParams={mockQuickfilterSearchParams}
+          response={mockResponse}
+        />,
+      );
+      checkForContentNotFoundOnDprYet(false);
+    });
+    describe("and we view the last page of results", () => {
+      const mockResponseLastPage = {
+        ...mockResponse,
+        pagination: generatePagination(10, 100),
+      };
+      it("should render ContentNotOnDprYet component between last ApplicationCard and Pagination", () => {
+        render(
+          <PageSearch
+            params={baseParams}
+            appConfig={mockAppConfig}
+            searchParams={mockQuickfilterSearchParams}
+            response={mockResponseLastPage}
+          />,
+        );
+        checkForContentNoResultAfterApplicationCards();
+      });
+    });
   });
 
   describe("When an advanced search search has been performed", () => {
@@ -456,6 +543,34 @@ describe("PageSearch", () => {
         />,
       );
       checkForAdvancedSearchForm(true);
+    });
+    it("should not show ContentNotOnDprYet component", () => {
+      render(
+        <PageSearch
+          params={baseParams}
+          appConfig={mockAppConfig}
+          searchParams={mockAdvancedSearchParams}
+          response={mockResponse}
+        />,
+      );
+      checkForContentNotFoundOnDprYet(false);
+    });
+    describe("and we view the last page of results", () => {
+      const mockResponseLastPage = {
+        ...mockResponse,
+        pagination: generatePagination(10, 100),
+      };
+      it("should render ContentNotOnDprYet component between last ApplicationCard and Pagination", () => {
+        render(
+          <PageSearch
+            params={baseParams}
+            appConfig={mockAppConfig}
+            searchParams={mockAdvancedSearchParams}
+            response={mockResponseLastPage}
+          />,
+        );
+        checkForContentNoResultAfterApplicationCards();
+      });
     });
   });
 

--- a/__tests__/components/PageSearch.test.tsx
+++ b/__tests__/components/PageSearch.test.tsx
@@ -74,6 +74,12 @@ jest.mock("@/lib/planningApplication/search", () => ({
   ),
 }));
 
+jest.mock("@/components/ContentNotOnDprYet", () => ({
+  ContentNotOnDprYet: (props: any) => (
+    <div data-testid="content-not-on-dpr-yet" />
+  ),
+}));
+
 const baseParams = { council: "camden" };
 const mockAppConfig: AppConfig = {
   defaults: {
@@ -228,6 +234,19 @@ describe("PageSearch", () => {
       );
       checkForAdvancedSearchForm(false);
     });
+    it("should show ContentNotOnDprYet component", () => {
+      render(
+        <PageSearch
+          params={baseParams}
+          appConfig={mockAppConfig}
+          searchParams={baseSearchParams}
+          response={mockResponse}
+        />,
+      );
+      expect(
+        screen.queryAllByTestId("content-not-on-dpr-yet").length,
+      ).toBeGreaterThan(0);
+    });
   });
 
   describe("When a simple search has been performed", () => {
@@ -291,6 +310,22 @@ describe("PageSearch", () => {
         />,
       );
       checkForAdvancedSearchForm(false);
+    });
+    it("should not show ContentNotOnDprYet component unless the current page is the last page", () => {
+      render(
+        <PageSearch
+          params={baseParams}
+          appConfig={mockAppConfig}
+          searchParams={mockSimpleSearchParams}
+          response={{
+            ...mockResponse,
+            pagination: generatePagination(1, 1),
+          }}
+        />,
+      );
+      expect(
+        screen.queryByTestId("content-not-on-dpr-yet"),
+      ).toBeInTheDocument();
     });
   });
 
@@ -455,6 +490,23 @@ describe("PageSearch", () => {
       expect(screen.queryAllByTestId("application-card")).toHaveLength(0);
       expect(screen.queryByTestId("pagination")).not.toBeInTheDocument();
       expect(screen.getByTestId("content-no-result")).toBeInTheDocument();
+    });
+    it("if no results it shows ContentNotOnDprYet component", () => {
+      render(
+        <PageSearch
+          params={baseParams}
+          appConfig={mockAppConfig}
+          searchParams={baseSearchParams}
+          response={{
+            ...mockResponse,
+            data: null,
+          }}
+        />,
+      );
+
+      expect(
+        screen.queryAllByTestId("content-not-on-dpr-yet").length,
+      ).toBeGreaterThan(0);
     });
   });
 });

--- a/src/components/ContentNotOnDprYet/ContentNotOnDprYet.stories.tsx
+++ b/src/components/ContentNotOnDprYet/ContentNotOnDprYet.stories.tsx
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Meta, StoryObj } from "@storybook/react";
+import { ContentNotOnDprYet } from "./ContentNotOnDprYet";
+import { createCouncilConfig } from "@mocks/appConfigFactory";
+
+const council = createCouncilConfig({
+  councilName: "Public Council 1",
+  currentLiveRegister: "example.com",
+});
+
+const meta = {
+  title: "DPR Components/ContentNotOnDprYet",
+  component: ContentNotOnDprYet,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  parameters: {
+    // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
+    layout: "fullscreen",
+  },
+  args: {
+    council: council,
+  },
+} satisfies Meta<typeof ContentNotOnDprYet>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const NoCurrentLiveRegister: Story = {
+  args: {
+    council: createCouncilConfig({
+      councilName: "Public Council 2",
+      currentLiveRegister: undefined,
+    }),
+  },
+};

--- a/src/components/ContentNotOnDprYet/ContentNotOnDprYet.tsx
+++ b/src/components/ContentNotOnDprYet/ContentNotOnDprYet.tsx
@@ -1,0 +1,71 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Button } from "../button";
+import { Details } from "../govukDpr/Details";
+import { Council } from "@/config/types";
+
+type ContentNotOnDprYetProps = {
+  council?: Council;
+};
+
+export const ContentNotOnDprYet = ({ council }: ContentNotOnDprYetProps) => {
+  const currentLiveRegister = council?.currentLiveRegister;
+
+  return (
+    <>
+      <Details
+        summaryText={
+          "Not all planning applications are available on this register."
+        }
+        text={
+          <>
+            <p>
+              This register is being used as part of a pilot scheme to test Open
+              Digital Planning products in real-world settings.{" "}
+              <Button
+                element="link"
+                variant="text-only"
+                href="https://opendigitalplanning.org/end-end-product-pilot"
+              >
+                Find out more about this pilot scheme.
+              </Button>
+            </p>
+            <p>
+              This means that only a limited set of applications are being
+              published here.
+            </p>
+            <p>
+              If you cannot find an application here,{" "}
+              {currentLiveRegister ? (
+                <Button
+                  element="link"
+                  variant="text-only"
+                  href={currentLiveRegister}
+                >
+                  visit the primary planning register for {council?.name}.
+                </Button>
+              ) : (
+                <>visit the primary planning register for {council?.name}.</>
+              )}
+            </p>
+          </>
+        }
+      />
+    </>
+  );
+};

--- a/src/components/ContentNotOnDprYet/index.ts
+++ b/src/components/ContentNotOnDprYet/index.ts
@@ -1,0 +1,17 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+export * from "./ContentNotOnDprYet";

--- a/src/components/PageSearch/PageSearch.stories.tsx
+++ b/src/components/PageSearch/PageSearch.stories.tsx
@@ -188,3 +188,22 @@ export const AdvancedSearchPerformed: Story = {
     },
   },
 };
+
+export const LastPageShowsNotOnDprYet: Story = {
+  args: {
+    searchParams: {
+      page: 10,
+      resultsPerPage: 10,
+      type: "simple",
+      reference: "12345",
+    },
+    response: {
+      status: {
+        code: 200,
+        message: "OK",
+      },
+      data: [],
+      pagination: generatePagination(10, 100),
+    },
+  },
+};

--- a/src/components/PageSearch/PageSearch.tsx
+++ b/src/components/PageSearch/PageSearch.tsx
@@ -36,6 +36,7 @@ import { FormSearchFull } from "@/components/FormSearchFull";
 import { FormApplicationsSort } from "@/components/FormApplicationsSort";
 import React, { Suspense } from "react";
 import { applicationSearchFields } from "@/util/featureFlag";
+import { ContentNotOnDprYet } from "../ContentNotOnDprYet";
 
 export interface PageSearchProps {
   params: {
@@ -73,7 +74,14 @@ export const PageSearch = ({
   return (
     <PageMain>
       {type === "simple" && !searchPerformed && (
-        <SimpleNoSearchHeader emailAlertsLink={emailAlertsLink} />
+        <>
+          <SimpleNoSearchHeader emailAlertsLink={emailAlertsLink} />
+          <div className="govuk-grid-row grid-row-extra-bottom-margin">
+            <div className="govuk-grid-column-two-thirds">
+              <ContentNotOnDprYet council={appConfig.council} />
+            </div>
+          </div>
+        </>
       )}
       {type === "full" && searchPerformed && (
         <NotificationBanner
@@ -126,6 +134,12 @@ export const PageSearch = ({
                 application={application}
               />
             ))}
+            {searchPerformed &&
+              response.pagination &&
+              response.pagination.currentPage ===
+                response.pagination.totalPages && (
+                <ContentNotOnDprYet council={appConfig.council} />
+              )}
             {response.pagination && response.pagination.totalPages > 1 && (
               <Pagination
                 baseUrl={createPathFromParams(params)}
@@ -135,7 +149,13 @@ export const PageSearch = ({
             )}
           </>
         ) : (
-          <ContentNoResult councilConfig={appConfig.council} />
+          <>
+            <ContentNoResult
+              councilConfig={appConfig.council}
+              type="application"
+            />
+            <ContentNotOnDprYet council={appConfig.council} />
+          </>
         )}
       </Suspense>
     </PageMain>
@@ -161,11 +181,6 @@ const SimpleNoSearchHeader = ({
         <p className="govuk-body">
           You can find planning applications submitted through the Open Digital
           Planning system for your local council planning authority.
-        </p>
-        <p className="govuk-body">
-          Not all planning applications will be available through this register.
-          You may need to check individual council&apos;s websites to see what
-          records are kept here.
         </p>
       </div>
 

--- a/src/components/PageSearch/PageSearch.tsx
+++ b/src/components/PageSearch/PageSearch.tsx
@@ -74,14 +74,10 @@ export const PageSearch = ({
   return (
     <PageMain>
       {type === "simple" && !searchPerformed && (
-        <>
-          <SimpleNoSearchHeader emailAlertsLink={emailAlertsLink} />
-          <div className="govuk-grid-row grid-row-extra-bottom-margin">
-            <div className="govuk-grid-column-two-thirds">
-              <ContentNotOnDprYet council={appConfig.council} />
-            </div>
-          </div>
-        </>
+        <SimpleNoSearchHeader
+          emailAlertsLink={emailAlertsLink}
+          appConfig={appConfig}
+        />
       )}
       {type === "full" && searchPerformed && (
         <NotificationBanner
@@ -134,8 +130,7 @@ export const PageSearch = ({
                 application={application}
               />
             ))}
-            {searchPerformed &&
-              response.pagination &&
+            {response.pagination &&
               response.pagination.currentPage ===
                 response.pagination.totalPages && (
                 <ContentNotOnDprYet council={appConfig.council} />
@@ -169,8 +164,10 @@ export const PageSearch = ({
  */
 const SimpleNoSearchHeader = ({
   emailAlertsLink,
+  appConfig,
 }: {
   emailAlertsLink?: string;
+  appConfig: AppConfig;
 }) => {
   return (
     <div className="govuk-grid-row grid-row-extra-bottom-margin">
@@ -182,6 +179,7 @@ const SimpleNoSearchHeader = ({
           You can find planning applications submitted through the Open Digital
           Planning system for your local council planning authority.
         </p>
+        <ContentNotOnDprYet council={appConfig.council} />
       </div>
 
       {emailAlertsLink && (

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -252,6 +252,8 @@ const councils: Council[] = [
     features: {
       logoInHeader: true,
     },
+    currentLiveRegister:
+      "https://planningrecords.camden.gov.uk/NECSWS/PlanningExplorer/GeneralSearch.aspx",
     pageContent: {
       council_reference_submit_comment_pre_submission: {
         what_happens_to_your_comments_link:

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -90,6 +90,7 @@ export interface Council {
   features?: {
     logoInHeader?: boolean;
   };
+  currentLiveRegister?: string;
   pageContent: {
     privacy_policy: {
       privacy_policy_link: string;


### PR DESCRIPTION
[Ticket 1351](https://tpximpact.atlassian.net/browse/DSNPI-1351)

Adds the new ContentNotOnDprYet component.

It appears:
- At the top of the application list page when a search hasn't been performed
- At the end of any search result list, on the last page
- On the ‘no results found’ page

Also additional tests and storybook stories.