### PR TITLE
fix for decision notice url being incorrect

### DIFF
--- a/__tests__/handlers/bops/actions/getDecisionNoticeUrl.test.ts
+++ b/__tests__/handlers/bops/actions/getDecisionNoticeUrl.test.ts
@@ -1,0 +1,77 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { getDecisionNoticeUrl } from "@/handlers/bops/actions/getDecisionNoticeUrl";
+import { handleBopsGetRequest } from "@/handlers/bops/requests";
+
+jest.mock("@/handlers/bops/requests", () => ({
+  handleBopsGetRequest: jest.fn(),
+}));
+
+const logErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+describe("getDecisionNoticeUrl", () => {
+  const council = "camden";
+  const reference = "APP/1234/2024";
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the decision notice url if present", async () => {
+    (handleBopsGetRequest as jest.Mock).mockResolvedValue({
+      data: {
+        decisionNotice: { url: "https://example.com/decision.pdf" },
+      },
+    });
+
+    const url = await getDecisionNoticeUrl(council, reference);
+    expect(url).toBe("https://example.com/decision.pdf");
+    expect(handleBopsGetRequest).toHaveBeenCalledWith(
+      council,
+      expect.stringContaining(reference),
+    );
+  });
+
+  it("returns undefined if decisionNotice is missing", async () => {
+    (handleBopsGetRequest as jest.Mock).mockResolvedValue({
+      data: {},
+    });
+
+    const url = await getDecisionNoticeUrl(council, reference);
+    expect(url).toBeUndefined();
+  });
+
+  it("returns undefined if data is null", async () => {
+    (handleBopsGetRequest as jest.Mock).mockResolvedValue({
+      data: null,
+    });
+
+    const url = await getDecisionNoticeUrl(council, reference);
+    expect(url).toBeUndefined();
+  });
+
+  it("returns undefined if handleBopsGetRequest throws", async () => {
+    (handleBopsGetRequest as jest.Mock).mockRejectedValue(
+      new Error("Network error"),
+    );
+
+    const url = await getDecisionNoticeUrl(council, reference);
+    expect(url).toBeUndefined();
+    expect(logErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/planningApplication/converter.test.tsx
+++ b/__tests__/lib/planningApplication/converter.test.tsx
@@ -230,6 +230,36 @@ describe("convertToDprApplication", () => {
     );
   };
 
+  describe("additionalData", () => {
+    it("includes additional data when provided", () => {
+      const decisionNoticeUrl = "testUrl";
+      const applicationType = "pp.full.householder";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "determined",
+        decision: "granted",
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const result = convertToDprApplication(from, {
+        decisionNoticeUrl,
+      });
+      expect(result.data?.assessment?.decisionNotice?.url).toBe(
+        decisionNoticeUrl,
+      );
+    });
+    it("doesn't include additional data when not provided", () => {
+      const applicationType = "pp.full.householder";
+      const from = generateOldDprApplication({
+        applicationType: applicationType,
+        applicationStatus: "determined",
+        decision: "granted",
+        consultationStartDate: consultationStartDateInPast,
+      });
+      const result = convertToDprApplication(from);
+      expect(result.data?.assessment?.decisionNotice).not.toBeDefined();
+    });
+  });
+
   describe("03-consultation", () => {
     it("in_assessment", () => {
       const applicationType = "pp.full.householder";

--- a/src/handlers/bops/actions/getDecisionNoticeUrl.ts
+++ b/src/handlers/bops/actions/getDecisionNoticeUrl.ts
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the Digital Planning Register project.
+ *
+ * Digital Planning Register is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Digital Planning Register is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Digital Planning Register. If not, see <https://www.gnu.org/licenses/>.
+ */
+"use server";
+import { ApiResponse } from "@/types";
+import { BopsV2PublicPlanningApplicationDocuments } from "../types";
+import { handleBopsGetRequest } from "../requests";
+
+export const getDecisionNoticeUrl = async (
+  council: string,
+  reference: string,
+): Promise<string | undefined> => {
+  try {
+    let url = `public/planning_applications/${reference}/documents`;
+    const params = new URLSearchParams({
+      page: "1",
+      resultsPerPage: "1",
+    });
+    url = `${url}?${params.toString()}`;
+    const documentsRequest = await handleBopsGetRequest<
+      ApiResponse<BopsV2PublicPlanningApplicationDocuments | null>
+    >(council, url);
+    return documentsRequest?.data?.decisionNotice?.url;
+  } catch (error) {
+    console.error("Error fetching decision notice URL:", error);
+    return undefined;
+  }
+};

--- a/src/handlers/bops/v2/show.ts
+++ b/src/handlers/bops/v2/show.ts
@@ -25,6 +25,7 @@ import {
   convertToDprApplication,
   isDprApplication,
 } from "@/lib/planningApplication/converter";
+import { getDecisionNoticeUrl } from "../actions/getDecisionNoticeUrl";
 
 /**
  * Get the details for an application
@@ -47,9 +48,11 @@ export async function show(
     }
     const convertedData = convertBopsToDpr(request.data, council);
 
+    const decisionNoticeUrl = await getDecisionNoticeUrl(council, reference);
+
     const convertedApplication: DprApplication = isDprApplication(convertedData)
       ? convertedData
-      : convertToDprApplication(convertedData);
+      : convertToDprApplication(convertedData, { decisionNoticeUrl });
 
     return { ...request, data: convertedApplication };
   } catch (error) {

--- a/src/lib/planningApplication/converter.ts
+++ b/src/lib/planningApplication/converter.ts
@@ -68,6 +68,7 @@ export const getIsConsultationPeriod = (
 
 export const convertToDprApplication = (
   app: DprPlanningApplication,
+  additionalData?: { decisionNoticeUrl?: string },
 ): DprApplication => {
   let stage = undefined;
   let status = undefined;
@@ -289,11 +290,12 @@ export const convertToDprApplication = (
     dprApplication.data.assessment = {
       planningOfficerDecision: app.application.decision as AssessmentDecision,
       planningOfficerDecisionDate: app.application.determinedAt,
-      decisionNotice: app.application.decision
-        ? {
-            url: "https://planningregister.org",
-          }
-        : undefined,
+      decisionNotice:
+        app.application.decision && additionalData?.decisionNoticeUrl
+          ? {
+              url: additionalData.decisionNoticeUrl,
+            }
+          : undefined,
     } as PostSubmissionAssessment;
 
     if (getPrimaryApplicationTypeKey(app.applicationType) === "pa") {


### PR DESCRIPTION
Bug fix for the decision notice url not being set from the BOPS converter. 

- [x] I've added the ability to pass various 'additionalData' to the converter, since theres potential for this being needed in other areas. 
- [x] Added a new `getDecisionNoticeUrl` action in the BOPS handler to fetch (and not convert) the documents endpoint which will give us the decisionNoticeUrl to add into the ODP formatted application. 