### PR TITLE
DSNPI-1369 / Add decision notice to progress component and remove from documents

### DIFF
--- a/__tests__/handlers/bops/v2/documents.test.ts
+++ b/__tests__/handlers/bops/v2/documents.test.ts
@@ -18,11 +18,7 @@
 import { documents } from "@/handlers/bops/v2/documents";
 import { handleBopsGetRequest } from "@/handlers/bops/requests";
 import { convertBopsDocumentEndpointToDprDocumentEndpoint } from "@/handlers/bops/converters/documents";
-import {
-  ApiResponse,
-  DprDocumentsApiResponse,
-  SearchParamsDocuments,
-} from "@/types";
+import { SearchParamsDocuments } from "@/types";
 
 jest.mock("@/handlers/bops/requests");
 jest.mock("@/handlers/bops/converters/documents");
@@ -76,7 +72,7 @@ describe("documents", () => {
     expect(urlArg).toContain("publishedAtTo=2024-01-31");
   });
 
-  it("adds only the application form if decisionNoticeUrl is not set", async () => {
+  it("adds only the application form", async () => {
     mockHandleBopsGetRequest.mockResolvedValue({
       status: { code: 200, message: "" },
       data: { files: [], metadata: { totalResults: 0 } },
@@ -88,25 +84,6 @@ describe("documents", () => {
       mockConvertBopsDocumentEndpointToDprDocumentEndpoint.mock.calls[0][4];
     expect(extraDocs).toHaveLength(1);
     expect(extraDocs[0].title).toBe("Application form");
-  });
-
-  it("adds the decision notice if decisionNoticeUrl is set", async () => {
-    mockHandleBopsGetRequest.mockResolvedValue({
-      status: { code: 200, message: "" },
-      data: {
-        files: [],
-        metadata: { totalResults: 0 },
-        decisionNotice: { url: "/docs/decision.pdf" },
-      },
-    });
-
-    await documents("camden", "APP-123", baseSearchParams);
-
-    const extraDocs =
-      mockConvertBopsDocumentEndpointToDprDocumentEndpoint.mock.calls[0][4];
-    expect(extraDocs).toHaveLength(2);
-    expect(extraDocs[1].title).toBe("Decision notice");
-    expect(extraDocs[1].url).toBe("/docs/decision.pdf");
   });
 
   it("returns the result from the converter", async () => {

--- a/src/components/ApplicationDetails/ApplicationDetails.tsx
+++ b/src/components/ApplicationDetails/ApplicationDetails.tsx
@@ -67,8 +67,6 @@ export const ApplicationDetails = ({
     application.data.caseOfficer.name || application.submission.data.applicant;
   const applicationProgress = buildApplicationProgress(application);
   const appeal = application.data.appeal;
-  const { url: decisionNoticeUrl } =
-    documents?.find((d) => d.title === "Decision notice") ?? {};
 
   const sidebar = [
     {
@@ -165,7 +163,7 @@ export const ApplicationDetails = ({
         <div className="govuk-grid-column-two-thirds-from-desktop dpr-application-details--flow">
           <ApplicationProgressInfo
             sections={applicationProgress}
-            decisionNoticeUrl={decisionNoticeUrl}
+            application={application}
           />
           <h2 className="govuk-heading-l" id="description">
             Description

--- a/src/components/ApplicationProgressInfo/ApplicationProgressInfo.stories.tsx
+++ b/src/components/ApplicationProgressInfo/ApplicationProgressInfo.stories.tsx
@@ -66,6 +66,7 @@ export const Consultation: Story = {
   name: "03-consultation",
   args: {
     sections: buildApplicationProgress(consultation),
+    application: consultation,
   },
 };
 
@@ -74,6 +75,7 @@ export const AssessmentInProgress: Story = {
   name: "04-assessment-00-assessment-in-progress",
   args: {
     sections: buildApplicationProgress(assessmentInProgress),
+    application: assessmentInProgress,
   },
 };
 
@@ -82,6 +84,7 @@ export const PlanningOfficerDetermined: Story = {
   name: "04-assessment-01-council-determined",
   args: {
     sections: buildApplicationProgress(planningOfficerDetermined),
+    application: planningOfficerDetermined,
   },
 };
 
@@ -90,6 +93,7 @@ export const AssessmentInCommittee: Story = {
   name: "04-assessment-02-assessment-in-committee",
   args: {
     sections: buildApplicationProgress(assessmentInCommittee),
+    application: assessmentInCommittee,
   },
 };
 
@@ -98,6 +102,7 @@ export const CommitteeDetermined: Story = {
   name: "04-assessment-03-committee-determined",
   args: {
     sections: buildApplicationProgress(committeeDetermined),
+    application: committeeDetermined,
   },
 };
 
@@ -106,6 +111,7 @@ export const AppealLodged: Story = {
   name: "05-appeal-00-appeal-lodged",
   args: {
     sections: buildApplicationProgress(appealLodged),
+    application: appealLodged,
   },
 };
 
@@ -114,6 +120,7 @@ export const AppealValid: Story = {
   name: "05-appeal-01-appeal-validated",
   args: {
     sections: buildApplicationProgress(appealValid),
+    application: appealValid,
   },
 };
 

--- a/src/components/ApplicationProgressInfo/ApplicationProgressInfo.tsx
+++ b/src/components/ApplicationProgressInfo/ApplicationProgressInfo.tsx
@@ -26,17 +26,17 @@ import {
   ProgressSectionBase,
 } from "./ApplicationProgressInfoSection";
 import { ApplicationProgressInfoToggleButton } from "./ApplicationProgressInfoToggleButton";
-import { Button } from "../button";
 import { Details } from "../govukDpr/Details";
-
+import { FileList } from "@/components/FileList";
+import { DprApplication } from "@/types";
 export interface ApplicationProgressInfoProps {
   sections: ProgressSectionBase[];
-  decisionNoticeUrl?: string;
+  application: DprApplication;
 }
 
 export const ApplicationProgressInfo = ({
   sections,
-  decisionNoticeUrl,
+  application,
 }: ApplicationProgressInfoProps) => {
   const [isClient, setIsClient] = useState(false);
   useEffect(() => {
@@ -91,6 +91,10 @@ export const ApplicationProgressInfo = ({
     return null;
   }
 
+  const decisionNoticeUrl = application?.data?.assessment?.decisionNotice?.url;
+  const decisionDate =
+    application?.data?.assessment?.planningOfficerDecisionDate;
+
   return (
     <section
       className="dpr-progress-info__container"
@@ -138,9 +142,20 @@ export const ApplicationProgressInfo = ({
         </>
       )}
       {decisionNoticeUrl && (
-        <Button variant="information" element="link" href={decisionNoticeUrl}>
-          View decision notice
-        </Button>
+        <div className="grid-row-extra-bottom-margin">
+          <FileList
+            documents={[
+              {
+                url: decisionNoticeUrl,
+                title: "Decision notice",
+                createdDate: decisionDate,
+                metadata: {
+                  contentType: "application/pdf",
+                },
+              },
+            ]}
+          />
+        </div>
       )}
       {/* commented out until we do this work */}
       {/* {councilSlug && reference && (

--- a/src/components/ApplicationProgressInfo/ApplicationProgressInfo.tsx
+++ b/src/components/ApplicationProgressInfo/ApplicationProgressInfo.tsx
@@ -31,7 +31,7 @@ import { FileList } from "@/components/FileList";
 import { DprApplication } from "@/types";
 export interface ApplicationProgressInfoProps {
   sections: ProgressSectionBase[];
-  application: DprApplication;
+  application?: DprApplication;
 }
 
 export const ApplicationProgressInfo = ({

--- a/src/handlers/bops/v2/documents.ts
+++ b/src/handlers/bops/v2/documents.ts
@@ -68,7 +68,6 @@ export async function documents(
   const totalResults = bopsPagination.totalResults;
 
   // add extra documents
-  const decisionNoticeUrl = request?.data?.decisionNotice?.url;
   const extraDocuments = [
     {
       url: `/${council}/${reference}/application-form`,
@@ -77,17 +76,6 @@ export async function documents(
         contentType: "html",
       },
     },
-    ...(decisionNoticeUrl
-      ? [
-          {
-            url: decisionNoticeUrl,
-            title: "Decision notice",
-            metadata: {
-              contentType: "application/pdf",
-            },
-          },
-        ]
-      : []),
   ];
 
   const documents = convertBopsDocumentEndpointToDprDocumentEndpoint(


### PR DESCRIPTION
[Ticket 1369](https://tpximpact.atlassian.net/jira/software/projects/DSNPI/boards/15?jql=assignee%20%3D%2062a6f3cb6085950068acebf7&selectedIssue=DSNPI-1369)

This PR adds the decision notice document to the `<ApplicationProgressInfo />` component via the `<FileList />` component.
It also removes the decision notice from being inserted into the documents.

![image](https://github.com/user-attachments/assets/09830a41-ab3e-44c9-9b92-5de8619eac5b)
