### PR TITLE
Fix for changed package name and docker build to include package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ WORKDIR /app
 COPY package*.json ./
 # Husky install file needed too
 COPY .husky/install.mjs ./.husky/install.mjs
+# Copy the local tgz package
+COPY digital-planning-data-schemas-*.tgz ./
 # Install dependencies
 RUN npm ci
 

--- a/__tests__/components/ApplicationConstraints/ApplicationConstraints.test.tsx
+++ b/__tests__/components/ApplicationConstraints/ApplicationConstraints.test.tsx
@@ -20,10 +20,10 @@ import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { ApplicationConstraints } from "@/components/ApplicationConstraints/ApplicationConstraints";
 import { fetchConstraintData } from "@/components/ApplicationConstraints/ApplicationConstraints.data";
-import {
+import type {
   PlanningConstraint,
   PlanningDesignation,
-} from "@/types/odp-types/shared/Constraints";
+} from "digital-planning-data-schemas/types/shared/Constraints.ts";
 // needed for the mocks
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { ApplicationConstraintsConstraint } from "@/components/ApplicationConstraints/ApplicationConstraintsConstraint";

--- a/__tests__/components/ApplicationConstraints/ApplicationConstraints.utils.test.ts
+++ b/__tests__/components/ApplicationConstraints/ApplicationConstraints.utils.test.ts
@@ -19,10 +19,10 @@ import {
   filterConstraints,
   getEntityFromUrl,
 } from "@/components/ApplicationConstraints/ApplicationConstraints.utils";
-import {
+import type {
   PlanningConstraint,
   PlanningDesignation,
-} from "@/types/odp-types/shared/Constraints";
+} from "digital-planning-data-schemas/types/shared/Constraints.ts";
 
 // NonIntersectingPlanningDesignation
 const testNonIntersectingPlanningDesignation: PlanningDesignation = {

--- a/__tests__/components/ApplicationConstraints/ApplicationConstraintsConstraint.test.tsx
+++ b/__tests__/components/ApplicationConstraints/ApplicationConstraintsConstraint.test.tsx
@@ -19,10 +19,10 @@ import "@testing-library/jest-dom";
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ApplicationConstraintsConstraint } from "@/components/ApplicationConstraints/ApplicationConstraintsConstraint";
-import {
+import type {
   PlanningConstraint,
   PlanningDesignation,
-} from "@/types/odp-types/shared/Constraints";
+} from "digital-planning-data-schemas/types/shared/Constraints.ts";
 import { DprDesignationConstraint } from "@/components/ApplicationConstraints";
 
 // Mock ApplicationMapLoader

--- a/src/components/ApplicationConstraints/ApplicationConstraints.tsx
+++ b/src/components/ApplicationConstraints/ApplicationConstraints.tsx
@@ -23,10 +23,10 @@ import {
 import { Accordion, AccordionSection } from "../Accordion";
 import { useRef, useState } from "react";
 import { fetchConstraintData } from "./ApplicationConstraints.data";
-import {
+import type {
   PlanningConstraint,
   PlanningDesignation,
-} from "@/types/odp-types/shared/Constraints";
+} from "digital-planning-data-schemas/types/shared/Constraints.ts";
 import { DprDesignationConstraint } from "./ApplicationConstraints.types";
 import { ApplicationConstraintsConstraint } from "@/components/ApplicationConstraints/ApplicationConstraintsConstraint";
 export interface ApplicationConstraintsProps {

--- a/src/components/ApplicationConstraints/ApplicationConstraints.types.ts
+++ b/src/components/ApplicationConstraints/ApplicationConstraints.types.ts
@@ -1,4 +1,4 @@
-import { Entity } from "@/types/odp-types/shared/Constraints";
+import type { Entity } from "digital-planning-data-schemas/types/shared/Constraints.ts";
 import { GeoJSON } from "geojson";
 
 export type DprDesignationConstraint = {

--- a/src/components/ApplicationConstraints/ApplicationConstraints.utils.ts
+++ b/src/components/ApplicationConstraints/ApplicationConstraints.utils.ts
@@ -15,10 +15,10 @@
  * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import {
+import type {
   PlanningConstraint,
   PlanningDesignation,
-} from "@/types/odp-types/shared/Constraints";
+} from "digital-planning-data-schemas/types/shared/Constraints.ts";
 import { DprDesignationConstraint } from ".";
 
 /**


### PR DESCRIPTION
This PR should fix the deployment pipeline. 

When we merged constraints they didn't have the new ODP package name which caused the build to fail.

We also weren't including the packaged ODP in the dockerfile so the deployment was failing.