### PR TITLE
Fix for specialist comment attachments not mapping correctly

### DIFF
--- a/src/components/SpecialistCommentCard/SpecialistCommentCard.tsx
+++ b/src/components/SpecialistCommentCard/SpecialistCommentCard.tsx
@@ -154,9 +154,11 @@ export const SpecialistCommentCard = ({
                   url={file?.url}
                   fileName={file?.name}
                   thumbnailUrl={file?.thumbnailUrl}
-                  contentType={file?.metadata?.mimeType}
                   fileSize={file.metadata?.size?.bytes}
-                  createdDate={file.metadata?.createdAt}
+                  uploadedAt={file.metadata?.createdAt}
+                  {...(file?.metadata?.mimeType !== undefined
+                    ? { mimeType: file?.metadata?.mimeType }
+                    : {})}
                 />
               ))}
             </div>


### PR DESCRIPTION
I had tweaked the `<Attachment />` component to accept an already decided `contentType` or `mimeType` specifically that would be mapped inside the component. The Specialist Comment Component was done before that change, this fixes the build error

I had also changed `createdDate` to `uploadedAt` to match the component design