### PR TITLE
DSNPI-1473 update constraints work for our new understandings

### DIFF
--- a/__tests__/components/ApplicationConstraints/ApplicationConstraints.utils.test.ts
+++ b/__tests__/components/ApplicationConstraints/ApplicationConstraints.utils.test.ts
@@ -103,7 +103,7 @@ describe("ApplicationConstraints.utils", () => {
   });
 
   describe("filterConstraints", () => {
-    it("returns only constraints where intersects is true", () => {
+    it("returns only constraints where intersects is true and has entities", () => {
       const constraints = [
         testNonIntersectingPlanningDesignation,
         testIntersectingPlanningDesignation,
@@ -116,6 +116,17 @@ describe("ApplicationConstraints.utils", () => {
         testIntersectingPlanningDesignation,
         testIntersectingPlanningConstraint,
       ]);
+    });
+
+    it("returns only constraints where intersects is true and has entities", () => {
+      const constraints = [
+        testNonIntersectingPlanningDesignation,
+        { ...testIntersectingPlanningDesignation, entities: [] },
+        testNonIntersectingPlanningConstraint,
+        { ...testIntersectingPlanningConstraint, entities: [] },
+      ];
+      const result = filterConstraints(constraints);
+      expect(result).toHaveLength(0);
     });
   });
 

--- a/__tests__/components/ApplicationConstraints/ApplicationConstraintsConstraint.test.tsx
+++ b/__tests__/components/ApplicationConstraints/ApplicationConstraintsConstraint.test.tsx
@@ -19,309 +19,92 @@ import "@testing-library/jest-dom";
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ApplicationConstraintsConstraint } from "@/components/ApplicationConstraints/ApplicationConstraintsConstraint";
-import type {
-  PlanningConstraint,
-  PlanningDesignation,
-} from "digital-planning-data-schemas/types/shared/Constraints.ts";
-import { DprDesignationConstraint } from "@/components/ApplicationConstraints";
+import { DprPlanningDataEntity } from "@/components/ApplicationConstraints";
 
 // Mock ApplicationMapLoader
 jest.mock("@/components/ApplicationMap", () => ({
   ApplicationMapLoader: jest.fn(() => <div data-testid="mock-map" />),
 }));
 
-// NonIntersectingPlanningDesignation
-const testNonIntersectingPlanningDesignation: PlanningDesignation = {
-  value: "nature.SAC",
-  description: "Special Area of Conservation (SAC)",
-  intersects: false,
-};
-
-// IntersectingPlanningDesignation
-const testIntersectingPlanningDesignation: PlanningDesignation = {
-  value: "articleFour",
-  description: "Article 4 direction area",
-  intersects: true,
-  entities: [
-    {
-      name: "Whole District excluding the Town of Chesham - Poultry production.",
-      description:
-        "Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.",
-      source: {
-        text: "Planning Data",
-        url: "https://www.planning.data.gov.uk/entity/7010002192",
-      },
-    },
-    {
-      name: "Stock Lane - Classified Unnumbered",
-      source: {
-        text: "Ordnance Survey MasterMap Highways",
-      },
-    },
-  ],
-};
-
-// NonIntersectingPlanningConstraint
-const testNonIntersectingPlanningConstraint: PlanningConstraint = {
-  value: "any value non intersecting",
-  description: "any description",
-  intersects: false,
-};
-
-// IntersectingPlanningConstraint
-const testIntersectingPlanningConstraint: PlanningConstraint = {
-  value: "any value intersecting",
-  description: "any description",
-  intersects: true,
-  entities: [
-    {
-      name: "Whole District excluding the Town of Chesham - Poultry production.",
-      description:
-        "Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.",
-      source: {
-        text: "Planning Data",
-        url: "https://www.planning.data.gov.uk/entity/7010002192",
-      },
-    },
-    {
-      name: "Stock Lane - Classified Unnumbered",
-      source: {
-        text: "Ordnance Survey MasterMap Highways",
-      },
-    },
-  ],
-};
-
-describe.only("ApplicationConstraintsConstraint", () => {
+describe("ApplicationConstraintsConstraint", () => {
   describe("When no data has been loaded for the constraint", () => {
-    it("Should render the default values for a NonIntersectingPlanningDesignation", () => {
-      render(
-        <ApplicationConstraintsConstraint
-          constraint={testNonIntersectingPlanningDesignation}
-        />,
+    it("Should render the default values for a constraint", () => {
+      const constraint: DprPlanningDataEntity = {
+        name: "Entity 2",
+        source: { text: "Planning Data", url: "https://example.com" },
+      };
+      const { container } = render(
+        <ApplicationConstraintsConstraint constraint={constraint} />,
       );
 
-      expect(
-        screen.getByText("Special Area of Conservation (SAC)"),
-      ).toBeInTheDocument();
-    });
-    it("Should render the default values for a IntersectingPlanningDesignation", () => {
-      render(
-        <ApplicationConstraintsConstraint
-          constraint={testIntersectingPlanningDesignation}
-        />,
-      );
+      // Check only one <p> is rendered
+      const paragraphs = container.querySelectorAll("p");
+      expect(paragraphs).toHaveLength(1);
 
-      expect(screen.getByText("Article 4 direction area")).toBeInTheDocument();
-
-      //first entity
-      expect(
-        screen.getByText(
-          "Whole District excluding the Town of Chesham - Poultry production.",
-        ),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(
-          "Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.",
-        ),
-      ).toBeInTheDocument();
-      const firstEntityLink = screen.getByRole("link", {
-        name: "https://www.planning.data.gov.uk/entity/7010002192",
-      });
-      expect(firstEntityLink).toBeInTheDocument();
-      expect(firstEntityLink).toHaveAttribute(
-        "href",
-        "https://www.planning.data.gov.uk/entity/7010002192",
-      );
-
-      // second entity
-      expect(
-        screen.getByText("Stock Lane - Classified Unnumbered"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText("Ordnance Survey MasterMap Highways"),
-      ).toBeInTheDocument();
-    });
-    it("Should render the default values for a NonIntersectingPlanningConstraint", () => {
-      render(
-        <ApplicationConstraintsConstraint
-          constraint={testNonIntersectingPlanningConstraint}
-        />,
-      );
-      expect(screen.getByText("any description")).toBeInTheDocument();
-    });
-    it("Should render the default values for a IntersectingPlanningConstraint", () => {
-      render(
-        <ApplicationConstraintsConstraint
-          constraint={testIntersectingPlanningConstraint}
-        />,
-      );
-
-      expect(screen.getByText("any description")).toBeInTheDocument();
-
-      //first entity
-      expect(
-        screen.getByText(
-          "Whole District excluding the Town of Chesham - Poultry production.",
-        ),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(
-          "Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.",
-        ),
-      ).toBeInTheDocument();
-      const firstEntityLink = screen.getByRole("link", {
-        name: "https://www.planning.data.gov.uk/entity/7010002192",
-      });
-      expect(firstEntityLink).toBeInTheDocument();
-      expect(firstEntityLink).toHaveAttribute(
-        "href",
-        "https://www.planning.data.gov.uk/entity/7010002192",
-      );
-
-      // second entity
-      expect(
-        screen.getByText("Stock Lane - Classified Unnumbered"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText("Ordnance Survey MasterMap Highways"),
-      ).toBeInTheDocument();
+      // Check that the <p> contains "Source:"
+      expect(paragraphs[0]).toHaveTextContent("Source:");
     });
   });
 
-  const baseConstraint: DprDesignationConstraint = {
-    description: "Test constraint description",
-    value: "test",
-    intersects: true,
-  };
-
-  it("renders the constraint description", () => {
-    render(<ApplicationConstraintsConstraint constraint={baseConstraint} />);
-    expect(screen.getByText("Test constraint description")).toBeInTheDocument();
-  });
-
-  it("renders entity name and description when no data is loaded", () => {
-    const constraint: DprDesignationConstraint = {
-      ...baseConstraint,
-      entities: [
-        {
-          name: "Entity 1",
-          description: "Entity 1 description",
-          source: { text: "Planning Data", url: "https://example.com" },
-        },
-      ],
-    };
-    render(<ApplicationConstraintsConstraint constraint={constraint} />);
-    expect(screen.getByText("Entity 1")).toBeInTheDocument();
-    expect(screen.getByText("Entity 1 description")).toBeInTheDocument();
-
-    const entityLink = screen.getByRole("link", {
-      name: "https://example.com",
-    });
-    expect(entityLink).toBeInTheDocument();
-    expect(entityLink).toHaveAttribute("href", "https://example.com");
-  });
-
-  it("renders loaded entity data fields", () => {
-    const constraint: DprDesignationConstraint = {
-      ...baseConstraint,
-      entities: [
-        {
-          name: "Entity 2",
-          source: { text: "Planning Data", url: "https://example.com" },
-          data: {
-            name: "Loaded Name",
-            description: "Loaded description",
-            reference: "REF123",
-            entryDate: "2024-01-01",
-            startDate: "2024-01-02",
-            endDate: "2024-01-03",
-            designationDate: "2024-01-04",
+  describe("When data has been loaded for the constraint", () => {
+    it("Should render the loaded values for a constraint", () => {
+      const constraint: DprPlanningDataEntity = {
+        name: "Entity 2",
+        source: { text: "Planning Data", url: "https://example.com" },
+        data: {
+          name: "Loaded Name",
+          description: "Loaded description",
+          reference: "REF123",
+          entryDate: "2024-01-01",
+          startDate: "2024-01-02",
+          endDate: "2024-01-03",
+          designationDate: "2024-01-04",
+          geometry: {
+            type: "Feature",
             geometry: {
-              type: "Feature",
-              geometry: {
-                type: "MultiPolygon",
-                coordinates: [
+              type: "MultiPolygon",
+              coordinates: [
+                [
                   [
-                    [
-                      [-0.750518, 51.687475],
-                      [-0.749934, 51.687746],
-                      [-0.749934, 51.687746],
-                      [-0.750518, 51.687475],
-                    ],
+                    [-0.750518, 51.687475],
+                    [-0.749934, 51.687746],
+                    [-0.749934, 51.687746],
+                    [-0.750518, 51.687475],
                   ],
                 ],
-              },
-              properties: {},
+              ],
             },
-            documentUrl: "https://doc.example.com",
-            documentationUrl: "https://docu.example.com",
-            dataset: "test-dataset",
-            entity: 42,
+            properties: {},
           },
+          documentUrl: "https://doc.example.com",
+          documentationUrl: "https://docu.example.com",
+          dataset: "test-dataset",
+          entity: 42,
         },
-      ],
-    };
-    render(<ApplicationConstraintsConstraint constraint={constraint} />);
-    expect(screen.getByText("Loaded Name")).toBeInTheDocument();
-    expect(screen.getByText("Loaded description")).toBeInTheDocument();
-    expect(screen.getByText("REF123")).toBeInTheDocument();
-    expect(screen.getByText("2024-01-01")).toBeInTheDocument();
-    expect(screen.getByText("2024-01-02")).toBeInTheDocument();
-    expect(screen.getByText("2024-01-03")).toBeInTheDocument();
-    expect(screen.getByText("2024-01-04")).toBeInTheDocument();
-    expect(screen.getByTestId("mock-map")).toBeInTheDocument();
-    expect(screen.getByText("https://doc.example.com")).toBeInTheDocument();
-    expect(screen.getByText("https://docu.example.com")).toBeInTheDocument();
-  });
+      };
+      render(<ApplicationConstraintsConstraint constraint={constraint} />);
+      // no name as thats in the accordion title
+      expect(screen.queryByText("Loaded Name")).not.toBeInTheDocument();
+      expect(screen.getByText("Loaded description")).toBeInTheDocument();
+      expect(screen.getByText("REF123")).toBeInTheDocument();
+      expect(screen.getByText("2024-01-01")).toBeInTheDocument();
+      expect(screen.getByText("2024-01-02")).toBeInTheDocument();
+      expect(screen.getByText("2024-01-03")).toBeInTheDocument();
+      expect(screen.getByText("2024-01-04")).toBeInTheDocument();
+      expect(screen.getByTestId("mock-map")).toBeInTheDocument();
+      expect(screen.getByText("https://doc.example.com")).toBeInTheDocument();
+      expect(screen.getByText("https://docu.example.com")).toBeInTheDocument();
+    });
 
-  it("renders multiple entities", () => {
-    const constraint: DprDesignationConstraint = {
-      ...baseConstraint,
-      entities: [
-        {
-          name: "Entity 1",
-          source: { text: "Ordnance Survey MasterMap Highways" },
-        },
-        {
-          name: "Entity 2",
-          source: { text: "Ordnance Survey MasterMap Highways" },
-        },
-      ],
-    };
-    render(<ApplicationConstraintsConstraint constraint={constraint} />);
-    expect(screen.getByText("Entity 1")).toBeInTheDocument();
-    expect(screen.getByText("Entity 2")).toBeInTheDocument();
-    expect(
-      screen.getAllByText("Ordnance Survey MasterMap Highways").length,
-    ).toBe(2);
-  });
-
-  it("renders only the source text if url is not present", () => {
-    const constraint: DprDesignationConstraint = {
-      ...baseConstraint,
-      entities: [
-        {
-          name: "Entity 3",
-          source: { text: "Ordnance Survey MasterMap Highways" },
-        },
-      ],
-    };
-    render(<ApplicationConstraintsConstraint constraint={constraint} />);
-    expect(
-      screen.getByText("Ordnance Survey MasterMap Highways"),
-    ).toBeInTheDocument();
-  });
-
-  it("renders nothing for empty entities array", () => {
-    const constraint = {
-      ...baseConstraint,
-      entities: [],
-    };
-    const { container } = render(
-      <ApplicationConstraintsConstraint constraint={constraint} />,
-    );
-    // Only the description should be present
-    expect(container).toHaveTextContent("Test constraint description");
+    it("renders only the source text if url is not present", () => {
+      const constraint: DprPlanningDataEntity = {
+        name: "Entity 3",
+        source: { text: "Ordnance Survey MasterMap Highways" },
+      };
+      render(<ApplicationConstraintsConstraint constraint={constraint} />);
+      expect(
+        screen.getByText("Ordnance Survey MasterMap Highways"),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/__tests__/components/ApplicationDetails.test.tsx
+++ b/__tests__/components/ApplicationDetails.test.tsx
@@ -96,7 +96,7 @@ const baseProps = {
   appConfig: baseAppConfig as AppConfig,
 };
 
-describe.only("ApplicationDetails", () => {
+describe("ApplicationDetails", () => {
   it("renders ContentError if council config is missing", () => {
     render(
       <ApplicationDetails

--- a/src/components/ApplicationConstraints/ApplicationConstraints.data.ts
+++ b/src/components/ApplicationConstraints/ApplicationConstraints.data.ts
@@ -16,46 +16,29 @@
  */
 
 import { fetchEntityFromPlanningData } from "@/actions/planningData";
-import {
-  DprDesignationConstraint,
-  DprPlanningDataEntity,
-} from "./ApplicationConstraints.types";
+import { DprPlanningDataEntity } from "./ApplicationConstraints.types";
 import { getEntityFromUrl } from "./ApplicationConstraints.utils";
 
 export const fetchConstraintData = async (
-  constraint: DprDesignationConstraint,
-): Promise<DprDesignationConstraint> => {
-  if (!constraint.entities) return constraint;
-  const entities = constraint.entities;
-
-  const updatedEntities = await Promise.allSettled(
-    entities.map(async (entity: DprPlanningDataEntity) => {
-      try {
-        if (
-          entity.source &&
-          "url" in entity.source &&
-          typeof entity.source.url === "string" &&
-          entity.source.url.includes("planning.data.gov.uk/entity")
-        ) {
-          const entityId = getEntityFromUrl(entity.source.url);
-          if (entityId) {
-            const planningData = await fetchEntityFromPlanningData(entityId);
-            if (planningData.data) {
-              return { ...entity, data: planningData.data };
-            }
-          }
+  constraint: DprPlanningDataEntity,
+): Promise<DprPlanningDataEntity> => {
+  try {
+    if (
+      constraint.source &&
+      "url" in constraint.source &&
+      typeof constraint.source.url === "string" &&
+      constraint.source.url.includes("planning.data.gov.uk/entity")
+    ) {
+      const entityId = getEntityFromUrl(constraint.source.url);
+      if (entityId) {
+        const planningData = await fetchEntityFromPlanningData(entityId);
+        if (planningData.data) {
+          return { ...constraint, data: planningData.data };
         }
-        return entity;
-      } catch {
-        return entity;
       }
-    }),
-  );
-
-  return {
-    ...constraint,
-    entities: updatedEntities.map((result, i) =>
-      result.status === "fulfilled" ? result.value : { ...entities[i] },
-    ),
-  };
+    }
+    return constraint;
+  } catch {
+    return constraint;
+  }
 };

--- a/src/components/ApplicationConstraints/ApplicationConstraints.stories.tsx
+++ b/src/components/ApplicationConstraints/ApplicationConstraints.stories.tsx
@@ -39,15 +39,6 @@ const meta = {
   },
   args: {
     constraints: [
-      //  https://www.planning.data.gov.uk/entity/44009642
-      // https://www.planning.data.gov.uk/entity/7010002613
-      // NonIntersectingPlanningDesignation
-      {
-        value: "nature.SAC",
-        description: "Special Area of Conservation (SAC)",
-        intersects: false,
-      },
-      // IntersectingPlanningDesignation
       {
         value: "articleFour",
         description: "Article 4 direction area",
@@ -62,38 +53,18 @@ const meta = {
               url: "https://www.planning.data.gov.uk/entity/7010002192",
             },
           },
-          {
-            name: "Stock Lane - Classified Unnumbered",
-            source: {
-              text: "Ordnance Survey MasterMap Highways",
-            },
-          },
         ],
       },
-      // NonIntersectingPlanningConstraint
       {
-        value: "NonIntersectingPlanningConstraint value",
-        description: "NonIntersectingPlanningConstraint description",
+        value: "articleFour.caz",
+        description: "Central Activities Zone (CAZ)",
         intersects: false,
       },
-      // IntersectingPlanningConstraint
       {
-        value: "IntersectingPlanningConstraint value",
-        description: "IntersectingPlanningConstraint description",
-        intersects: true,
-        entities: [
-          {
-            name: "Whole District excluding the Town of Chesham - Poultry production.",
-            description:
-              "Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.",
-            source: {
-              text: "Planning Data",
-              url: "https://www.planning.data.gov.uk/entity/7010002192",
-            },
-          },
-        ],
+        value: "tpo",
+        description: "Tree Preservation Order (TPO) or zone",
+        intersects: false,
       },
-      // example with multiple entities
       {
         value: "listed",
         description: "Listed building",
@@ -115,6 +86,118 @@ const meta = {
           },
         ],
       },
+      {
+        value: "monument",
+        description: "Site of a Scheduled Monument",
+        intersects: false,
+      },
+      {
+        value: "greenBelt",
+        description: "Green belt",
+        intersects: true,
+        entities: [
+          {
+            name: "Buckinghamshire",
+            source: {
+              text: "Planning Data",
+              url: "https://www.planning.data.gov.uk/entity/610030",
+            },
+          },
+        ],
+      },
+      {
+        value: "designated",
+        description: "Designated land",
+        intersects: true,
+      },
+      {
+        value: "nature.SAC",
+        description: "Special Area of Conservation (SAC)",
+        intersects: false,
+      },
+      {
+        value: "nature.ASNW",
+        description: "Ancient Semi-Natural Woodland (ASNW)",
+        intersects: false,
+      },
+      {
+        value: "nature.SSSI",
+        description: "Site of Special Scientific Interest (SSSI)",
+        intersects: false,
+      },
+      {
+        value: "nature.SPA",
+        description: "Special Protection Area (SPA)",
+        intersects: false,
+      },
+      {
+        value: "designated.WHS",
+        description: "UNESCO World Heritage Site (WHS)",
+        intersects: false,
+      },
+      {
+        value: "registeredPark",
+        description: "Registered parks and gardens",
+        intersects: false,
+      },
+      {
+        value: "designated.AONB",
+        description: "Area of Outstanding Natural Beauty (AONB)",
+        intersects: true,
+        entities: [
+          {
+            name: "Chilterns",
+            source: {
+              text: "Planning Data",
+              url: "https://www.planning.data.gov.uk/entity/1000005",
+            },
+          },
+        ],
+      },
+      {
+        value: "designated.nationalPark",
+        description: "National Park",
+        intersects: false,
+      },
+      {
+        value: "designated.conservationArea",
+        description: "Conservation area",
+        intersects: true,
+        entities: [
+          {
+            name: "Dulwich Village",
+            source: {
+              url: "https://www.planning.data.gov.uk/entity/44007440",
+              text: "Planning Data",
+            },
+          },
+          {
+            name: "Hackford Road",
+            source: {
+              text: "Planning Data",
+              url: "https://www.planning.data.gov.uk/entity/44000877",
+            },
+          },
+        ],
+      },
+      {
+        value: "designated.nationalPark.broads",
+        description: "National Park - Broads",
+        intersects: false,
+      },
+      {
+        value: "road.classified",
+        description: "Classified road",
+        intersects: true,
+        entities: [
+          {
+            name: "Stock Lane - Classified Unnumbered",
+            source: {
+              text: "Ordnance Survey MasterMap Highways",
+            },
+          },
+        ],
+      },
     ],
   },
 } satisfies Meta<typeof ApplicationConstraints>;
@@ -123,3 +206,95 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const NoConstraintsFoundInPlanX: Story = {
+  args: {
+    constraints: [
+      {
+        value: "articleFour",
+        description: "Article 4 direction area",
+        intersects: false,
+      },
+      {
+        value: "articleFour.caz",
+        description: "Central Activities Zone (CAZ)",
+        intersects: false,
+      },
+      {
+        value: "tpo",
+        description: "Tree Preservation Order (TPO) or zone",
+        intersects: false,
+      },
+      {
+        value: "listed",
+        description: "Listed building",
+        intersects: false,
+      },
+      {
+        value: "monument",
+        description: "Site of a Scheduled Monument",
+        intersects: false,
+      },
+      {
+        value: "designated",
+        description: "Designated land",
+        intersects: false,
+      },
+      {
+        value: "nature.SAC",
+        description: "Special Area of Conservation (SAC)",
+        intersects: false,
+      },
+      {
+        value: "nature.ASNW",
+        description: "Ancient Semi-Natural Woodland (ASNW)",
+        intersects: false,
+      },
+      {
+        value: "nature.SSSI",
+        description: "Site of Special Scientific Interest (SSSI)",
+        intersects: false,
+      },
+      {
+        value: "nature.SPA",
+        description: "Special Protection Area (SPA)",
+        intersects: false,
+      },
+      {
+        value: "designated.WHS",
+        description: "UNESCO World Heritage Site (WHS)",
+        intersects: false,
+      },
+      {
+        value: "registeredPark",
+        description: "Registered parks and gardens",
+        intersects: false,
+      },
+      {
+        value: "designated.AONB",
+        description: "Area of Outstanding Natural Beauty (AONB)",
+        intersects: false,
+      },
+      {
+        value: "designated.nationalPark",
+        description: "National Park",
+        intersects: false,
+      },
+      {
+        value: "designated.conservationArea",
+        description: "Conservation area",
+        intersects: false,
+      },
+      {
+        value: "designated.nationalPark.broads",
+        description: "National Park - Broads",
+        intersects: false,
+      },
+      {
+        value: "road.classified",
+        description: "Classified road",
+        intersects: false,
+      },
+    ],
+  },
+};

--- a/src/components/ApplicationConstraints/ApplicationConstraints.utils.ts
+++ b/src/components/ApplicationConstraints/ApplicationConstraints.utils.ts
@@ -41,12 +41,17 @@ export const prepareConstraints = (
 };
 
 /**
- * Removes constraints that do not intersect from the list of constraints.
+ * Allow only items that have intersects set to true and has entities
  * @param constraints
  * @returns
  */
 export const filterConstraints = (constraints: DprDesignationConstraint[]) => {
-  return constraints.filter((constraint) => constraint.intersects);
+  return constraints.filter(
+    (constraint) =>
+      constraint.intersects &&
+      constraint.entities &&
+      constraint.entities.length > 0,
+  );
 };
 
 /**

--- a/src/components/ApplicationConstraints/ApplicationConstraintsConstraint.stories.tsx
+++ b/src/components/ApplicationConstraints/ApplicationConstraintsConstraint.stories.tsx
@@ -3533,118 +3533,63 @@ const geometry: GeoJSON = {
     entity: 7010002192,
   },
 };
-export const LoadedIntersectingPlanningDesignation: Story = {
+
+export const LoadedPlanningDataConstraint: Story = {
   args: {
     constraint: {
-      value: "articleFour",
-      description: "Article 4 direction area",
-      intersects: true,
-      entities: [
-        {
-          name: "Whole District excluding the Town of Chesham - Poultry production.",
-          description:
-            "Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.",
-          source: {
-            text: "Planning Data",
-            url: "https://www.planning.data.gov.uk/entity/7010002192",
-          },
-          data: {
-            name: "Whole District excluding the Town of Chesham - Poultry production.",
-            dataset: "article-4-direction-area",
-            entity: 7010002192,
-            description:
-              "Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.",
-            entryDate: "2025-01-08",
-            startDate: "2059-01-15",
-            geometry: geometry,
-          },
-        },
-        {
-          name: "Stock Lane - Classified Unnumbered",
-          source: {
-            text: "Ordnance Survey MasterMap Highways",
-          },
-        },
-      ],
+      name: "Whole District excluding the Town of Chesham - Poultry production.",
+      description:
+        "Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.",
+      source: {
+        text: "Planning Data",
+        url: "https://www.planning.data.gov.uk/entity/7010002192",
+      },
+      data: {
+        name: "Whole District excluding the Town of Chesham - Poultry production.",
+        dataset: "article-4-direction-area",
+        entity: 7010002192,
+        description:
+          "Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.",
+        entryDate: "2025-01-08",
+        startDate: "2059-01-15",
+        geometry: geometry,
+      },
     },
   },
 };
 
-export const LoadedIntersectingPlanningConstraint: Story = {
+export const LoadedOrdnanceSurveyConstraint: Story = {
   args: {
     constraint: {
-      value: "IntersectingPlanningConstraint value",
-      description: "IntersectingPlanningConstraint description",
-      intersects: true,
-      entities: [
-        {
-          name: "Whole District excluding the Town of Chesham - Poultry production.",
-          description:
-            "Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.",
-          source: {
-            text: "Planning Data",
-            url: "https://www.planning.data.gov.uk/entity/7010002192",
-          },
-          data: {
-            name: "Whole District excluding the Town of Chesham - Poultry production.",
-            dataset: "article-4-direction-area",
-            entity: 7010002192,
-            description:
-              "Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.",
-            entryDate: "2025-01-08",
-            startDate: "2059-01-15",
-            geometry: geometry,
-          },
-        },
-      ],
+      name: "Stock Lane - Classified Unnumbered",
+      source: {
+        text: "Ordnance Survey MasterMap Highways",
+      },
     },
   },
 };
 
-export const DefaultIntersectingPlanningDesignation: Story = {
+export const DefaultPlanningDataConstraint: Story = {
   args: {
     constraint: {
-      value: "articleFour",
-      description: "Article 4 direction area",
-      intersects: true,
-      entities: [
-        {
-          name: "Whole District excluding the Town of Chesham - Poultry production.",
-          description:
-            "Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.",
-          source: {
-            text: "Planning Data",
-            url: "https://www.planning.data.gov.uk/entity/7010002192",
-          },
-        },
-        {
-          name: "Stock Lane - Classified Unnumbered",
-          source: {
-            text: "Ordnance Survey MasterMap Highways",
-          },
-        },
-      ],
+      name: "Whole District excluding the Town of Chesham - Poultry production.",
+      description:
+        "Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.",
+      source: {
+        text: "Planning Data",
+        url: "https://www.planning.data.gov.uk/entity/7010002192",
+      },
     },
   },
 };
 
-export const DefaultIntersectingPlanningConstraint: Story = {
+export const DefaultOrdnanceSurveyConstraint: Story = {
   args: {
     constraint: {
-      value: "IntersectingPlanningConstraint value",
-      description: "IntersectingPlanningConstraint description",
-      intersects: true,
-      entities: [
-        {
-          name: "Whole District excluding the Town of Chesham - Poultry production.",
-          description:
-            "Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.",
-          source: {
-            text: "Planning Data",
-            url: "https://www.planning.data.gov.uk/entity/7010002192",
-          },
-        },
-      ],
+      name: "Stock Lane - Classified Unnumbered",
+      source: {
+        text: "Ordnance Survey MasterMap Highways",
+      },
     },
   },
 };

--- a/src/components/ApplicationConstraints/ApplicationConstraintsConstraint.tsx
+++ b/src/components/ApplicationConstraints/ApplicationConstraintsConstraint.tsx
@@ -16,11 +16,11 @@
  */
 
 import React from "react";
-import { DprDesignationConstraint } from "./ApplicationConstraints.types";
+import { DprPlanningDataEntity } from "./ApplicationConstraints.types";
 import { ApplicationMapLoader } from "../ApplicationMap";
 
 export interface ApplicationConstraintsConstraintProps {
-  constraint: DprDesignationConstraint;
+  constraint: DprPlanningDataEntity;
 }
 
 export const ApplicationConstraintsConstraint = ({
@@ -28,133 +28,114 @@ export const ApplicationConstraintsConstraint = ({
 }: ApplicationConstraintsConstraintProps) => {
   return (
     <>
-      <p className="govuk-body">{constraint.description}</p>
-      {constraint.entities && constraint.entities.length > 0 && (
-        <React.Fragment>
-          {constraint.entities.map((entity, index) => (
-            <React.Fragment key={index}>
-              <hr className="govuk-section-break govuk-section-break--l" />
+      {/* if there is loaded data show it! */}
+      {constraint.data ? (
+        <>
+          {constraint.data.description && (
+            <p className="govuk-body">{constraint.data.description}</p>
+          )}
+          {constraint.data.reference && (
+            <p className="govuk-body">
+              <strong>Reference:</strong> {constraint.data.reference}
+            </p>
+          )}
 
-              {/* if there is loaded data show it! */}
-              {entity.data ? (
-                <>
-                  {entity.data.name && (
-                    <p className="govuk-body-l govuk-!-font-weight-bold">
-                      {entity.data.name}
-                    </p>
-                  )}
-                  {entity.data.description && (
-                    <p className="govuk-body">{entity.data.description}</p>
-                  )}
-                  {entity.data.reference && (
-                    <p className="govuk-body">
-                      <strong>Reference:</strong> {entity.data.reference}
-                    </p>
-                  )}
+          {constraint.data.entryDate && (
+            <p className="govuk-body">
+              <strong>Entry date:</strong> {constraint.data.entryDate}
+            </p>
+          )}
+          {constraint.data.startDate && (
+            <p className="govuk-body">
+              <strong>Start date:</strong> {constraint.data.startDate}
+            </p>
+          )}
+          {constraint.data.endDate && (
+            <p className="govuk-body">
+              <strong>End date:</strong> {constraint.data.endDate}
+            </p>
+          )}
+          {constraint.data.designationDate && (
+            <p className="govuk-body">
+              <strong>End date:</strong> {constraint.data.designationDate}
+            </p>
+          )}
 
-                  {entity.data.entryDate && (
-                    <p className="govuk-body">
-                      <strong>Entry date:</strong> {entity.data.entryDate}
-                    </p>
-                  )}
-                  {entity.data.startDate && (
-                    <p className="govuk-body">
-                      <strong>Start date:</strong> {entity.data.startDate}
-                    </p>
-                  )}
-                  {entity.data.endDate && (
-                    <p className="govuk-body">
-                      <strong>End date:</strong> {entity.data.endDate}
-                    </p>
-                  )}
-                  {entity.data.designationDate && (
-                    <p className="govuk-body">
-                      <strong>End date:</strong> {entity.data.designationDate}
-                    </p>
-                  )}
+          {constraint.data.geometry && (
+            <>
+              <ApplicationMapLoader
+                reference={constraint.data.entity.toString()}
+                mapData={constraint.data.geometry}
+                description={`Map showing outline of the area covered for ${constraint.data.entity}`}
+                mapType="constraint-accordion"
+              />
+              <br />
+            </>
+          )}
 
-                  {entity.data.geometry && (
-                    <>
-                      <ApplicationMapLoader
-                        reference={entity.data.entity.toString()}
-                        mapData={entity.data.geometry}
-                        description={`Map showing outline of the area covered for ${entity.data.entity}`}
-                        mapType="constraint-accordion"
-                      />
-                      <br />
-                    </>
-                  )}
+          {constraint.data.documentUrl && (
+            <p className="govuk-body">
+              <strong>Document URL:</strong>{" "}
+              <a
+                href={constraint.data.documentUrl}
+                target="_blank"
+                className="govuk-link govuk-link--no-visited-state"
+                rel="noopener noreferrer"
+              >
+                {constraint.data.documentUrl}
+              </a>
+            </p>
+          )}
 
-                  {entity.data.documentUrl && (
-                    <p className="govuk-body">
-                      <strong>Document URL:</strong>{" "}
-                      <a
-                        href={entity.data.documentUrl}
-                        target="_blank"
-                        className="govuk-link govuk-link--no-visited-state"
-                        rel="noopener noreferrer"
-                      >
-                        {entity.data.documentUrl}
-                      </a>
-                    </p>
-                  )}
+          {constraint.data.documentationUrl && (
+            <p className="govuk-body">
+              <strong>Document URL:</strong>{" "}
+              <a
+                href={constraint.data.documentationUrl}
+                target="_blank"
+                className="govuk-link govuk-link--no-visited-state"
+                rel="noopener noreferrer"
+              >
+                {constraint.data.documentationUrl}
+              </a>
+            </p>
+          )}
 
-                  {entity.data.documentationUrl && (
-                    <p className="govuk-body">
-                      <strong>Document URL:</strong>{" "}
-                      <a
-                        href={entity.data.documentationUrl}
-                        target="_blank"
-                        className="govuk-link govuk-link--no-visited-state"
-                        rel="noopener noreferrer"
-                      >
-                        {entity.data.documentationUrl}
-                      </a>
-                    </p>
-                  )}
-
-                  {/* hidden but useful for debugging purposes */}
-                  {entity.data.dataset && (
-                    <p className="hidden">
-                      <strong>Dataset:</strong> {entity.data.dataset}
-                    </p>
-                  )}
-                  {entity.data.entity && (
-                    <p className="hidden">
-                      <strong>Entity:</strong> {entity.data.entity}
-                    </p>
-                  )}
-                </>
+          {/* hidden but useful for testing & debugging purposes */}
+          {constraint.data.dataset && (
+            <p className="hidden" data-field="dataset">
+              <strong>Dataset:</strong> {constraint.data.dataset}
+            </p>
+          )}
+          {constraint.data.entity && (
+            <p className="hidden">
+              <strong>Entity:</strong> {constraint.data.entity}
+            </p>
+          )}
+        </>
+      ) : (
+        <>
+          {constraint.description && (
+            <p className="govuk-body">{constraint.description}</p>
+          )}
+          {constraint.source.text && (
+            <p className="govuk-body-s">
+              <strong>Source:</strong>{" "}
+              {"url" in constraint.source && constraint.source.url ? (
+                <a
+                  href={constraint.source.url}
+                  target="_blank"
+                  className="govuk-link govuk-link--no-visited-state"
+                  rel="noopener noreferrer"
+                >
+                  {constraint.source.url || constraint.source.text}
+                </a>
               ) : (
-                <>
-                  <p className="govuk-body-l govuk-!-font-weight-bold">
-                    {entity.name}
-                  </p>
-                  {entity.description && (
-                    <p className="govuk-body">{entity.description}</p>
-                  )}
-                  {entity.source.text && (
-                    <p className="govuk-body-s">
-                      <strong>Source:</strong>{" "}
-                      {"url" in entity.source && entity.source.url ? (
-                        <a
-                          href={entity.source.url}
-                          target="_blank"
-                          className="govuk-link govuk-link--no-visited-state"
-                          rel="noopener noreferrer"
-                        >
-                          {entity.source.url || entity.source.text}
-                        </a>
-                      ) : (
-                        entity.source.text
-                      )}
-                    </p>
-                  )}
-                </>
+                constraint.source.text
               )}
-            </React.Fragment>
-          ))}
-        </React.Fragment>
+            </p>
+          )}
+        </>
       )}
     </>
   );


### PR DESCRIPTION
This PR removes some extra logic we were doing to split out the entities from their groups. 

We had thought each 'block' containing entities was the constraint but thats not the case. Each entity inside an 'entities' field is the constraint and its grouped by the planning data (or other) data set. 

Previously we did:

- Constraint 1 open/close
  - Entity 1 (Constraint 1)
    - Fetched data
  - Entity 2 (Constraint 1)
    - Fetched data
- Constraint 2 open/close
  - Entity 1 (Constraint 2)
    - Fetched data
  - Entity 2 (Constraint 2)
    - Fetched data

Now we do:

- Constraint 1: Entity 1
    - Fetched data
- Constraint 1: Entity 2
    - Fetched data
- Constraint 2: Entity 1
    - Fetched data
- Constraint 2: Entity 2
    - Fetched data


## Before:
<img width="3262" height="1952" alt="image" src="https://github.com/user-attachments/assets/b798446e-a266-4b00-b1aa-5489ddfa4a02" />
<img width="3262" height="4998" alt="image" src="https://github.com/user-attachments/assets/e5a1990a-37c9-4c2f-8f8a-d1d3ebb7e4bf" />


## After:
<img width="3262" height="2511" alt="image" src="https://github.com/user-attachments/assets/3512addd-c4c3-41f5-b7ee-00f3d809a05b" />
<img width="3262" height="5008" alt="image" src="https://github.com/user-attachments/assets/1c450568-37a1-4563-9342-65bd591d0684" />
